### PR TITLE
fix(lst): apply consistent compile-time scope filtering across all LST stages

### DIFF
--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStage.kt
@@ -102,13 +102,17 @@ open class BuildFileParseStage(
      * dependency graph, applying nearest-wins conflict resolution across the full
      * transitive graph. Used when only direct coordinates are known (static parsing).
      *
+     * Includes `compile`, `provided`, and `test` scoped transitive dependencies so
+     * that OpenRewrite can resolve types in both main and test source sets.
+     * Excludes `runtime` and `system` scoped transitives — consistent with Stage 2.
+     *
      * Overridable so tests can intercept resolution without network access.
      */
     protected open fun resolveWithPomTraversal(coordinates: List<String>): List<Path> {
         logger.info("Resolving ${coordinates.size} declared dependencies via Maven Resolver")
-        val deps = coordinates.map { Dependency(DefaultArtifact(it), "runtime") }
+        val deps = coordinates.map { Dependency(DefaultArtifact(it), "compile") }
         val collectRequest = CollectRequest(deps, emptyList(), aetherContext.remoteRepos)
-        val scopeFilter = ScopeDependencyFilter(null, listOf("test", "provided"))
+        val scopeFilter = ScopeDependencyFilter(null, listOf("runtime", "system"))
         val depRequest = DependencyRequest(collectRequest, scopeFilter)
         return try {
             aetherContext.system

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
@@ -200,19 +200,26 @@ open class DependencyResolutionStage(
      * [INFO] \- com.fasterxml.jackson.core:jackson-databind:jar:2.16.0:compile
      * ```
      *
+     * Includes `compile`, `provided`, and `test` scopes for correct OpenRewrite type
+     * resolution (test sources need test deps; provided deps supply compile-time types).
+     * Excludes `runtime` and `system` scopes — consistent with Stage 3.
+     *
      * @return Deduplicated list of `groupId:artifactId:version` coordinates.
      */
     internal fun parseMavenDependencyTreeOutput(output: String): List<String> {
         val coordinates = mutableSetOf<String>()
         // Lines like: [INFO] +- org.springframework:spring-core:jar:6.1.0:compile
         val pattern = Regex(
-            """^\[INFO\]\s+[\s|+\\-]+([a-zA-Z][\w.\-]+:[a-zA-Z][\w.\-]+):(?:jar|war|pom|ear|zip|aar|bundle):([^:]+):\w+\s*$"""
+            """^\[INFO\]\s+[\s|+\\-]+([a-zA-Z][\w.\-]+:[a-zA-Z][\w.\-]+):(?:jar|war|pom|ear|zip|aar|bundle):([^:]+):(\w+)\s*$"""
         )
         for (line in output.lines()) {
             val match = pattern.find(line) ?: continue
             val groupArtifact = match.groupValues[1]
             val version = match.groupValues[2]
-            if (version.isNotBlank() && version != "FAILED") {
+            val scope = match.groupValues[3]
+            if (version.isNotBlank() && version != "FAILED" &&
+                scope !in listOf("runtime", "system")
+            ) {
                 coordinates.add("$groupArtifact:$version")
             }
         }
@@ -383,15 +390,37 @@ open class DependencyResolutionStage(
      *
      * Handles resolved version overrides (`1.0 -> 2.0`) by using the final
      * resolved version. Deduplicates results.
+     *
+     * Only includes dependencies from compile-time configurations (e.g.
+     * `compileClasspath`, `testCompileClasspath`, `implementation`,
+     * `testImplementation`). Runtime-only configurations (`runtimeClasspath`,
+     * `testRuntimeClasspath`, `runtimeOnly`, `testRuntimeOnly`) are skipped so
+     * that the resulting classpath matches the compile-time view required for
+     * OpenRewrite type resolution — consistent with Stage 3.
      */
     internal fun parseGradleDependencyTaskOutput(output: String): List<String> {
         val coordinates = mutableSetOf<String>()
+        val configHeaderPattern = Regex("""^([a-zA-Z][\w\-]*)\s+-\s+.+$""")
         // Dependency lines start with tree-drawing characters (+---, \---, |    etc.)
         // followed by group:artifact:declaredVersion, optionally overridden by -> resolvedVersion.
         val depPattern = Regex(
             """^[\s|+\\-]+([a-zA-Z][\w.\-]*:[a-zA-Z][\w.\-]+):([\w.\-]+)(?:\s*->\s*([\w.\-]+))?"""
         )
+        // Start in "include" mode — lines before the first config header belong to no
+        // named configuration (task header lines, blank lines) and are harmless to skip.
+        var inCompileConfig = false
         for (line in output.lines()) {
+            // Configuration headers do not start with tree-drawing characters.
+            if (!line.startsWith(" ") && !line.startsWith("+") &&
+                !line.startsWith("\\") && !line.startsWith("|")
+            ) {
+                val configMatch = configHeaderPattern.find(line)
+                if (configMatch != null) {
+                    inCompileConfig = isCompileTimeConfiguration(configMatch.groupValues[1])
+                    continue
+                }
+            }
+            if (!inCompileConfig) continue
             val match = depPattern.find(line) ?: continue
             val groupArtifact = match.groupValues[1]
             val declaredVersion = match.groupValues[2]
@@ -403,5 +432,20 @@ open class DependencyResolutionStage(
             }
         }
         return coordinates.toList()
+    }
+
+    /**
+     * Returns true if [name] is a compile-time Gradle configuration whose dependencies
+     * belong on the compile classpath used for OpenRewrite type resolution.
+     *
+     * Excludes runtime-only configurations (e.g. `runtimeClasspath`, `runtimeOnly`,
+     * `testRuntimeClasspath`, `testRuntimeOnly`) whose dependencies are not available
+     * at compile time.
+     */
+    private fun isCompileTimeConfiguration(name: String): Boolean {
+        val lower = name.lowercase()
+        // A configuration is runtime-only when "runtime" appears in its name but
+        // "compile" does not (e.g. runtimeClasspath, testRuntimeOnly).
+        return !("runtime" in lower && "compile" !in lower)
     }
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/StaticBuildFileParser.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/StaticBuildFileParser.kt
@@ -24,8 +24,11 @@ internal class StaticBuildFileParser(private val logger: RunnerLogger) {
     // ─── Maven ────────────────────────────────────────────────────────────────
 
     /**
-     * Parses the `pom.xml` in [projectDir] and returns compile/runtime dependency coordinates.
-     * Skips `provided`- and `system`-scoped dependencies and any dependency whose version is
+     * Parses the `pom.xml` in [projectDir] and returns compile-time dependency coordinates.
+     * Includes `compile` (default), `provided`, and `test` scoped dependencies so that
+     * OpenRewrite can resolve types in both main and test source sets; `provided` deps
+     * supply compile-time types even though they are not bundled at runtime.
+     * Skips `runtime`- and `system`-scoped dependencies and any dependency whose version is
      * absent or uses property interpolation (`${...}`).
      */
     fun parseMavenDependencies(projectDir: Path): List<String> {
@@ -33,7 +36,7 @@ internal class StaticBuildFileParser(private val logger: RunnerLogger) {
         return try {
             val model = MavenXpp3Reader().read(pomFile.toFile().inputStream())
             model.dependencies
-                .filter { !listOf("provided", "system").contains(it.scope) }
+                .filter { it.scope !in listOf("runtime", "system") }
                 .mapNotNull { dep ->
                     val version = dep.version?.takeIf { it.isNotBlank() && !it.startsWith("\${") }
                         ?: return@mapNotNull null
@@ -109,9 +112,16 @@ internal class StaticBuildFileParser(private val logger: RunnerLogger) {
         val buildDirs = listOf(projectDir) + subprojectDirs
 
         val coordPattern = Regex("""["']([a-zA-Z][\w.\-]+:[a-zA-Z][\w.\-]+:[\w.\-]+)["']""")
+        // runtimeOnly and testRuntimeOnly are excluded — their JARs are not on the compile
+        // classpath and are not needed for OpenRewrite type resolution.
         val threeArgPattern = Regex(
-            """(?:implementation|api|compileOnly|runtimeOnly|testImplementation|testCompileOnly)\s*\(\s*["']([^"']+)["']\s*,\s*["']([^"']+)["']\s*,\s*["']([^"']+)["']\s*\)"""
+            """(?:implementation|api|compileOnly|testImplementation|testCompileOnly)\s*\(\s*["']([^"']+)["']\s*,\s*["']([^"']+)["']\s*,\s*["']([^"']+)["']\s*\)"""
         )
+        // Lines that start with a runtime-only configuration keyword are skipped before
+        // applying the broad coordPattern so that quoted coordinate strings on those lines
+        // are not inadvertently collected.
+        val runtimeOnlyLinePattern =
+            Regex("""^\s*(?:runtimeOnly|testRuntimeOnly|runtime|testRuntime)\b""")
 
         val coordinates = mutableListOf<String>()
         for (dir in buildDirs) {
@@ -119,7 +129,10 @@ internal class StaticBuildFileParser(private val logger: RunnerLogger) {
             logger.debug("Stage 3: statically parsing ${buildFile.toAbsolutePath()}")
             try {
                 val text = buildFile.toFile().readText()
-                coordPattern.findAll(text).forEach { match ->
+                val compileTimeText = text.lines()
+                    .filterNot { runtimeOnlyLinePattern.containsMatchIn(it) }
+                    .joinToString("\n")
+                coordPattern.findAll(compileTimeText).forEach { match ->
                     val coord = match.groupValues[1]
                     if (!coord.contains("bom") && !coord.contains("platform")) {
                         coordinates.add(coord)

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageResolveClasspathTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageResolveClasspathTest.kt
@@ -108,7 +108,7 @@ class DependencyResolutionStageResolveClasspathTest :
 
         // ─── StaticBuildFileParser: parseMavenDependencies edge cases ────────────
 
-        test("parseMavenDependencies skips provided-scoped dependencies") {
+        test("parseMavenDependencies includes provided-scoped dependencies") {
             projectDir.resolve("pom.xml").writeText(
                 """
                 <project>
@@ -134,8 +134,8 @@ class DependencyResolutionStageResolveClasspathTest :
             )
             val coords = StaticBuildFileParser(NoOpRunnerLogger).parseMavenDependencies(projectDir)
             assertTrue(
-                coords.none { it.contains("servlet-api") },
-                "provided scope should be excluded"
+                coords.any { it.contains("servlet-api") },
+                "provided scope must be included for compile-time type resolution"
             )
             assertTrue(
                 coords.any { it.contains("commons-lang3") },
@@ -213,7 +213,7 @@ class DependencyResolutionStageResolveClasspathTest :
                     NoOpRunnerLogger
                 ) {
                     override fun runGradleDependenciesRawOutput(projectDir: Path) =
-                        "compileClasspath\n+--- org.apache.commons:commons-lang3:3.12.0\n"
+                        "compileClasspath - Compile classpath for source set 'main'.\n+--- org.apache.commons:commons-lang3:3.12.0\n"
 
                     override fun resolveArtifactsDirectly(coordinates: List<String>): List<Path> {
                         directCalled = true

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageTest.kt
@@ -113,7 +113,7 @@ class DependencyResolutionStageTest :
             assertEquals("org.apache.commons:commons-lang3:3.12.0", coords.first())
         }
 
-        test("parseMavenDependencies excludes provided-scoped dependencies") {
+        test("parseMavenDependencies includes provided-scoped dependencies") {
             projectDir.resolve("pom.xml").writeText(
                 """
                 <project>
@@ -134,7 +134,12 @@ class DependencyResolutionStageTest :
             )
 
             val coords = staticParser().parseMavenDependencies(projectDir)
-            assertEquals(0, coords.size, "Provided dependency should be excluded")
+            assertEquals(
+                1,
+                coords.size,
+                "Provided dependency must be included for compile-time type resolution"
+            )
+            assertTrue(coords.contains("javax.servlet:javax.servlet-api:4.0.1"))
         }
 
         test("parseMavenDependencies skips dependency with property-placeholder version") {
@@ -181,6 +186,30 @@ class DependencyResolutionStageTest :
             )
         }
 
+        test("parseMavenDependencies excludes runtime-scoped dependencies") {
+            projectDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>app</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.postgresql</groupId>
+                            <artifactId>postgresql</artifactId>
+                            <version>42.7.0</version>
+                            <scope>runtime</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """.trimIndent()
+            )
+
+            val coords = staticParser().parseMavenDependencies(projectDir)
+            assertEquals(0, coords.size, "runtime-scoped dependency must be excluded")
+        }
+
         // ─── Static Gradle build file parsing ────────────────────────────────────
 
         test("parseGradleDependenciesStatically extracts Kotlin DSL string coordinates") {
@@ -220,7 +249,10 @@ class DependencyResolutionStageTest :
             val coords = staticParser().parseGradleDependenciesStatically(projectDir)
 
             assertTrue(coords.contains("org.springframework:spring-core:6.1.0"))
-            assertTrue(coords.contains("ch.qos.logback:logback-classic:1.4.11"))
+            assertFalse(
+                coords.contains("ch.qos.logback:logback-classic:1.4.11"),
+                "runtimeOnly dep must not appear on compile classpath"
+            )
         }
 
         test("parseGradleDependenciesStatically prefers build_gradle_kts over build_gradle") {
@@ -338,6 +370,28 @@ class DependencyResolutionStageTest :
             )
         }
 
+        test("parseGradleDependenciesStatically excludes runtimeOnly dependencies") {
+            projectDir.resolve("build.gradle.kts").writeText(
+                """
+                dependencies {
+                    implementation("org.apache.commons:commons-lang3:3.12.0")
+                    runtimeOnly("org.postgresql:postgresql:42.7.0")
+                }
+                """.trimIndent()
+            )
+
+            val coords = staticParser().parseGradleDependenciesStatically(projectDir)
+
+            assertTrue(
+                coords.contains("org.apache.commons:commons-lang3:3.12.0"),
+                "compile-time dep must be included"
+            )
+            assertFalse(
+                coords.contains("org.postgresql:postgresql:42.7.0"),
+                "runtimeOnly dep must not appear on classpath"
+            )
+        }
+
         // ─── Gradle dependencies task output parsing ──────────────────────────────
 
         test("parseGradleDependencyTaskOutput extracts simple coordinates") {
@@ -357,7 +411,7 @@ class DependencyResolutionStageTest :
         test("parseGradleDependencyTaskOutput uses resolved version when overridden") {
             val output =
                 """
-                runtimeClasspath - Runtime classpath of source set 'main'.
+                compileClasspath - Compile classpath for source set 'main'.
                 +--- com.google.guava:guava:30.0-jre -> 32.1.2-jre
                 \--- org.springframework:spring-core:5.3.0 -> 6.1.0
                 """.trimIndent()
@@ -457,6 +511,109 @@ class DependencyResolutionStageTest :
 
             assertTrue(coords.contains("org.apache.commons:commons-lang3:3.12.0"))
             assertTrue(coords.contains("com.google.guava:guava:32.1.2-jre"))
+        }
+
+        test(
+            "parseGradleDependencyTaskOutput includes dependencies from testCompileClasspath configuration"
+        ) {
+            val output =
+                """
+                testCompileClasspath - Compile classpath for source set 'test'.
+                \--- junit:junit:4.13.2
+                """.trimIndent()
+
+            val coords = stage().parseGradleDependencyTaskOutput(output)
+
+            assertTrue(
+                coords.contains("junit:junit:4.13.2"),
+                "test compile classpath dep must be included"
+            )
+        }
+
+        test(
+            "parseGradleDependencyTaskOutput excludes dependencies from runtimeClasspath configuration"
+        ) {
+            val output =
+                """
+                compileClasspath - Compile classpath for source set 'main'.
+                \--- org.apache.commons:commons-lang3:3.12.0
+
+                runtimeClasspath - Runtime classpath for source set 'main'.
+                \--- org.postgresql:postgresql:42.7.0
+                """.trimIndent()
+
+            val coords = stage().parseGradleDependencyTaskOutput(output)
+
+            assertTrue(coords.contains("org.apache.commons:commons-lang3:3.12.0"))
+            assertFalse(
+                coords.contains("org.postgresql:postgresql:42.7.0"),
+                "runtime-only dependency must not appear on compile classpath"
+            )
+        }
+
+        test(
+            "parseGradleDependencyTaskOutput excludes dependencies from testRuntimeClasspath configuration"
+        ) {
+            val output =
+                """
+                testCompileClasspath - Compile classpath for source set 'test'.
+                \--- junit:junit:4.13.2
+
+                testRuntimeClasspath - Runtime classpath for source set 'test'.
+                \--- ch.qos.logback:logback-classic:1.4.0
+                """.trimIndent()
+
+            val coords = stage().parseGradleDependencyTaskOutput(output)
+
+            assertTrue(coords.contains("junit:junit:4.13.2"))
+            assertFalse(
+                coords.contains("ch.qos.logback:logback-classic:1.4.0"),
+                "test runtime-only dependency must not appear on classpath"
+            )
+        }
+
+        // ─── Maven dependency:tree output parsing ─────────────────────────────────
+
+        test("parseMavenDependencyTreeOutput includes compile-scoped dependencies") {
+            val output = "[INFO] +- org.apache.commons:commons-lang3:jar:3.12.0:compile"
+            val coords = stage().parseMavenDependencyTreeOutput(output)
+            assertTrue(coords.contains("org.apache.commons:commons-lang3:3.12.0"))
+        }
+
+        test("parseMavenDependencyTreeOutput includes provided-scoped dependencies") {
+            val output = "[INFO] +- javax.servlet:javax.servlet-api:jar:4.0.1:provided"
+            val coords = stage().parseMavenDependencyTreeOutput(output)
+            assertTrue(
+                coords.contains("javax.servlet:javax.servlet-api:4.0.1"),
+                "provided-scoped dep must be included for compile-time type resolution"
+            )
+        }
+
+        test("parseMavenDependencyTreeOutput includes test-scoped dependencies") {
+            val output = "[INFO] +- junit:junit:jar:4.13.2:test"
+            val coords = stage().parseMavenDependencyTreeOutput(output)
+            assertTrue(
+                coords.contains("junit:junit:4.13.2"),
+                "test-scoped dep must be included for test source type resolution"
+            )
+        }
+
+        test("parseMavenDependencyTreeOutput excludes runtime-scoped dependencies") {
+            val output = "[INFO] +- org.postgresql:postgresql:jar:42.7.0:runtime"
+            val coords = stage().parseMavenDependencyTreeOutput(output)
+            assertFalse(
+                coords.contains("org.postgresql:postgresql:42.7.0"),
+                "runtime-scoped dependency must not appear on compile classpath"
+            )
+        }
+
+        test("parseMavenDependencyTreeOutput excludes system-scoped dependencies") {
+            val output = "[INFO] +- com.sun:tools:jar:1.8:system"
+            val coords = stage().parseMavenDependencyTreeOutput(output)
+            assertFalse(
+                coords.contains("com.sun:tools:1.8"),
+                "system-scoped dependency must not appear on compile classpath"
+            )
         }
 
         // ─── Subproject discovery ─────────────────────────────────────────────────


### PR DESCRIPTION
All four LST build stages now use the same scope policy for classpath
construction, which is required for correct OpenRewrite type resolution:

Maven scopes included: compile (default), provided, test
Maven scopes excluded: runtime, system

Gradle configurations included: any whose name is not runtime-only
  (i.e. name contains "compile" or has no "runtime"-without-"compile")
Gradle configurations excluded: runtimeClasspath, testRuntimeClasspath,
  runtimeOnly, testRuntimeOnly, and any *RuntimeClasspath/*RuntimeOnly

Changes per component:

Stage 2 – DependencyResolutionStage
- parseMavenDependencyTreeOutput(): capture scope group in regex;
  skip coordinates whose scope is "runtime" or "system"
- parseGradleDependencyTaskOutput(): track configuration header lines;
  skip dependency lines inside runtime-only configurations via new
  private isCompileTimeConfiguration() helper

Stage 3 – BuildFileParseStage
- resolveWithPomTraversal(): change root dependency scope from "runtime"
  to "compile" (prevents scope narrowing of compile-time transitives);
  change ScopeDependencyFilter from excluding test/provided to excluding
  runtime/system so test and provided JARs are now resolved

Stage 3/4 – StaticBuildFileParser
- parseMavenDependencies(): change filter from excluding provided/system
  to excluding runtime/system; provided is now included
- parseGradleDependenciesStatically(): remove runtimeOnly from the
  three-argument pattern; pre-filter lines matching runtime-only config
  keywords before applying the broad coordinate pattern

Tests (TDD – written before implementation):
- parseMavenDependencyTreeOutput: includes provided/test, excludes
  runtime/system
- parseGradleDependencyTaskOutput: includes testCompileClasspath deps,
  excludes runtimeClasspath and testRuntimeClasspath deps
- parseMavenDependencies: includes provided, excludes runtime
- parseGradleDependenciesStatically: excludes runtimeOnly deps
- Updated stale assertions that expected provided scope to be excluded

Closes #128

https://claude.ai/code/session_01Qdw7WwTDD9bX5ok2pMmXz2