### PR TITLE
feat(recipe): add rewriteConfigContent(String) to RewriteRunner builder

### DIFF
--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
@@ -92,15 +92,23 @@ class RewriteRunner private constructor(private val config: Builder) {
             emptyList()
         }
 
-        // 3. Load recipe
+        // 3. Load recipe (precedence: string content > explicit path > implicit projectDir/rewrite.yaml)
         log.info("[3/6] Loading recipe '${config.activeRecipe}'")
-        val effectiveRewriteConfig = config.rewriteConfig
-            ?: config.projectDir.resolve("rewrite.yaml")
-        val recipe = RecipeLoader().load(
-            recipeJars = recipeJars,
-            activeRecipeName = config.activeRecipe,
-            rewriteYaml = effectiveRewriteConfig
-        )
+        val recipe = if (config.rewriteConfigContent != null) {
+            RecipeLoader().load(
+                recipeJars = recipeJars,
+                activeRecipeName = config.activeRecipe,
+                rewriteYamlContent = config.rewriteConfigContent
+            )
+        } else {
+            val effectiveRewriteConfig =
+                config.rewriteConfig ?: config.projectDir.resolve("rewrite.yaml")
+            RecipeLoader().load(
+                recipeJars = recipeJars,
+                activeRecipeName = config.activeRecipe,
+                rewriteYaml = effectiveRewriteConfig
+            )
+        }
         log.info("      Recipe ready: ${recipe.name}")
 
         // 4. Build LST (3-stage pipeline)
@@ -197,6 +205,8 @@ class RewriteRunner private constructor(private val config: Builder) {
             private set
         internal var rewriteConfig: Path? = null
             private set
+        internal var rewriteConfigContent: String? = null
+            private set
         internal var cacheDir: Path? = null
             private set
         internal var configFile: Path? = null
@@ -239,6 +249,10 @@ class RewriteRunner private constructor(private val config: Builder) {
 
         /** Path to a `rewrite.yaml` file for custom composite recipes. */
         fun rewriteConfig(path: Path): Builder = apply { rewriteConfig = path }
+
+        /** Raw `rewrite.yaml` content. Takes precedence over [rewriteConfig] when both are set. */
+        fun rewriteConfigContent(content: String): Builder =
+            apply { rewriteConfigContent = content }
 
         /**
          * Directory used to cache downloaded recipe JARs.

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeLoader.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeLoader.kt
@@ -1,6 +1,8 @@
 package io.github.skhokhlov.rewriterunner.recipe
 
+import java.io.ByteArrayInputStream
 import java.io.FileInputStream
+import java.net.URI
 import java.net.URLClassLoader
 import java.nio.file.Path
 import java.util.Properties
@@ -94,6 +96,76 @@ class RecipeLoader {
         // the recipe causes NoClassDefFoundError when those classes are first needed.
         // The loader is a short-lived object tied to a single CLI/library invocation and
         // will be GC'd once the run completes, so explicit close() is unnecessary.
+        return recipe
+    }
+
+    /**
+     * Overload that accepts raw YAML content as a [String] instead of a file path.
+     * Use this when the `rewrite.yaml` content is already in memory and writing it to
+     * disk would be unnecessary I/O.
+     *
+     * @param rewriteYamlContent Raw YAML string, or `null` to skip YAML loading and rely
+     *   solely on classpath-scanned recipes.
+     */
+    fun load(
+        recipeJars: List<Path>,
+        activeRecipeName: String,
+        rewriteYamlContent: String?
+    ): Recipe {
+        val props = Properties()
+        val parentLoader = Thread.currentThread().contextClassLoader
+
+        val recipeClassLoader = if (recipeJars.isNotEmpty()) {
+            URLClassLoader(
+                recipeJars.map { it.toUri().toURL() }.toTypedArray(),
+                parentLoader
+            )
+        } else {
+            parentLoader
+        }
+
+        val builder = Environment.builder()
+
+        for (jar in recipeJars) {
+            log.debug("Scanning recipe JAR: $jar")
+            try {
+                builder.load(ClasspathScanningLoader(jar, props, emptyList(), recipeClassLoader))
+            } catch (e: Exception) {
+                log.warn("Failed to scan recipe JAR $jar (skipping): ${e.message}")
+            }
+        }
+
+        if (recipeJars.isEmpty()) {
+            try {
+                builder.load(ClasspathScanningLoader(props, recipeClassLoader))
+            } catch (e: Exception) {
+                log.warn("Failed to scan tool classpath (skipping): ${e.message}")
+            }
+        }
+
+        if (rewriteYamlContent != null) {
+            log.info("Loading rewrite.yaml from string content")
+            ByteArrayInputStream(rewriteYamlContent.toByteArray(Charsets.UTF_8)).use { stream ->
+                builder.load(
+                    YamlResourceLoader(stream, URI("string:rewrite.yaml"), props, recipeClassLoader)
+                )
+            }
+        }
+
+        val env = builder.build()
+        val recipe =
+            try {
+                env.activateRecipes(activeRecipeName)
+            } catch (e: RecipeException) {
+                throw IllegalArgumentException(
+                    "Recipe '$activeRecipeName' not found. " +
+                        "Verify the recipe name and that the correct recipe artifact is supplied via --recipe-artifact.",
+                    e
+                )
+            }
+        require(recipe.recipeList.isNotEmpty() || recipe.name == activeRecipeName) {
+            "Recipe '$activeRecipeName' not found. Verify the recipe name and that the correct recipe JAR is supplied via --recipe-artifact."
+        }
         return recipe
     }
 }

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeLoaderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeLoaderTest.kt
@@ -122,4 +122,38 @@ class RecipeLoaderTest :
                 "Exception message should explain the recipe was not found: $msg"
             )
         }
+
+        // ─── YAML content string overload ────────────────────────────────────────
+
+        test("load with yaml content string activates composite recipe") {
+            val yamlContent =
+                """
+                ---
+                type: specs.openrewrite.org/v1beta/recipe
+                name: com.example.test.FindTxtFiles
+                recipeList:
+                  - org.openrewrite.FindSourceFiles:
+                      filePattern: "**/*.txt"
+                """.trimIndent()
+
+            val recipe =
+                RecipeLoader().load(
+                    recipeJars = emptyList(),
+                    activeRecipeName = "com.example.test.FindTxtFiles",
+                    rewriteYamlContent = yamlContent
+                )
+
+            assertNotNull(recipe)
+            assertEquals("com.example.test.FindTxtFiles", recipe.name)
+        }
+
+        test("load with null yaml content string falls back to classpath scan") {
+            val recipe =
+                RecipeLoader().load(
+                    recipeJars = emptyList(),
+                    activeRecipeName = "org.openrewrite.FindSourceFiles",
+                    rewriteYamlContent = null
+                )
+            assertNotNull(recipe)
+        }
     })


### PR DESCRIPTION
Library clients can now pass rewrite.yaml content directly as a String via RewriteRunner.builder().rewriteConfigContent(...), avoiding unnecessary disk I/O. String content takes precedence over rewriteConfig(Path) and the implicit projectDir/rewrite.yaml fallback.