### PR TITLE
feat(core): expose repositories and excludePaths as RewriteRunner bui…

### DIFF
--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner
 
+import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
 import io.github.skhokhlov.rewriterunner.lst.DependencyResolutionStage
 import io.github.skhokhlov.rewriterunner.lst.LstBuilder
@@ -72,13 +73,14 @@ class RewriteRunner private constructor(private val config: Builder) {
         }
         val effectiveIncludeMavenCentral =
             config.includeMavenCentral ?: toolConfig.includeMavenCentral
+        val effectiveRepositories = toolConfig.resolvedRepositories() + config.repositories
         // Recipe artifacts are isolated in the tool's own cache so they never mix with
         // the project's build artifacts in the user's Maven local repository.
         val recipeLocalRepoDir = effectiveCacheDir.resolve("repository")
         Files.createDirectories(recipeLocalRepoDir)
         val recipeContext = AetherContext.build(
             localRepoDir = recipeLocalRepoDir,
-            extraRepositories = toolConfig.resolvedRepositories(),
+            extraRepositories = effectiveRepositories,
             includeMavenCentral = effectiveIncludeMavenCentral
         )
         // Project dependencies use the Maven default local repository so already-cached
@@ -86,7 +88,7 @@ class RewriteRunner private constructor(private val config: Builder) {
         val mavenLocalRepoDir = Paths.get(System.getProperty("user.home"), ".m2", "repository")
         val projectContext = AetherContext.build(
             localRepoDir = mavenLocalRepoDir,
-            extraRepositories = toolConfig.resolvedRepositories(),
+            extraRepositories = effectiveRepositories,
             includeMavenCentral = effectiveIncludeMavenCentral
         )
 
@@ -128,10 +130,15 @@ class RewriteRunner private constructor(private val config: Builder) {
             toolConfig = toolConfig,
             depResolutionStage = DependencyResolutionStage(projectContext)
         )
+        val effectiveParseConfig = if (config.excludePaths.isNotEmpty()) {
+            toolConfig.parse.copy(excludePaths = config.excludePaths)
+        } else {
+            toolConfig.parse
+        }
         val lstStart = System.currentTimeMillis()
         val sourceFiles = lstBuilder.build(
             projectDir = config.projectDir,
-            parseConfig = toolConfig.parse,
+            parseConfig = effectiveParseConfig,
             includeExtensionsCli = config.includeExtensions,
             excludeExtensionsCli = config.excludeExtensions
         )
@@ -226,6 +233,10 @@ class RewriteRunner private constructor(private val config: Builder) {
             private set
         internal var includeMavenCentral: Boolean? = null
             private set
+        internal var repositories: List<RepositoryConfig> = emptyList()
+            private set
+        internal var excludePaths: List<String> = emptyList()
+            private set
 
         /**
          * The root directory of the project to analyse. Defaults to the current working
@@ -309,6 +320,30 @@ class RewriteRunner private constructor(private val config: Builder) {
          * When not set, falls back to `includeMavenCentral` from the tool config (default `true`).
          */
         fun includeMavenCentral(value: Boolean): Builder = apply { includeMavenCentral = value }
+
+        /**
+         * Add a single extra Maven repository for artifact resolution. May be called
+         * multiple times; all entries accumulate and are combined with any repositories
+         * declared in the tool config file.
+         */
+        fun repository(repo: RepositoryConfig): Builder = apply {
+            repositories = repositories + repo
+        }
+
+        /**
+         * Replace the full list of extra Maven repositories for artifact resolution.
+         * Combined with any repositories declared in the tool config file.
+         */
+        fun repositories(repos: List<RepositoryConfig>): Builder = apply {
+            repositories = repos
+        }
+
+        /**
+         * Glob patterns (relative to the project root) for paths to skip during parsing.
+         * When non-empty, overrides `parse.excludePaths` from the tool config file.
+         * Supports the same glob syntax as [java.nio.file.FileSystem.getPathMatcher].
+         */
+        fun excludePaths(paths: List<String>): Builder = apply { excludePaths = paths }
 
         /**
          * Construct the [RewriteRunner].

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner
 
+import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
@@ -70,5 +71,65 @@ class RewriteRunnerTest :
             runDeletePropertiesRecipe(dryRun = true)
 
             assertTrue(propsFile.exists(), "Dry-run must not delete files from disk")
+        }
+
+        // ─── excludePaths builder property ───────────────────────────────────────
+
+        test("builder excludePaths skips matching files") {
+            projectDir.resolve("excluded").toFile().mkdirs()
+            projectDir.resolve("included").toFile().mkdirs()
+            val excludedFile = projectDir.resolve("excluded/app.properties")
+            val includedFile = projectDir.resolve("included/app.properties")
+            excludedFile.writeText("key=value\n")
+            includedFile.writeText("key=value\n")
+
+            projectDir.resolve("rewrite.yaml").writeText(
+                """
+                ---
+                type: specs.openrewrite.org/v1beta/recipe
+                name: com.test.DeleteProperties
+                recipeList:
+                  - org.openrewrite.DeleteSourceFiles:
+                      filePattern: "**/*.properties"
+                """.trimIndent()
+            )
+
+            RewriteRunner.builder()
+                .projectDir(projectDir)
+                .activeRecipe("com.test.DeleteProperties")
+                .cacheDir(cacheDir)
+                .excludePaths(listOf("excluded/**"))
+                .build()
+                .run()
+
+            assertTrue(excludedFile.exists(), "File in excluded path should not be deleted")
+            assertFalse(includedFile.exists(), "File in included path should be deleted")
+        }
+
+        // ─── repositories builder property ───────────────────────────────────────
+
+        test("builder repositories are accepted without error") {
+            // Verify that supplying a RepositoryConfig programmatically does not throw.
+            // Full resolution behaviour is covered by integration tests.
+            projectDir.resolve("rewrite.yaml").writeText(
+                """
+                ---
+                type: specs.openrewrite.org/v1beta/recipe
+                name: com.test.DeleteProperties
+                recipeList:
+                  - org.openrewrite.DeleteSourceFiles:
+                      filePattern: "**/*.properties"
+                """.trimIndent()
+            )
+
+            RewriteRunner.builder()
+                .projectDir(projectDir)
+                .activeRecipe("com.test.DeleteProperties")
+                .cacheDir(cacheDir)
+                .repository(RepositoryConfig(url = "https://repo.example.com/maven"))
+                .repositories(listOf(RepositoryConfig(url = "https://other.example.com/maven")))
+                .build()
+                .run()
+            // No assertion needed — the test passes if no exception is thrown
         }
     })

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -28,6 +28,9 @@ val result = RewriteRunner.builder()
 | `dryRun(Boolean)` | `Boolean` | `false` | Run without writing files to disk |
 | `includeExtensions(List<String>)` | `List` | `[]` | Restrict to these extensions; overrides config file |
 | `excludeExtensions(List<String>)` | `List` | `[]` | Skip these extensions; overrides config file |
+| `excludePaths(List<String>)` | `List` | `[]` | Glob patterns to skip during parsing; overrides `parse.excludePaths` from config file |
+| `repository(RepositoryConfig)` | — | — | Add one extra Maven repository; accumulated, combined with config file repos |
+| `repositories(List<RepositoryConfig>)` | `List` | `[]` | Replace all extra Maven repositories; combined with config file repos |
 
 ### Throws
 - `IllegalArgumentException` — recipe not found in loaded JARs or classpath


### PR DESCRIPTION
…lder properties

Library users can now supply RepositoryConfig entries and parse excludePaths directly on the builder without needing a rewrite-runner.yml config file. Builder repositories are merged with any repos from the config file; excludePaths overrides parse.excludePaths from config when non-empty.