### PR TITLE
feat(config): add --no-maven-central flag and includeMavenCentral con…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ java -jar cli/build/libs/cli-1.0-SNAPSHOT-all.jar --help
 | `--exclude-extensions` | | Comma-separated file types to skip | — |
 | `--info` | | Enable INFO-level logging to stderr | `false` |
 | `--debug` | | Enable DEBUG-level logging (overrides `--info`) | `false` |
+| `--no-maven-central` | | Disable Maven Central; use only repos from config | `false` |
 
 **Output modes**: `diff` (unified diffs) · `files` (one path per line) · `report` (JSON to `openrewrite-report.json`)
 

--- a/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
+++ b/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
@@ -105,6 +105,12 @@ class RunCommand : Callable<Int> {
     )
     var excludeExtensions: List<String> = emptyList()
 
+    @Option(
+        names = ["--no-maven-central"],
+        description = ["Disable Maven Central; use only repositories from config."]
+    )
+    var noMavenCentral: Boolean = false
+
     override fun call(): Int {
         // Apply log level override before any work (--debug takes precedence over --info)
         if (debugLogging || infoLogging) {
@@ -122,6 +128,7 @@ class RunCommand : Callable<Int> {
             rewriteConfig?.let { builder.rewriteConfig(it) }
             cacheDir?.let { builder.cacheDir(it) }
             configFile?.let { builder.configFile(it) }
+            if (noMavenCentral) builder.includeMavenCentral(false)
 
             val runResult = builder.build().run()
 

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
@@ -145,6 +145,15 @@ class RunCommandTest :
             assertTrue(baos.toString().contains("--info"), "--help should document --info option")
         }
 
+        test("--help output mentions --no-maven-central") {
+            val baos = ByteArrayOutputStream()
+            cli().setOut(PrintWriter(baos)).execute("--help")
+            assertTrue(
+                baos.toString().contains("no-maven-central"),
+                "--help should document --no-maven-central option"
+            )
+        }
+
         test("multiple --recipe-artifact flags are collected into a list") {
             val cmd = RunCommand()
             CommandLine(cmd).parseArgs(

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/AetherContext.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/AetherContext.kt
@@ -58,7 +58,8 @@ class AetherContext(
             localRepoDir: Path,
             extraRepositories: List<RepositoryConfig> = emptyList(),
             connectTimeoutMs: Int = 30_000,
-            requestTimeoutMs: Int = 60_000
+            requestTimeoutMs: Int = 60_000,
+            includeMavenCentral: Boolean = true
         ): AetherContext {
             val system = RepositorySystemSupplier().get()
             localRepoDir.toFile().mkdirs()
@@ -97,15 +98,16 @@ class AetherContext(
                 .setIgnoreArtifactDescriptorRepositories(true)
                 .build()
 
-            val remoteRepos =
-                mutableListOf(
+            val remoteRepos = mutableListOf<RemoteRepository>()
+            if (includeMavenCentral) {
+                remoteRepos.add(
                     RemoteRepository.Builder(
                         "central",
                         "default",
                         "https://repo.maven.apache.org/maven2"
-                    )
-                        .build()
+                    ).build()
                 )
+            }
             extraRepositories.forEachIndexed { index, cfg ->
                 // Use a stable, URL-safe ID: "extra-0", "extra-1", etc.
                 // hashCode() was previously used but can produce negative integers which

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
@@ -70,20 +70,24 @@ class RewriteRunner private constructor(private val config: Builder) {
         val effectiveCacheDir = (config.cacheDir ?: toolConfig.resolvedCacheDir()).also {
             log.info("      Cache dir: $it")
         }
+        val effectiveIncludeMavenCentral =
+            config.includeMavenCentral ?: toolConfig.includeMavenCentral
         // Recipe artifacts are isolated in the tool's own cache so they never mix with
         // the project's build artifacts in the user's Maven local repository.
         val recipeLocalRepoDir = effectiveCacheDir.resolve("repository")
         Files.createDirectories(recipeLocalRepoDir)
         val recipeContext = AetherContext.build(
             localRepoDir = recipeLocalRepoDir,
-            extraRepositories = toolConfig.resolvedRepositories()
+            extraRepositories = toolConfig.resolvedRepositories(),
+            includeMavenCentral = effectiveIncludeMavenCentral
         )
         // Project dependencies use the Maven default local repository so already-cached
         // artifacts from the project's own build are reused without re-downloading.
         val mavenLocalRepoDir = Paths.get(System.getProperty("user.home"), ".m2", "repository")
         val projectContext = AetherContext.build(
             localRepoDir = mavenLocalRepoDir,
-            extraRepositories = toolConfig.resolvedRepositories()
+            extraRepositories = toolConfig.resolvedRepositories(),
+            includeMavenCentral = effectiveIncludeMavenCentral
         )
 
         // 2. Resolve recipe JARs
@@ -220,6 +224,8 @@ class RewriteRunner private constructor(private val config: Builder) {
             private set
         internal var excludeExtensions: List<String> = emptyList()
             private set
+        internal var includeMavenCentral: Boolean? = null
+            private set
 
         /**
          * The root directory of the project to analyse. Defaults to the current working
@@ -295,6 +301,14 @@ class RewriteRunner private constructor(private val config: Builder) {
         fun excludeExtensions(extensions: List<String>): Builder = apply {
             excludeExtensions = extensions
         }
+
+        /**
+         * Override whether Maven Central is included as a remote repository.
+         * When `false`, only the repositories explicitly configured via the tool config
+         * file are used. Useful in enterprise environments where Central is unreachable.
+         * When not set, falls back to `includeMavenCentral` from the tool config (default `true`).
+         */
+        fun includeMavenCentral(value: Boolean): Builder = apply { includeMavenCentral = value }
 
         /**
          * Construct the [RewriteRunner].

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
@@ -67,7 +67,8 @@ data class ParseConfig(
 data class ToolConfig(
     val repositories: List<RepositoryConfig> = emptyList(),
     val cacheDir: String = "~/.rewriterunner/cache",
-    val parse: ParseConfig = ParseConfig()
+    val parse: ParseConfig = ParseConfig(),
+    val includeMavenCentral: Boolean = true
 ) {
     /** Returns [cacheDir] with `~` expanded to the user home directory and environment
      *  variable placeholders replaced. Recipe JARs are cached under the returned path's

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/AetherContextTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/AetherContextTest.kt
@@ -55,4 +55,35 @@ class AetherContextTest :
             assertEquals(repoA.toAbsolutePath(), pathA)
             assertEquals(repoB.toAbsolutePath(), pathB)
         }
+
+        // ─── includeMavenCentral ──────────────────────────────────────────────────
+
+        test("build by default includes Maven Central in remoteRepos") {
+            val ctx = AetherContext.build(localRepoDir = tempDir.resolve("repo"))
+            assertTrue(
+                ctx.remoteRepos.any { it.url == "https://repo.maven.apache.org/maven2" },
+                "Maven Central should be present by default"
+            )
+        }
+
+        test("build with includeMavenCentral=false excludes Maven Central from remoteRepos") {
+            val extraRepo = io.github.skhokhlov.rewriterunner.config.RepositoryConfig(
+                url = "https://nexus.example.com/repository/maven-public"
+            )
+            val ctx = AetherContext.build(
+                localRepoDir = tempDir.resolve("repo"),
+                extraRepositories = listOf(extraRepo),
+                includeMavenCentral = false
+            )
+            assertTrue(
+                ctx.remoteRepos.none { it.url == "https://repo.maven.apache.org/maven2" },
+                "Maven Central should be absent when includeMavenCentral=false"
+            )
+            assertTrue(
+                ctx.remoteRepos.any {
+                    it.url == "https://nexus.example.com/repository/maven-public"
+                },
+                "Extra repo should still be present"
+            )
+        }
     })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfigTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfigTest.kt
@@ -158,6 +158,20 @@ class ToolConfigTest :
             assertEquals("secret123", config.repositories[0].password)
         }
 
+        // ─── includeMavenCentral ──────────────────────────────────────────────────
+
+        test("includeMavenCentral defaults to true when not specified") {
+            val config = ToolConfig()
+            assertEquals(true, config.includeMavenCentral)
+        }
+
+        test("loads includeMavenCentral: false from yaml") {
+            val configFile = tempDir.resolve("runner.yml")
+            configFile.writeText("includeMavenCentral: false")
+            val config = ToolConfig.load(configFile)
+            assertEquals(false, config.includeMavenCentral)
+        }
+
         test("repository without credentials has null username and password") {
             val configFile = tempDir.resolve("runner.yml")
             configFile.writeText(


### PR DESCRIPTION
…fig option

Allow users in enterprise environments to opt out of Maven Central by setting `includeMavenCentral: false` in `rewrite-runner.yml` or passing `--no-maven-central` on the CLI, preventing connection timeouts when Central is unreachable.