### PR TITLE
feat(config): rename config file to rewriterunner.yml with case-insen…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ java -jar cli/build/libs/cli-1.0-SNAPSHOT-all.jar --help
 | `--rewrite-config` | | Path to custom `rewrite.yaml` | — |
 | `--output` | `-o` | Output mode: `diff`, `files`, `report` | `diff` |
 | `--cache-dir` | | JAR cache directory | `~/.rewriterunner/cache` |
-| `--config` | | Path to `rewrite-runner.yml` | — |
+| `--config` | | Path to `rewriterunner.yml` | `<projectDir>/rewriterunner.yml`, then `~/.rewriterunner/rewriterunner.yml` |
 | `--dry-run` | | Run without writing to disk | `false` |
 | `--include-extensions` | | Comma-separated file types to parse | — |
 | `--exclude-extensions` | | Comma-separated file types to skip | — |

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ ResultFormatter(OutputMode.DIFF).format(result.results, result.projectDir)
 | `recipeArtifacts(List<String>)` | optional | — | Set all recipe artifact coordinates at once |
 | `rewriteConfig(Path)` | optional | `<projectDir>/rewrite.yaml` | Custom `rewrite.yaml` path |
 | `cacheDir(Path)` | optional | `~/.rewriterunner/cache` | Cache root for downloaded recipe JARs (stored under `<cacheDir>/repository`). Project dependencies always resolve from `~/.m2/repository`. |
-| `configFile(Path)` | optional | — | Path to `rewrite-runner.yml` |
+| `configFile(Path)` | optional | `~/.rewriterunner/rewriterunner.yml` | Path to `rewriterunner.yml` |
 | `dryRun(Boolean)` | optional | `false` | Analyse without writing to disk |
 | `includeExtensions(List<String>)` | optional | all supported | File extensions to parse |
 | `excludeExtensions(List<String>)` | optional | — | File extensions to skip |
@@ -185,7 +185,7 @@ Usage: rewrite-runner [-h] [--dry-run] [--active-recipe=<recipe>]
 | `--rewrite-config` | Path to `rewrite.yaml` for custom recipe compositions | `<project-dir>/rewrite.yaml` |
 | `--output`, `-o` | Output mode: `diff`, `files`, or `report` | `diff` |
 | `--cache-dir` | Cache root for downloaded recipe JARs (stored under `<path>/repository`). Project dependencies always resolve from `~/.m2/repository`. | `~/.rewriterunner/cache` |
-| `--config` | Path to tool config file (`rewrite-runner.yml`) | — |
+| `--config` | Path to tool config file (`rewriterunner.yml`) | `<project-dir>/rewriterunner.yml`, then `~/.rewriterunner/rewriterunner.yml` |
 | `--dry-run` | Run recipe but do not write changes to disk | `false` |
 | `--include-extensions` | Comma-separated file extensions to parse (e.g. `.java,.kt`) | all supported |
 | `--exclude-extensions` | Comma-separated file extensions to skip | — |
@@ -266,7 +266,13 @@ java -jar rewrite-runner-all.jar \
 
 ## Tool Config File
 
-Create `rewrite-runner.yml` to configure repositories and caching for your environment:
+Create `rewriterunner.yml` to configure repositories and caching for your environment.
+
+**Default locations** (checked in order):
+1. `<project-dir>/rewriterunner.yml` — project-level config
+2. `~/.rewriterunner/rewriterunner.yml` — global fallback, shared across all projects
+
+File name matching is case-insensitive (e.g. `RewriteRunner.yml` also works). Override either default with `--config <path>`.
 
 ```yaml
 repositories:
@@ -284,7 +290,7 @@ parse:
     - "**/build/**"
 ```
 
-Environment variable placeholders (`${VAR_NAME}`) are expanded at runtime. Pass the config file with `--config rewrite-runner.yml`.
+Environment variable placeholders (`${VAR_NAME}`) are expanded at runtime.
 
 ## Resilient Parsing Pipeline
 
@@ -325,7 +331,7 @@ Unresolved types appear as `JavaType.Unknown` in the LST, but all structural, te
 | `.xml` | `XmlParser` |
 | `.properties` | `PropertiesParser` |
 
-The parsed file set is configurable via `--include-extensions`, `--exclude-extensions`, and the `parse` section of `rewrite-runner.yml`.
+The parsed file set is configurable via `--include-extensions`, `--exclude-extensions`, and the `parse` section of `rewriterunner.yml`.
 
 ## Development
 

--- a/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
+++ b/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
@@ -69,7 +69,10 @@ class RunCommand : Callable<Int> {
 
     @Option(
         names = ["--config"],
-        description = ["Path to tool config file (rewrite-runner.yml)."]
+        description = [
+            "Path to tool config file (rewriterunner.yml).",
+            "Defaults: <project-dir>/rewriterunner.yml, then ~/.rewriterunner/rewriterunner.yml."
+        ]
     )
     var configFile: Path? = null
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
@@ -10,6 +10,7 @@ import io.github.skhokhlov.rewriterunner.recipe.RecipeRunner
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.exists
 import org.slf4j.LoggerFactory
 
 /**
@@ -67,7 +68,12 @@ class RewriteRunner private constructor(private val config: Builder) {
 
         // 1. Load tool config
         log.info("[1/6] Loading configuration")
-        val toolConfig = ToolConfig.load(config.configFile)
+        val effectiveConfigFile = config.configFile
+            ?: findConfigCaseInsensitive(config.projectDir)
+            ?: findConfigCaseInsensitive(
+                Paths.get(System.getProperty("user.home"), ".rewriterunner")
+            )
+        val toolConfig = ToolConfig.load(effectiveConfigFile)
         val effectiveCacheDir = (config.cacheDir ?: toolConfig.resolvedCacheDir()).also {
             log.info("      Cache dir: $it")
         }
@@ -111,7 +117,9 @@ class RewriteRunner private constructor(private val config: Builder) {
             )
         } else {
             val effectiveRewriteConfig =
-                config.rewriteConfig ?: config.projectDir.resolve("rewrite.yaml")
+                config.rewriteConfig
+                    ?: config.projectDir.resolve("rewrite.yaml").takeIf { it.exists() }
+                    ?: config.projectDir.resolve("rewrite.yml")
             RecipeLoader().load(
                 recipeJars = recipeJars,
                 activeRecipeName = config.activeRecipe,
@@ -286,8 +294,10 @@ class RewriteRunner private constructor(private val config: Builder) {
         fun cacheDir(path: Path): Builder = apply { cacheDir = path }
 
         /**
-         * Path to the `rewrite-runner.yml` tool config file for repository and cache
-         * configuration. If not set, a default [ToolConfig] is used.
+         * Path to the `rewriterunner.yml` tool config file for repository and cache
+         * configuration. If not set, auto-discovery checks `<projectDir>/rewriterunner.yml`
+         * first, then `~/.rewriterunner/rewriterunner.yml` as a global fallback.
+         * File name matching is case-insensitive. If no file is found, built-in defaults apply.
          */
         fun configFile(path: Path): Builder = apply { configFile = path }
 
@@ -367,5 +377,20 @@ class RewriteRunner private constructor(private val config: Builder) {
          */
         @JvmStatic
         fun builder(): Builder = Builder()
+
+        /**
+         * Find `rewriterunner.yml` (or `.yaml`) in [dir] using case-insensitive name matching.
+         * Returns `null` if [dir] does not exist or contains no matching file.
+         */
+        private fun findConfigCaseInsensitive(dir: Path): Path? = try {
+            Files.list(dir).use { stream ->
+                stream.filter {
+                    val name = it.fileName.toString().lowercase()
+                    name == "rewriterunner.yml" || name == "rewriterunner.yaml"
+                }.findFirst().orElse(null)
+            }
+        } catch (_: Exception) {
+            null
+        }
     }
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
@@ -49,7 +49,7 @@ data class ParseConfig(
 )
 
 /**
- * Top-level tool configuration, typically loaded from `rewrite-runner.yml`.
+ * Top-level tool configuration, typically loaded from `rewriterunner.yml`.
  *
  * Supports environment variable interpolation (`${VAR_NAME}`) and tilde expansion in all
  * string fields. Loaded via [ToolConfig.load]; programmatic library users may also
@@ -103,7 +103,7 @@ data class ToolConfig(
          * The YAML text is pre-processed to expand `${VAR_NAME}` placeholders before parsing.
          * Unknown YAML keys are silently ignored.
          *
-         * @param configFile Path to `rewrite-runner.yml`. May be `null` or point to a
+         * @param configFile Path to `rewriterunner.yml`. May be `null` or point to a
          *   non-existent file; in either case a default [ToolConfig] is returned.
          */
         fun load(configFile: Path?): ToolConfig {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerBuilderTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -188,6 +189,63 @@ class RewriteRunnerBuilderTest :
                     .activeRecipe("org.openrewrite.FindSourceFiles")
                     .build()
             assertFailsWith<IllegalArgumentException> { runner.run() }
+        }
+
+        test("auto-discovers rewriterunner.yml from project dir when configFile not set") {
+            val customCache = tempDir.resolve("my-custom-cache")
+            tempDir.resolve("rewriterunner.yml").writeText("cacheDir: $customCache")
+
+            RewriteRunner.builder()
+                .projectDir(tempDir)
+                .activeRecipe("org.openrewrite.FindSourceFiles")
+                .dryRun(true)
+                .build()
+                .run()
+
+            assertTrue(
+                customCache.resolve("repository").toFile().exists(),
+                "Custom cacheDir from rewriterunner.yml should have been auto-discovered"
+            )
+        }
+
+        test("auto-discovers rewriterunner.yml case-insensitively from project dir") {
+            val customCache = tempDir.resolve("my-custom-cache-ci")
+            tempDir.resolve("RewriteRunner.yml").writeText("cacheDir: $customCache")
+
+            RewriteRunner.builder()
+                .projectDir(tempDir)
+                .activeRecipe("org.openrewrite.FindSourceFiles")
+                .dryRun(true)
+                .build()
+                .run()
+
+            assertTrue(
+                customCache.resolve("repository").toFile().exists(),
+                "rewriterunner.yml should be found case-insensitively"
+            )
+        }
+
+        test("auto-discovers rewrite.yml from project dir when rewrite.yaml absent") {
+            tempDir.resolve("rewrite.yml").writeText(
+                """
+                ---
+                type: specs.openrewrite.org/v1beta/recipe
+                name: io.test.AutoDiscoveredYmlRecipe
+                displayName: Auto-discovered yml recipe
+                recipeList:
+                  - org.openrewrite.FindSourceFiles
+                """.trimIndent()
+            )
+
+            val result = RewriteRunner.builder()
+                .projectDir(tempDir)
+                .activeRecipe("io.test.AutoDiscoveredYmlRecipe")
+                .cacheDir(tempDir.resolve("cache"))
+                .dryRun(true)
+                .build()
+                .run()
+
+            assertNotNull(result)
         }
 
         test("run on empty directory with built-in recipe returns empty results") {

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -24,7 +24,7 @@ val result = RewriteRunner.builder()
 | `recipeArtifacts(List<String>)` | `List` | `[]` | Replace all recipe coordinates at once |
 | `rewriteConfig(Path)` | `Path?` | `<projectDir>/rewrite.yaml` | Custom `rewrite.yaml` |
 | `cacheDir(Path)` | `Path?` | from config / `~/.rewriterunner/cache` | Recipe JAR cache directory; resolved under `<cacheDir>/repository` |
-| `configFile(Path)` | `Path?` | none | `rewrite-runner.yml` tool config |
+| `configFile(Path)` | `Path?` | `<projectDir>/rewriterunner.yml`, then `~/.rewriterunner/rewriterunner.yml` | `rewriterunner.yml` tool config (case-insensitive name match) |
 | `dryRun(Boolean)` | `Boolean` | `false` | Run without writing files to disk |
 | `includeExtensions(List<String>)` | `List` | `[]` | Restrict to these extensions; overrides config file |
 | `excludeExtensions(List<String>)` | `List` | `[]` | Skip these extensions; overrides config file |
@@ -50,7 +50,7 @@ Return type of `RewriteRunner.run()`.
 
 ## ToolConfig YAML
 
-Config file (`rewrite-runner.yml`) loaded via `--config` CLI flag or `configFile()` builder method. Supports `${ENV_VAR}` interpolation and `~` expansion in all string fields.
+Config file (`rewriterunner.yml`) loaded via `--config` CLI flag or `configFile()` builder method. File name matching is case-insensitive. Auto-discovered from `<projectDir>/rewriterunner.yml` (project-level) then `~/.rewriterunner/rewriterunner.yml` (global fallback) when not explicitly provided. Supports `${ENV_VAR}` interpolation and `~` expansion in all string fields.
 
 ```yaml
 cacheDir: ~/.rewriterunner/cache   # default


### PR DESCRIPTION
…sitive discovery

- Config file renamed from rewrite-runner.yml to rewriterunner.yml
- Auto-discovery checks <projectDir>/rewriterunner.yml first, then ~/.rewriterunner/rewriterunner.yml as global fallback
- File name matching is case-insensitive (RewriteRunner.yml, etc. work)
- Both .yml and .yaml extensions supported
- Remove redundant isDirectory pre-check in findConfigCaseInsensitive; the catch block already handles non-existent/non-directory paths
- Update KotlinDoc, CLI help text, README, CLAUDE.md, and library-api.md