### PR TITLE
Add plugin-first recipe execution stage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,11 @@ java -jar cli/build/libs/cli-1.0-SNAPSHOT-all.jar --help
 | `--cache-dir` | | JAR cache directory | `~/.rewriterunner/cache` |
 | `--config` | | Path to `rewriterunner.yml` | `<projectDir>/rewriterunner.yml`, then `~/.rewriterunner/rewriterunner.yml` |
 | `--dry-run` | | Run without writing to disk | `false` |
+| `--skip-plugin-run` | | Skip official plugin-first execution and use the LST pipeline directly | `false` |
+| `--process-timeout-seconds` | | Build-tool subprocess timeout for the fallback LST pipeline | `120` |
+| `--plugin-timeout-seconds` | | Stage 0 Gradle/Maven plugin timeout | `600` |
+| `--resolver-connect-timeout-ms` | | Maven Resolver TCP connection timeout | `30000` |
+| `--resolver-request-timeout-ms` | | Maven Resolver socket/request timeout | `60000` |
 | `--include-extensions` | | Comma-separated file types to parse | — |
 | `--exclude-extensions` | | Comma-separated file types to skip | — |
 | `--info` | | Enable INFO-level logging to stderr | `false` |
@@ -58,6 +63,7 @@ core/src/
 │   ├── RewriteRunner.kt            # Library facade — builder API, orchestrates the full pipeline
 │   ├── RunResult.kt
 │   ├── config/ToolConfig.kt        # YAML config + env var interpolation
+│   ├── plugin/                     # Stage 0 official Gradle/Maven plugin execution + patch parsing
 │   ├── lst/
 │   │   ├── LstBuilder.kt           # Orchestrates 4-stage pipeline + multi-language parsing
 │   │   ├── ProjectBuildStage.kt       # Stage 1: Maven/Gradle subprocess (build-classpath/init-script)
@@ -98,6 +104,7 @@ cli/src/
 - `InMemoryLargeSourceSet` is in `org.openrewrite.internal` (not the top-level package)
 - `ProjectBuildStage` and `DependencyResolutionStage` are `open` with `open` methods — subclass in tests instead of mocking
 - `ResultFormatter` has a secondary constructor accepting `PrintWriter`; `RunCommand` passes picocli's `@Spec` output writer
+- Stage 0 tries the official Gradle/Maven OpenRewrite plugins first and returns `RunResult.rawDiffs` on success. Use `--skip-plugin-run` / `Builder.skipPluginRun(true)` when testing or debugging the in-process LST pipeline directly.
 - Extension filtering: CLI flags take precedence over config file settings
 - OpenRewrite requires all source files in memory simultaneously — for large projects use `-Xmx6g`
 - Dockerfile/Containerfile files are collected both by extension (`.dockerfile`, `.containerfile`) and by filename prefix (`Dockerfile*`, `Containerfile*`) — all go into the `.dockerfile` bucket for `DockerParser`

--- a/README.md
+++ b/README.md
@@ -177,13 +177,13 @@ import io.github.skhokhlov.rewriterunner.output.ResultFormatter
 val result = runner.run()
 
 // Print unified diffs to stdout
-ResultFormatter(OutputMode.DIFF).format(result.results, result.projectDir)
+ResultFormatter(OutputMode.DIFF).format(result)
 
 // Print only the paths of changed files (one per line)
-ResultFormatter(OutputMode.FILES).format(result.results, result.projectDir)
+ResultFormatter(OutputMode.FILES).format(result)
 
 // Write openrewrite-report.json to the project directory
-ResultFormatter(OutputMode.REPORT).format(result.results, result.projectDir)
+ResultFormatter(OutputMode.REPORT).format(result)
 ```
 
 `OutputMode` values:
@@ -209,6 +209,7 @@ Library consumers that only need to inspect changes programmatically can skip `R
 | `cacheDir(Path)` | optional | `~/.rewriterunner/cache` | Cache root for downloaded recipe JARs (stored under `<cacheDir>/repository`). Project dependencies always resolve from `~/.m2/repository`. |
 | `configFile(Path)` | optional | auto-discovered | Path to `rewriterunner.yml`; auto-discovery checks `<projectDir>/rewriterunner.yml` then `~/.rewriterunner/rewriterunner.yml` |
 | `dryRun(Boolean)` | optional | `false` | Analyse without writing to disk |
+| `skipPluginRun(Boolean)` | optional | `false` | Skip plugin-first execution and use the in-process LST pipeline directly |
 | `includeExtensions(List<String>)` | optional | all supported | File extensions to parse; overrides config file setting |
 | `excludeExtensions(List<String>)` | optional | — | File extensions to skip; overrides config file setting |
 | `excludePaths(List<String>)` | optional | — | Glob patterns (relative to project root) for paths to skip during parsing; overrides `parse.excludePaths` from config file |
@@ -305,10 +306,15 @@ val result = RewriteRunner.builder()
 ## CLI Reference
 
 ```
-Usage: rewrite-runner [-h] [--dry-run] [--info] [--debug] [--no-maven-central]
+Usage: rewrite-runner [-h] [--dry-run] [--skip-plugin-run] [--info] [--debug]
+                          [--no-maven-central]
                           [--active-recipe=<recipe>]
                           [--cache-dir=<path>] [--config=<path>]
                           [--download-threads=<n>]
+                          [--process-timeout-seconds=<seconds>]
+                          [--plugin-timeout-seconds=<seconds>]
+                          [--resolver-connect-timeout-ms=<ms>]
+                          [--resolver-request-timeout-ms=<ms>]
                           [--output=<mode>] [--project-dir=<path>]
                           [--rewrite-config=<path>]
                           [--exclude-extensions=<ext>[,<ext>...]]
@@ -326,7 +332,12 @@ Usage: rewrite-runner [-h] [--dry-run] [--info] [--debug] [--no-maven-central]
 | `--cache-dir` | Cache root for downloaded recipe JARs (stored under `<path>/repository`). Project dependencies always resolve from `~/.m2/repository`. | `~/.rewriterunner/cache` |
 | `--config` | Path to tool config file (`rewriterunner.yml`) | `<project-dir>/rewriterunner.yml`, then `~/.rewriterunner/rewriterunner.yml` |
 | `--dry-run` | Run recipe but do not write changes to disk | `false` |
+| `--skip-plugin-run` | Skip plugin-first execution; use full LST pipeline directly | `false` |
 | `--download-threads` | Number of parallel artifact download threads | `5` |
+| `--process-timeout-seconds` | Timeout for build-tool subprocesses in the fallback LST pipeline | `120` |
+| `--plugin-timeout-seconds` | Timeout for plugin-first Gradle/Maven invocations | `600` |
+| `--resolver-connect-timeout-ms` | TCP connection timeout for Maven Resolver downloads | `30000` |
+| `--resolver-request-timeout-ms` | Socket read/request timeout for Maven Resolver downloads | `60000` |
 | `--include-extensions` | Comma-separated file extensions to parse (e.g. `.java,.kt`) | all supported |
 | `--exclude-extensions` | Comma-separated file extensions to skip | — |
 | `--no-maven-central` | Disable Maven Central; use only repositories from the config file | `false` |
@@ -428,6 +439,12 @@ repositories:
 cacheDir: ~/.rewriterunner/cache
 
 downloadThreads: 5   # parallel artifact download threads (default: 5)
+processTimeoutSeconds: 120        # fallback LST build-tool subprocess timeout
+pluginTimeoutSeconds: 600         # plugin-first rewriteDryRun/rewriteRun timeout
+rewriteGradlePluginVersion: 7.32.1
+rewriteMavenPluginVersion: 6.38.0
+resolverConnectTimeoutMs: 30000   # Maven Resolver TCP connection timeout
+resolverRequestTimeoutMs: 60000   # Maven Resolver socket/request timeout
 
 parse:
   includeExtensions: [".java", ".kt", ".xml"]
@@ -438,6 +455,21 @@ parse:
 ```
 
 Environment variable placeholders (`${VAR_NAME}`) are expanded at runtime.
+
+## Plugin-First Execution
+
+Before building its own LST, the tool first attempts to apply the recipe through the official OpenRewrite plugin for the project's build tool:
+
+- **Gradle**: injects a temporary init script that applies the `org.openrewrite.rewrite` plugin, then runs `rewriteDryRun` and, when not in `--dry-run` mode, `rewriteRun`
+- **Maven**: invokes `org.openrewrite.maven:rewrite-maven-plugin` directly via `./mvnw`, `mvnw.cmd`, or system `mvn`
+
+The dry-run goal always runs first so the tool can capture generated `rewrite.patch` files and format output in `diff`, `files`, or `report` mode. Maven multi-module builds may emit patches under each changed module's `target/site/rewrite/` directory, and those paths are reported relative to the project root. If no patches contain changes, the run short-circuits with no changes. If plugin execution succeeds with changes, the in-process LST pipeline is skipped entirely.
+
+If the plugin path fails for any reason (no build tool, plugin resolution failure, build error, recipe unavailable, timeout), the tool falls through silently to the fallback pipeline below.
+
+This plugin-first stage is enabled by default. Existing callers that need the previous direct LST pipeline behavior should pass `--skip-plugin-run` or set `skipPluginRun(true)`.
+
+Use `--skip-plugin-run` to bypass this stage.
 
 ## Resilient Parsing Pipeline
 
@@ -452,7 +484,7 @@ If successful, the resulting JAR list is passed to `JavaParser` for full type at
 
 ### Stage 2 — Direct dependency resolution
 If Stage 1 fails (broken build, no wrapper, timeout), the tool resolves dependencies without running the full build:
-- **Maven**: parses `pom.xml` using `maven-model`. All scopes except `provided` and `system` are included — test-scoped dependencies (JUnit, Mockito, etc.) are resolved so that test source files can be fully type-attributed.
+- **Maven**: parses `pom.xml` using `maven-model`. Includes `compile`, `provided`, and `test` scopes; excludes `runtime` and `system` scopes — provided and test dependencies are included to support compile-time and test-source type resolution while runtime-only artifacts are skipped.
 - **Gradle**: runs `gradle dependencies` for the root project **and all declared subprojects** (discovered from `settings.gradle` / `settings.gradle.kts`), parsing the resolved dependency tree to get accurately resolved versions; falls back to best-effort static regex parsing of `build.gradle` / `build.gradle.kts` if Gradle cannot be invoked.
 
 > **Note:** The `gradle dependencies` task only reports dependencies for the project it is applied to. Subprojects are queried explicitly (`:sub:dependencies`) so that multi-module builds are fully covered.
@@ -479,7 +511,7 @@ Unresolved types appear as `JavaType.Unknown` in the LST, but all structural, te
 
 | Extension | Parser |
 |-----------|--------|
-| `.java` | `JavaParser` (with classpath from 3-stage pipeline) |
+| `.java` | `JavaParser` (with classpath from fallback pipeline) |
 | `.kt`, `.kts` | `KotlinParser` (`.kts` augmented with Gradle DSL classpath) |
 | `.groovy`, `.gradle` | `GroovyParser` (`.gradle` augmented with Gradle DSL classpath) |
 | `.yaml`, `.yml` | `YamlParser` |

--- a/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
+++ b/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
@@ -79,6 +79,12 @@ class RunCommand : Callable<Int> {
     var dryRun: Boolean = false
 
     @Option(
+        names = ["--skip-plugin-run"],
+        description = ["Skip plugin-first execution; use full LST pipeline directly."]
+    )
+    var skipPluginRun: Boolean = false
+
+    @Option(
         names = ["--info"],
         description = ["Enable INFO-level logging (default)."]
     )
@@ -116,6 +122,36 @@ class RunCommand : Callable<Int> {
     )
     var downloadThreads: Int? = null
 
+    @Option(
+        names = ["--process-timeout-seconds"],
+        description = [
+            "Timeout for build-tool subprocesses in the fallback LST pipeline.",
+            "Defaults to 120."
+        ]
+    )
+    var processTimeoutSeconds: Long? = null
+
+    @Option(
+        names = ["--plugin-timeout-seconds"],
+        description = ["Timeout for plugin-first Gradle/Maven invocations. Defaults to 600."]
+    )
+    var pluginTimeoutSeconds: Long? = null
+
+    @Option(
+        names = ["--resolver-connect-timeout-ms"],
+        description = ["TCP connection timeout for Maven Resolver downloads. Defaults to 30000."]
+    )
+    var resolverConnectTimeoutMs: Int? = null
+
+    @Option(
+        names = ["--resolver-request-timeout-ms"],
+        description = [
+            "Socket read/request timeout for Maven Resolver downloads.",
+            "Defaults to 60000."
+        ]
+    )
+    var resolverRequestTimeoutMs: Int? = null
+
     override fun call(): Int {
         val logger =
             LogbackRunnerLogger(showInfo = infoLogging || debugLogging, showDebug = debugLogging)
@@ -126,6 +162,7 @@ class RunCommand : Callable<Int> {
                 .activeRecipe(activeRecipe)
                 .recipeArtifacts(recipeArtifacts)
                 .dryRun(dryRun)
+                .skipPluginRun(skipPluginRun)
                 .includeExtensions(includeExtensions)
                 .excludeExtensions(excludeExtensions)
                 .logger(logger)
@@ -134,13 +171,17 @@ class RunCommand : Callable<Int> {
             configFile?.let { builder.configFile(it) }
             if (noMavenCentral) builder.includeMavenCentral(false)
             downloadThreads?.let { builder.downloadThreads(it) }
+            processTimeoutSeconds?.let { builder.processTimeoutSeconds(it) }
+            pluginTimeoutSeconds?.let { builder.pluginTimeoutSeconds(it) }
+            resolverConnectTimeoutMs?.let { builder.resolverConnectTimeoutMs(it) }
+            resolverRequestTimeoutMs?.let { builder.resolverRequestTimeoutMs(it) }
 
             val runResult = builder.build().run()
 
             ResultFormatter(
                 outputMode,
                 spec.commandLine().out
-            ).format(runResult.results, runResult.projectDir)
+            ).format(runResult)
 
             0
         } catch (e: IllegalArgumentException) {

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
@@ -101,6 +101,14 @@ class RunCommandTest :
             assertEquals(false, cmd.dryRun, "--dry-run should default to false")
         }
 
+        test("--skip-plugin-run defaults to false") {
+            val cmd = RunCommand()
+            CommandLine(
+                cmd
+            ).parseArgs("--active-recipe", "io.github.skhokhlov.rewriterunner.MyRecipe")
+            assertEquals(false, cmd.skipPluginRun, "--skip-plugin-run should default to false")
+        }
+
         test("--debug defaults to false") {
             val cmd = RunCommand()
             CommandLine(
@@ -154,6 +162,15 @@ class RunCommandTest :
             )
         }
 
+        test("--help output mentions --skip-plugin-run") {
+            val baos = ByteArrayOutputStream()
+            cli().setOut(PrintWriter(baos)).execute("--help")
+            assertTrue(
+                baos.toString().contains("skip-plugin-run"),
+                "--help should document --skip-plugin-run option"
+            )
+        }
+
         test("--download-threads is parsed and propagated to the command") {
             val cmd = RunCommand()
             CommandLine(cmd).parseArgs(
@@ -167,6 +184,36 @@ class RunCommandTest :
                 cmd.downloadThreads,
                 "--download-threads 8 should set downloadThreads to 8"
             )
+        }
+
+        test("timeout options are parsed") {
+            val cmd = RunCommand()
+            CommandLine(cmd).parseArgs(
+                "--active-recipe",
+                "io.github.skhokhlov.rewriterunner.MyRecipe",
+                "--process-timeout-seconds",
+                "45",
+                "--plugin-timeout-seconds",
+                "900",
+                "--resolver-connect-timeout-ms",
+                "10000",
+                "--resolver-request-timeout-ms",
+                "20000"
+            )
+            assertEquals(45L, cmd.processTimeoutSeconds)
+            assertEquals(900L, cmd.pluginTimeoutSeconds)
+            assertEquals(10_000, cmd.resolverConnectTimeoutMs)
+            assertEquals(20_000, cmd.resolverRequestTimeoutMs)
+        }
+
+        test("--help output mentions timeout options") {
+            val baos = ByteArrayOutputStream()
+            cli().setOut(PrintWriter(baos)).execute("--help")
+            val help = baos.toString()
+            assertTrue(help.contains("--process-timeout-seconds"))
+            assertTrue(help.contains("--plugin-timeout-seconds"))
+            assertTrue(help.contains("--resolver-connect-timeout-ms"))
+            assertTrue(help.contains("--resolver-request-timeout-ms"))
         }
 
         test("multiple --recipe-artifact flags are collected into a list") {

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/GroovyProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/GroovyProjectIntegrationTest.kt
@@ -148,6 +148,7 @@ class GroovyProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions",
                     ".gradle"
                 )
@@ -177,7 +178,8 @@ class GroovyProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString()
+                    cacheDir.toString(),
+                    "--skip-plugin-run"
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -203,6 +205,7 @@ class GroovyProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
+                "--skip-plugin-run",
                 "--include-extensions",
                 ".gradle"
             )
@@ -233,7 +236,8 @@ class GroovyProjectIntegrationTest :
                 "--rewrite-config",
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
-                cacheDir.toString()
+                cacheDir.toString(),
+                "--skip-plugin-run"
             )
 
             assertTrue(

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/JavaProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/JavaProjectIntegrationTest.kt
@@ -266,6 +266,7 @@ class JavaProjectIntegrationTest :
                     "--active-recipe", "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir", cacheDir.toString(),
                     "--include-extensions", ".java",
+                    "--skip-plugin-run",
                     "--dry-run"
                 )
 
@@ -322,6 +323,7 @@ class JavaProjectIntegrationTest :
                     "--active-recipe", "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir", cacheDir.toString(),
                     "--include-extensions", ".java",
+                    "--skip-plugin-run",
                     "--dry-run"
                 )
 

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/KotlinProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/KotlinProjectIntegrationTest.kt
@@ -168,6 +168,7 @@ class KotlinProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions",
                     ".kts"
                 )
@@ -192,7 +193,8 @@ class KotlinProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString()
+                    cacheDir.toString(),
+                    "--skip-plugin-run"
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -217,6 +219,7 @@ class KotlinProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
+                "--skip-plugin-run",
                 "--include-extensions",
                 ".kts",
                 "--dry-run"
@@ -244,7 +247,8 @@ class KotlinProjectIntegrationTest :
                 "--rewrite-config",
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
-                cacheDir.toString()
+                cacheDir.toString(),
+                "--skip-plugin-run"
             )
 
             assertTrue(
@@ -273,6 +277,7 @@ class KotlinProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
+                "--skip-plugin-run",
                 "--include-extensions",
                 ".kts"
             )

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/MavenProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/MavenProjectIntegrationTest.kt
@@ -55,6 +55,7 @@ class MavenProjectIntegrationTest :
                     "--active-recipe", "com.example.integration.FindAndReplace",
                     "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir", cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions", ".xml"
                 )
 
@@ -79,6 +80,7 @@ class MavenProjectIntegrationTest :
                 "--active-recipe", "com.example.integration.FindAndReplace",
                 "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir", cacheDir.toString(),
+                "--skip-plugin-run",
                 "--include-extensions", ".xml",
                 "--dry-run"
             )
@@ -103,6 +105,7 @@ class MavenProjectIntegrationTest :
                     "--active-recipe", "com.example.integration.FindAndReplace",
                     "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir", cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions", ".xml",
                     "--dry-run"
                 )
@@ -138,6 +141,7 @@ class MavenProjectIntegrationTest :
                     "--active-recipe", "com.example.integration.FindAndReplace",
                     "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir", cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions", ".xml",
                     "--output", "files",
                     "--dry-run"
@@ -177,6 +181,7 @@ class MavenProjectIntegrationTest :
                     "--active-recipe", "com.example.integration.FindAndReplace",
                     "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir", cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions", ".xml",
                     "--output", "files",
                     "--dry-run"

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/MultiLanguageProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/MultiLanguageProjectIntegrationTest.kt
@@ -89,6 +89,7 @@ class MultiLanguageProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
+                "--skip-plugin-run",
                 "--include-extensions",
                 ".java"
             )
@@ -126,6 +127,7 @@ class MultiLanguageProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
+                "--skip-plugin-run",
                 "--include-extensions",
                 ".java,.kt,.yaml"
             )
@@ -176,6 +178,7 @@ class MultiLanguageProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions",
                     ".java,.yaml,.xml,.json,.properties",
                     "--output",
@@ -203,6 +206,7 @@ class MultiLanguageProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions",
                     ".java,.yaml,.xml,.json,.properties",
                     "--output",
@@ -239,6 +243,7 @@ class MultiLanguageProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions",
                     ".java,.yaml,.xml,.json,.properties",
                     "--output",
@@ -282,6 +287,7 @@ class MultiLanguageProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
+                "--skip-plugin-run",
                 "--include-extensions",
                 ".java,.kt,.yaml,.properties,.xml,.json",
                 "--dry-run"
@@ -313,6 +319,7 @@ class MultiLanguageProjectIntegrationTest :
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions",
                     ".java",
                     "--output",

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/PluginFirstIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/PluginFirstIntegrationTest.kt
@@ -1,0 +1,106 @@
+package io.github.skhokhlov.rewriterunner.integration
+
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private val isWindows = System.getProperty("os.name", "").lowercase().contains("windows")
+
+class PluginFirstIntegrationTest :
+    FunSpec({
+        var projectDir: Path = Path.of("")
+        var cacheDir: Path = Path.of("")
+
+        beforeEach {
+            projectDir = Files.createTempDirectory("pfit-project-")
+            cacheDir = Files.createTempDirectory("pfit-cache-")
+            projectDir.resolve("build.gradle.kts").writeText("")
+            projectDir.resolve("src").toFile().mkdirs()
+            projectDir.resolve("src/App.java").writeText("class App{}\n")
+        }
+
+        afterEach {
+            projectDir.toFile().deleteRecursively()
+            cacheDir.toFile().deleteRecursively()
+        }
+
+        fun writeFakeGradlew() {
+            val gradlew = projectDir.resolve("gradlew")
+            gradlew.writeText(
+                """
+                #!/bin/sh
+                if [ "$1" = "rewriteDryRun" ]; then
+                  mkdir -p build/reports/rewrite
+                  cat > build/reports/rewrite/rewrite.patch <<'PATCH'
+                diff --git a/src/App.java b/src/App.java
+                --- a/src/App.java
+                +++ b/src/App.java
+                @@ -1 +1 @@
+                -class App{}
+                +class App { }
+                PATCH
+                  exit 0
+                fi
+                if [ "$1" = "rewriteRun" ]; then
+                  printf 'class App { }\n' > src/App.java
+                  exit 0
+                fi
+                exit 1
+                """.trimIndent()
+            )
+            Files.setPosixFilePermissions(
+                gradlew,
+                setOf(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE
+                )
+            )
+        }
+
+        test(
+            "plugin-first Gradle path formats raw diffs and applies changes"
+        ).config(enabled = !isWindows) {
+            writeFakeGradlew()
+
+            // The fake wrapper validates plugin-first orchestration and raw-diff formatting.
+            // Init script content is covered by GradlePluginStrategyTest.
+            val result =
+                runCli(
+                    "--project-dir",
+                    projectDir.toString(),
+                    "--active-recipe",
+                    "com.example.Recipe",
+                    "--cache-dir",
+                    cacheDir.toString(),
+                    "--output",
+                    "files"
+                )
+
+            assertEquals(0, result.exitCode)
+            assertEquals("src/App.java", result.stdout.trim())
+            assertEquals("class App { }\n", projectDir.resolve("src/App.java").toFile().readText())
+        }
+
+        test("--skip-plugin-run bypasses fake plugin path").config(enabled = !isWindows) {
+            writeFakeGradlew()
+
+            val result =
+                runCli(
+                    "--project-dir",
+                    projectDir.toString(),
+                    "--active-recipe",
+                    "com.example.Recipe",
+                    "--cache-dir",
+                    cacheDir.toString(),
+                    "--skip-plugin-run"
+                )
+
+            assertTrue(result.exitCode != 0)
+            assertEquals("class App{}\n", projectDir.resolve("src/App.java").toFile().readText())
+        }
+    })

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/XmlProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/XmlProjectIntegrationTest.kt
@@ -54,6 +54,7 @@ class XmlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions",
                     ".xml"
                 )
@@ -115,6 +116,7 @@ class XmlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
+                    "--skip-plugin-run",
                     "--include-extensions",
                     ".xml"
                 )

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/AetherContext.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/AetherContext.kt
@@ -71,8 +71,8 @@ class AetherContext(
         fun build(
             localRepoDir: Path,
             extraRepositories: List<RepositoryConfig> = emptyList(),
-            connectTimeoutMs: Int = 30_000,
-            requestTimeoutMs: Int = 60_000,
+            connectTimeoutMs: Int = ExecutionTimeouts.DEFAULT_RESOLVER_CONNECT_TIMEOUT_MS,
+            requestTimeoutMs: Int = ExecutionTimeouts.DEFAULT_RESOLVER_REQUEST_TIMEOUT_MS,
             downloadThreads: Int = 5,
             excludeScopesFromGraph: Collection<String> = emptyList(),
             includeMavenCentral: Boolean = true,

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionTimeouts.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionTimeouts.kt
@@ -1,0 +1,9 @@
+package io.github.skhokhlov.rewriterunner
+
+/** Central defaults for external execution and resolver network timeouts. */
+object ExecutionTimeouts {
+    const val DEFAULT_PROCESS_TIMEOUT_SECONDS = 120L
+    const val DEFAULT_PLUGIN_TIMEOUT_SECONDS = 600L
+    const val DEFAULT_RESOLVER_CONNECT_TIMEOUT_MS = 30_000
+    const val DEFAULT_RESOLVER_REQUEST_TIMEOUT_MS = 60_000
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
@@ -3,6 +3,8 @@ package io.github.skhokhlov.rewriterunner
 import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
 import io.github.skhokhlov.rewriterunner.lst.LstBuilder
+import io.github.skhokhlov.rewriterunner.plugin.PluginRecipeRunner
+import io.github.skhokhlov.rewriterunner.plugin.PluginRunResult
 import io.github.skhokhlov.rewriterunner.recipe.RecipeArtifactResolver
 import io.github.skhokhlov.rewriterunner.recipe.RecipeLoader
 import io.github.skhokhlov.rewriterunner.recipe.RecipeRunner
@@ -15,6 +17,7 @@ import kotlin.io.path.exists
  * Programmatic entry point for running OpenRewrite recipes from library code.
  *
  * Encapsulates the same orchestration pipeline that the CLI uses:
+ * 0. Try the official Gradle/Maven OpenRewrite plugin via [PluginRecipeRunner].
  * 1. Load [ToolConfig] (from [Builder.configFile] if supplied, otherwise defaults).
  * 2. Resolve recipe JARs from Maven coordinates via [RecipeArtifactResolver].
  * 3. Load the requested recipe via [RecipeLoader].
@@ -64,17 +67,95 @@ class RewriteRunner private constructor(private val config: Builder) {
             "projectDir does not exist or is not a directory: ${config.projectDir}"
         }
 
-        // 1. Load tool config
-        logger.lifecycle("[1/6] Loading configuration")
         val effectiveConfigFile = config.configFile
             ?: findConfigCaseInsensitive(config.projectDir)
             ?: findConfigCaseInsensitive(
                 Paths.get(System.getProperty("user.home"), ".rewriterunner")
             )
         val toolConfig = ToolConfig.load(effectiveConfigFile, logger)
+        val effectiveProcessTimeoutSeconds =
+            positiveLong(
+                config.processTimeoutSeconds ?: toolConfig.processTimeoutSeconds,
+                "processTimeoutSeconds"
+            )
+        val effectivePluginTimeoutSeconds =
+            positiveLong(
+                config.pluginTimeoutSeconds ?: toolConfig.pluginTimeoutSeconds,
+                "pluginTimeoutSeconds"
+            )
+        val effectiveResolverConnectTimeoutMs =
+            positiveInt(
+                config.resolverConnectTimeoutMs ?: toolConfig.resolverConnectTimeoutMs,
+                "resolverConnectTimeoutMs"
+            )
+        val effectiveResolverRequestTimeoutMs =
+            positiveInt(
+                config.resolverRequestTimeoutMs ?: toolConfig.resolverRequestTimeoutMs,
+                "resolverRequestTimeoutMs"
+            )
+
+        // Stage 0: let the project's own build tool run the official OpenRewrite plugin first.
+        if (!config.skipPluginRun) {
+            logger.lifecycle("[0/7] Attempting plugin-first recipe execution")
+            val pluginResult =
+                PluginRecipeRunner(
+                    logger = logger,
+                    timeoutSeconds = effectivePluginTimeoutSeconds,
+                    rewriteGradlePluginVersion = toolConfig.rewriteGradlePluginVersion,
+                    rewriteMavenPluginVersion = toolConfig.rewriteMavenPluginVersion
+                ).run(
+                    projectDir = config.projectDir,
+                    activeRecipe = config.activeRecipe,
+                    recipeArtifacts = config.recipeArtifacts,
+                    rewriteConfig = config.rewriteConfig,
+                    rewriteConfigContent = config.rewriteConfigContent,
+                    dryRun = config.dryRun,
+                    includeMavenCentral = config.includeMavenCentral
+                        ?: toolConfig.includeMavenCentral,
+                    repositories = toolConfig.resolvedRepositories() + config.repositories
+                )
+            when (pluginResult) {
+                is PluginRunResult.Success -> {
+                    logger.lifecycle(
+                        "      Plugin complete: ${pluginResult.diffs.size} file(s) changed"
+                    )
+                    return RunResult(
+                        results = emptyList(),
+                        changedFiles = pluginResult.changedFiles,
+                        projectDir = config.projectDir,
+                        rawDiffs = pluginResult.diffs
+                    )
+                }
+
+                PluginRunResult.NoChanges -> {
+                    logger.lifecycle("      Plugin complete: no changes")
+                    return RunResult(
+                        results = emptyList(),
+                        changedFiles = emptyList(),
+                        projectDir = config.projectDir
+                    )
+                }
+
+                is PluginRunResult.Failed ->
+                    logger.info("      Plugin failed: ${pluginResult.reason}")
+
+                is PluginRunResult.Skipped ->
+                    logger.info("      Plugin skipped: ${pluginResult.reason}")
+            }
+        }
+
+        // 1. Load tool config
+        logger.lifecycle("[1/7] Loading configuration")
         val effectiveCacheDir = (config.cacheDir ?: toolConfig.resolvedCacheDir()).also {
             logger.info("      Cache dir: $it")
         }
+        val effectiveToolConfig =
+            toolConfig.copy(
+                processTimeoutSeconds = effectiveProcessTimeoutSeconds,
+                pluginTimeoutSeconds = effectivePluginTimeoutSeconds,
+                resolverConnectTimeoutMs = effectiveResolverConnectTimeoutMs,
+                resolverRequestTimeoutMs = effectiveResolverRequestTimeoutMs
+            )
         val effectiveIncludeMavenCentral =
             config.includeMavenCentral ?: toolConfig.includeMavenCentral
         val effectiveDownloadThreads = config.downloadThreads ?: toolConfig.downloadThreads
@@ -86,6 +167,8 @@ class RewriteRunner private constructor(private val config: Builder) {
         val recipeAetherContext = AetherContext.build(
             localRepoDir = recipeLocalRepoDir,
             extraRepositories = effectiveRepositories,
+            connectTimeoutMs = effectiveResolverConnectTimeoutMs,
+            requestTimeoutMs = effectiveResolverRequestTimeoutMs,
             downloadThreads = effectiveDownloadThreads,
             // Prune test/provided/system scope nodes from the graph during collection so
             // their POMs are never fetched. Recipes only need compile/runtime JARs to run.
@@ -99,6 +182,8 @@ class RewriteRunner private constructor(private val config: Builder) {
         val projectAetherContext = AetherContext.build(
             localRepoDir = mavenLocalRepoDir,
             extraRepositories = effectiveRepositories,
+            connectTimeoutMs = effectiveResolverConnectTimeoutMs,
+            requestTimeoutMs = effectiveResolverRequestTimeoutMs,
             downloadThreads = effectiveDownloadThreads,
             includeMavenCentral = effectiveIncludeMavenCentral,
             logger = logger
@@ -106,17 +191,17 @@ class RewriteRunner private constructor(private val config: Builder) {
 
         // 2. Resolve recipe JARs
         val recipeJars = if (config.recipeArtifacts.isNotEmpty()) {
-            logger.lifecycle("[2/6] Resolving ${config.recipeArtifacts.size} recipe artifact(s)")
+            logger.lifecycle("[2/7] Resolving ${config.recipeArtifacts.size} recipe artifact(s)")
             RecipeArtifactResolver(recipeAetherContext, logger).resolveAll(config.recipeArtifacts)
         } else {
-            logger.lifecycle("[2/6] No recipe artifacts specified — using classpath recipes only")
+            logger.lifecycle("[2/7] No recipe artifacts specified — using classpath recipes only")
             emptyList()
         }
 
         // Stages 3–6 run inside RecipeLoader.use{} so the URLClassLoader over recipe JARs
         // is always closed when this block exits (success or exception), releasing file
         // descriptors promptly rather than waiting for GC.
-        logger.lifecycle("[3/6] Loading recipe '${config.activeRecipe}'")
+        logger.lifecycle("[3/7] Loading recipe '${config.activeRecipe}'")
         return RecipeLoader(logger).use { recipeLoader ->
 
             // 3. Load recipe (precedence: string content > explicit path > implicit projectDir/rewrite.yaml)
@@ -143,16 +228,16 @@ class RewriteRunner private constructor(private val config: Builder) {
             // is deferred to the end of this use{} block, after all stages complete.
             logger.info("      Recipe ready: ${recipe.name}")
 
-            // 4. Build LST (3-stage pipeline)
+            // 4. Build LST (4-stage pipeline)
             // OpenRewrite requires all source files in memory simultaneously to support
             // cross-file analysis. For large projects set -Xmx accordingly, e.g.:
             //   java -Xmx6g -jar rewrite-runner-all.jar …
-            logger.lifecycle("[4/6] Building LST for ${config.projectDir}")
+            logger.lifecycle("[4/7] Building LST for ${config.projectDir}")
             val lstBuilder =
                 LstBuilder(
                     logger = logger,
                     cacheDir = effectiveCacheDir,
-                    toolConfig = toolConfig,
+                    toolConfig = effectiveToolConfig,
                     aetherContext = projectAetherContext
                 )
             val effectiveParseConfig =
@@ -175,7 +260,7 @@ class RewriteRunner private constructor(private val config: Builder) {
 
             // 5. Run recipe
             logger.lifecycle(
-                "[5/6] Running recipe '${recipe.name}' against ${sourceFiles.size} file(s)"
+                "[5/7] Running recipe '${recipe.name}' against ${sourceFiles.size} file(s)"
             )
             val recipeStart = System.currentTimeMillis()
             val results = RecipeRunner(logger).run(recipe, sourceFiles)
@@ -187,7 +272,7 @@ class RewriteRunner private constructor(private val config: Builder) {
             // 6. Apply changes (unless dryRun)
             val writtenFiles = mutableListOf<Path>()
             if (!config.dryRun) {
-                logger.lifecycle("[6/6] Writing changes to disk")
+                logger.lifecycle("[6/7] Writing changes to disk")
                 for (result in results) {
                     if (result.after == null) {
                         // Recipe deleted this file — remove it from disk
@@ -217,7 +302,7 @@ class RewriteRunner private constructor(private val config: Builder) {
                 }
             } else {
                 logger.lifecycle(
-                    "[6/6] Dry-run mode: skipping disk writes (${results.size} file(s) would change)"
+                    "[6/7] Dry-run mode: skipping disk writes (${results.size} file(s) would change)"
                 )
             }
 
@@ -258,6 +343,8 @@ class RewriteRunner private constructor(private val config: Builder) {
             private set
         internal var dryRun: Boolean = false
             private set
+        internal var skipPluginRun: Boolean = false
+            private set
         internal var includeExtensions: List<String> = emptyList()
             private set
         internal var excludeExtensions: List<String> = emptyList()
@@ -265,6 +352,14 @@ class RewriteRunner private constructor(private val config: Builder) {
         internal var includeMavenCentral: Boolean? = null
             private set
         internal var downloadThreads: Int? = null
+            private set
+        internal var processTimeoutSeconds: Long? = null
+            private set
+        internal var pluginTimeoutSeconds: Long? = null
+            private set
+        internal var resolverConnectTimeoutMs: Int? = null
+            private set
+        internal var resolverRequestTimeoutMs: Int? = null
             private set
         internal var repositories: List<RepositoryConfig> = emptyList()
             private set
@@ -335,6 +430,12 @@ class RewriteRunner private constructor(private val config: Builder) {
         fun dryRun(value: Boolean): Builder = apply { dryRun = value }
 
         /**
+         * When `true`, bypass the official Gradle/Maven plugin attempt and use the
+         * in-process LST pipeline directly.
+         */
+        fun skipPluginRun(value: Boolean): Builder = apply { skipPluginRun = value }
+
+        /**
          * Restrict parsing to the given file extensions (e.g. `".java"`, `".kt"`).
          * Overrides any `includeExtensions` setting from the tool config file.
          */
@@ -355,6 +456,24 @@ class RewriteRunner private constructor(private val config: Builder) {
          * When not set, falls back to `downloadThreads` from the tool config.
          */
         fun downloadThreads(n: Int): Builder = apply { downloadThreads = n }
+
+        /**
+         * Timeout for non-plugin build-tool subprocesses, including LST Stage 1,
+         * Stage 2, compile attempts, and build-tool metadata commands.
+         */
+        fun processTimeoutSeconds(seconds: Long): Builder =
+            apply { processTimeoutSeconds = seconds }
+
+        /** Timeout for official OpenRewrite Gradle/Maven plugin invocations in Stage 0. */
+        fun pluginTimeoutSeconds(seconds: Long): Builder = apply { pluginTimeoutSeconds = seconds }
+
+        /** TCP connection timeout for Maven Resolver artifact downloads. */
+        fun resolverConnectTimeoutMs(milliseconds: Int): Builder =
+            apply { resolverConnectTimeoutMs = milliseconds }
+
+        /** Socket read/request timeout for Maven Resolver artifact downloads. */
+        fun resolverRequestTimeoutMs(milliseconds: Int): Builder =
+            apply { resolverRequestTimeoutMs = milliseconds }
 
         /**
          * Override whether Maven Central is included as a remote repository.
@@ -431,6 +550,16 @@ class RewriteRunner private constructor(private val config: Builder) {
             }
         } catch (_: Exception) {
             null
+        }
+
+        private fun positiveLong(value: Long, name: String): Long {
+            require(value > 0) { "$name must be greater than 0: $value" }
+            return value
+        }
+
+        private fun positiveInt(value: Int, name: String): Int {
+            require(value > 0) { "$name must be greater than 0: $value" }
+            return value
         }
     }
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RunResult.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RunResult.kt
@@ -12,16 +12,19 @@ import org.openrewrite.Result
  * @property changedFiles Paths of files that were written to disk during this run.
  *   Empty when [RewriteRunner.Builder.dryRun] is `true` or when [results] is empty.
  * @property projectDir The project directory that was analysed, for reference.
+ * @property rawDiffs Unified diffs keyed by relative file path. Populated when the
+ *   plugin-first path succeeds and no raw OpenRewrite [Result] objects are available.
  */
 data class RunResult(
     val results: List<Result>,
     val changedFiles: List<Path>,
-    val projectDir: Path
+    val projectDir: Path,
+    val rawDiffs: Map<Path, String> = emptyMap()
 ) {
     /** `true` when the recipe produced at least one change, regardless of whether
      *  changes were written to disk. */
-    val hasChanges: Boolean get() = results.isNotEmpty()
+    val hasChanges: Boolean get() = results.isNotEmpty() || rawDiffs.isNotEmpty()
 
     /** Number of source files changed by the recipe. */
-    val changeCount: Int get() = results.size
+    val changeCount: Int get() = if (results.isNotEmpty()) results.size else rawDiffs.size
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
@@ -1,6 +1,7 @@
 package io.github.skhokhlov.rewriterunner.config
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
 import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import java.nio.file.Path
@@ -63,6 +64,16 @@ data class ParseConfig(
  *   Defaults to `~/.rewriterunner/cache`.
  * @property parse File parsing configuration controlling which extensions and paths are
  *   included or excluded from the LST-building stage.
+ * @property processTimeoutSeconds Timeout for build-tool subprocesses in the fallback
+ *   LST pipeline.
+ * @property pluginTimeoutSeconds Timeout for official Gradle/Maven plugin invocations
+ *   in Stage 0.
+ * @property rewriteGradlePluginVersion Version of the official OpenRewrite Gradle plugin
+ *   used by Stage 0 plugin-first execution.
+ * @property rewriteMavenPluginVersion Version of the official OpenRewrite Maven plugin
+ *   used by Stage 0 plugin-first execution.
+ * @property resolverConnectTimeoutMs TCP connection timeout for Maven Resolver downloads.
+ * @property resolverRequestTimeoutMs Socket read/request timeout for Maven Resolver downloads.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ToolConfig(
@@ -71,6 +82,12 @@ data class ToolConfig(
     val parse: ParseConfig = ParseConfig(),
     val includeMavenCentral: Boolean = true,
     val downloadThreads: Int = 5,
+    val processTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS,
+    val pluginTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+    val rewriteGradlePluginVersion: String = REWRITE_GRADLE_PLUGIN_VERSION,
+    val rewriteMavenPluginVersion: String = REWRITE_MAVEN_PLUGIN_VERSION,
+    val resolverConnectTimeoutMs: Int = ExecutionTimeouts.DEFAULT_RESOLVER_CONNECT_TIMEOUT_MS,
+    val resolverRequestTimeoutMs: Int = ExecutionTimeouts.DEFAULT_RESOLVER_REQUEST_TIMEOUT_MS,
     val logger: RunnerLogger = NoOpRunnerLogger
 ) {
     /** Returns [cacheDir] with `~` expanded to the user home directory and environment
@@ -95,6 +112,9 @@ data class ToolConfig(
     }
 
     companion object {
+        const val REWRITE_GRADLE_PLUGIN_VERSION = "7.32.1"
+        const val REWRITE_MAVEN_PLUGIN_VERSION = "6.38.0"
+
         private val yaml = YAMLMapper.builder()
             .addModule(KotlinModule.Builder().build())
             .build()

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
@@ -1,6 +1,7 @@
 package io.github.skhokhlov.rewriterunner.lst
 
 import io.github.skhokhlov.rewriterunner.AetherContext
+import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.lst.utils.ClasspathResolutionResult
 import io.github.skhokhlov.rewriterunner.lst.utils.GradleConfigData
@@ -60,7 +61,8 @@ import org.eclipse.aether.resolution.ArtifactResolutionException
  */
 open class DependencyResolutionStage(
     private val aetherContext: AetherContext,
-    protected val logger: RunnerLogger
+    protected val logger: RunnerLogger,
+    private val processTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS
 ) {
     private val staticParser = StaticBuildFileParser(logger)
 
@@ -181,6 +183,7 @@ open class DependencyResolutionStage(
             projectDir,
             listOf(mvnCmd, "dependency:tree"),
             captureStdout = output,
+            timeoutSeconds = processTimeoutSeconds,
             logger = logger
         ) ?: return null
         if (result != 0) {
@@ -268,6 +271,7 @@ open class DependencyResolutionStage(
                 "--no-configuration-cache"
             ) + tasks,
             captureStdout = output,
+            timeoutSeconds = processTimeoutSeconds,
             logger = logger
         ) ?: return null
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
@@ -77,12 +77,20 @@ open class LstBuilder(
     private val aetherContext: AetherContext = AetherContext.build(
         localRepoDir = Paths.get(System.getProperty("user.home"), ".m2", "repository"),
         extraRepositories = toolConfig.resolvedRepositories(),
+        connectTimeoutMs = toolConfig.resolverConnectTimeoutMs,
+        requestTimeoutMs = toolConfig.resolverRequestTimeoutMs,
+        downloadThreads = toolConfig.downloadThreads,
+        includeMavenCentral = toolConfig.includeMavenCentral,
         logger = logger
     ),
-    private val projectBuildStage: ProjectBuildStage = ProjectBuildStage(logger),
+    private val projectBuildStage: ProjectBuildStage = ProjectBuildStage(
+        logger,
+        toolConfig.processTimeoutSeconds
+    ),
     private val depResolutionStage: DependencyResolutionStage = DependencyResolutionStage(
         aetherContext,
-        logger
+        logger,
+        toolConfig.processTimeoutSeconds
     ),
     private val buildFileParseStage: BuildFileParseStage = BuildFileParseStage(
         aetherContext,
@@ -93,7 +101,8 @@ open class LstBuilder(
     private val versionDetector = VersionDetector(logger)
     private val staticParser = StaticBuildFileParser(logger)
     private val gradleDslClasspathResolver = GradleDslClasspathResolver(logger, versionDetector)
-    private val markerFactory = MarkerFactory(logger, staticParser, versionDetector)
+    private val markerFactory =
+        MarkerFactory(logger, staticParser, versionDetector, toolConfig.processTimeoutSeconds)
 
     // ─── Thin delegation methods for backward-compatible test access ──────────
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner.lst
 
+import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.lst.utils.hasBuildGradle
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
@@ -51,7 +52,10 @@ import kotlin.io.path.exists
  * **Extensibility:** The class is `open` with `open` methods so tests can subclass
  * it to inject a fake classpath without spawning real processes.
  */
-open class ProjectBuildStage(protected val logger: RunnerLogger) {
+open class ProjectBuildStage(
+    protected val logger: RunnerLogger,
+    private val processTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS
+) {
     /**
      * Attempts to extract the project's compile classpath by invoking the build tool.
      *
@@ -87,6 +91,7 @@ open class ProjectBuildStage(protected val logger: RunnerLogger) {
             val result = runProcess(
                 projectDir,
                 mvnCommand,
+                timeoutSeconds = processTimeoutSeconds,
                 logger = logger
             ) ?: return null
 
@@ -140,6 +145,7 @@ open class ProjectBuildStage(protected val logger: RunnerLogger) {
                 projectDir,
                 gradleCommand,
                 captureStdout = output,
+                timeoutSeconds = processTimeoutSeconds,
                 logger = logger
             ) ?: return null
 
@@ -224,7 +230,13 @@ open class ProjectBuildStage(protected val logger: RunnerLogger) {
 
     private fun runCompileTask(projectDir: Path, command: List<String>, toolName: String): Boolean =
         try {
-            val result = runProcess(projectDir, command, logger = logger) ?: return false
+            val result =
+                runProcess(
+                    projectDir,
+                    command,
+                    timeoutSeconds = processTimeoutSeconds,
+                    logger = logger
+                ) ?: return false
             if (result == 0) {
                 logger.info("$toolName compilation succeeded")
                 true

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/MarkerFactory.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/MarkerFactory.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner.lst.utils
 
+import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.lst.utils.StaticBuildFileParser
 import java.nio.file.Path
@@ -31,8 +32,12 @@ import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion
 internal class MarkerFactory(
     private val logger: RunnerLogger,
     private val staticParser: StaticBuildFileParser,
-    private val versionDetector: VersionDetector
+    private val versionDetector: VersionDetector,
+    private val processTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS,
+    private val processRunner: ProcessRunner = ::runProcess
 ) {
+    private val metadataProbeTimeoutSeconds = minOf(processTimeoutSeconds, 5)
+
     fun buildEnvironment(): BuildEnvironment? = try {
         BuildEnvironment.build { key -> System.getenv(key) }
     } catch (e: Exception) {
@@ -94,12 +99,12 @@ internal class MarkerFactory(
     private fun detectMavenVersion(projectDir: Path): String = try {
         val mvnCmd = resolveMavenCommand(projectDir)
         val output = StringBuilder()
-        val result = runProcess(
+        val result = processRunner(
             projectDir,
             listOf(mvnCmd, "--version"),
-            captureStdout = output,
-            timeoutSeconds = 5,
-            logger = logger
+            output,
+            metadataProbeTimeoutSeconds,
+            logger
         )
         if (result == 0) {
             Regex("""Apache Maven ([\d.]+)""").find(output.toString())?.groupValues?.get(1)

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
@@ -1,11 +1,21 @@
 package io.github.skhokhlov.rewriterunner.lst.utils
 
+import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
 import io.github.skhokhlov.rewriterunner.RunnerLogger
+import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.exists
+
+internal typealias ProcessRunner = (
+    workDir: Path,
+    command: List<String>,
+    captureStdout: StringBuilder?,
+    timeoutSeconds: Long,
+    logger: RunnerLogger
+) -> Int?
 
 /**
  * Runs an external process in [workDir] and waits up to [timeoutSeconds] for it to finish.
@@ -21,7 +31,7 @@ internal fun runProcess(
     workDir: Path,
     command: List<String>,
     captureStdout: StringBuilder? = null,
-    timeoutSeconds: Long = 120,
+    timeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS,
     logger: RunnerLogger
 ): Int? {
     val pb = ProcessBuilder(command).directory(workDir.toFile())
@@ -38,9 +48,13 @@ internal fun runProcess(
     // Log each line at DEBUG so Maven/Gradle output is visible with --debug.
     val prefix = command.first().substringAfterLast('/')
     fun drainStream(stream: InputStream, tag: String) = Thread(null, {
-        stream.bufferedReader().forEachLine {
-            logger.debug("[$prefix $tag] $it")
-            if (tag == "stdout") captureStdout?.append(it)?.append('\n')
+        try {
+            stream.bufferedReader().forEachLine {
+                logger.debug("[$prefix $tag] $it")
+                if (tag == "stdout") captureStdout?.append(it)?.append('\n')
+            }
+        } catch (e: IOException) {
+            logger.debug("[$prefix $tag] stream closed: ${e.message}")
         }
     }, "process-drain-$tag").apply {
         isDaemon = true
@@ -48,17 +62,33 @@ internal fun runProcess(
     }
     val stdoutThread = drainStream(process.inputStream, "stdout")
     val stderrThread = drainStream(process.errorStream, "stderr")
-    stdoutThread.join()
-    stderrThread.join()
 
     val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
     if (!finished) {
         process.destroyForcibly()
+        closeProcessStreams(process)
+        stdoutThread.join(TIMEOUT_DRAIN_JOIN_MILLIS)
+        stderrThread.join(TIMEOUT_DRAIN_JOIN_MILLIS)
         logger.warn("Process ${command.first()} timed out after ${timeoutSeconds}s")
         return null
     }
 
+    stdoutThread.join()
+    stderrThread.join()
+
     return process.exitValue()
+}
+
+private const val TIMEOUT_DRAIN_JOIN_MILLIS = 100L
+
+private fun closeProcessStreams(process: Process) {
+    listOf(process.outputStream, process.inputStream, process.errorStream).forEach { stream ->
+        try {
+            stream.close()
+        } catch (_: IOException) {
+            // Best effort: the process may already have closed one or more streams.
+        }
+    }
 }
 
 /** Returns the `build.gradle.kts` or `build.gradle` file in [dir], or null if neither exists. */

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatter.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatter.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner.output
 
+import io.github.skhokhlov.rewriterunner.RunResult
 import java.io.OutputStream
 import java.io.PrintStream
 import java.io.PrintWriter
@@ -76,6 +77,25 @@ class ResultFormatter(
         }
     }
 
+    /**
+     * Write formatted output for a full [RunResult], including plugin-first raw diffs
+     * when no OpenRewrite [Result] objects were produced in-process.
+     */
+    fun format(runResult: RunResult) {
+        // In-process recipe results and plugin-first raw diffs are mutually exclusive
+        // for normal runner output. Prefer Result objects if a future path supplies both.
+        if (runResult.results.isNotEmpty() || runResult.rawDiffs.isEmpty()) {
+            format(runResult.results, runResult.projectDir)
+            return
+        }
+
+        when (outputMode) {
+            OutputMode.DIFF -> printRawDiffs(runResult.rawDiffs)
+            OutputMode.FILES -> printRawFiles(runResult.rawDiffs.keys)
+            OutputMode.REPORT -> writeRawReport(runResult.rawDiffs, runResult.projectDir)
+        }
+    }
+
     // ─── diff ─────────────────────────────────────────────────────────────────
 
     private fun printDiffs(results: List<Result>) {
@@ -91,6 +111,14 @@ class ResultFormatter(
         }
     }
 
+    private fun printRawDiffs(rawDiffs: Map<Path, String>) {
+        if (rawDiffs.isEmpty()) {
+            out.println("No changes produced.")
+            return
+        }
+        rawDiffs.values.forEach { out.println(it.trimEnd()) }
+    }
+
     // ─── files ────────────────────────────────────────────────────────────────
 
     private fun printFiles(results: List<Result>) {
@@ -102,6 +130,14 @@ class ResultFormatter(
             val path = result.after?.sourcePath ?: result.before?.sourcePath
             if (path != null) out.println(path)
         }
+    }
+
+    private fun printRawFiles(paths: Set<Path>) {
+        if (paths.isEmpty()) {
+            out.println("No files changed.")
+            return
+        }
+        paths.forEach { out.println(it) }
     }
 
     // ─── report ───────────────────────────────────────────────────────────────
@@ -116,6 +152,23 @@ class ResultFormatter(
                     "isNewFile" to (r.before == null),
                     "isDeletedFile" to (r.after == null),
                     "diff" to r.diff()
+                )
+            }
+        )
+        json.writerWithDefaultPrettyPrinter().writeValue(reportFile, report)
+        out.println("Report written to: ${reportFile.absolutePath}")
+    }
+
+    private fun writeRawReport(rawDiffs: Map<Path, String>, reportDir: Path) {
+        val reportFile = reportDir.resolve("openrewrite-report.json").toFile()
+        val report = mapOf(
+            "totalChanged" to rawDiffs.size,
+            "results" to rawDiffs.map { (path, diff) ->
+                mapOf(
+                    "filePath" to path.toString(),
+                    "isNewFile" to diff.contains("\n--- /dev/null\n"),
+                    "isDeletedFile" to diff.contains("\n+++ /dev/null\n"),
+                    "diff" to diff
                 )
             }
         )

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/DirectPluginExecutor.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/DirectPluginExecutor.kt
@@ -1,0 +1,110 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+internal data class DirectPluginPatchFile(val file: Path, val baseDir: Path)
+
+internal data class DirectPluginInvocation(
+    val dryRunCommand: List<String>,
+    val applyCommand: List<String>,
+    val patchFiles: () -> List<DirectPluginPatchFile>,
+    val dryRunFailureMessage: (Int?) -> String,
+    val applyFailureMessage: (Int?) -> String
+)
+
+/**
+ * Runs an official OpenRewrite build plugin through the target project's build tool.
+ *
+ * The build-tool-specific strategies only construct commands and patch locations; this
+ * class owns the shared execution contract:
+ * 1. run dry-run to generate a patch,
+ * 2. parse generated patch files for formatted output,
+ * 3. run apply when changes exist and the caller is not in dry-run mode.
+ */
+internal class DirectPluginExecutor(
+    private val projectDir: Path,
+    private val dryRun: Boolean,
+    private val execute: (Path, List<String>) -> Int?
+) {
+    fun run(invocation: DirectPluginInvocation): PluginRunResult {
+        val dryRunExit = execute(projectDir, invocation.dryRunCommand)
+        if (dryRunExit != 0) {
+            return PluginRunResult.Failed(invocation.dryRunFailureMessage(dryRunExit))
+        }
+
+        val diffs = parseDiffs(invocation.patchFiles())
+        if (diffs.isEmpty()) return PluginRunResult.NoChanges
+
+        if (!dryRun) {
+            val applyExit = execute(projectDir, invocation.applyCommand)
+            if (applyExit != 0) {
+                return PluginRunResult.Failed(invocation.applyFailureMessage(applyExit))
+            }
+        }
+
+        return PluginRunResult.Success(
+            changedFiles = if (dryRun) emptyList() else diffs.keys.map(projectDir::resolve),
+            diffs = diffs
+        )
+    }
+
+    private fun parseDiffs(patchFiles: List<DirectPluginPatchFile>): Map<Path, String> = patchFiles
+        .filter { it.file.exists() }
+        .flatMap { patchFile ->
+            val baseRelative = relativeToProject(patchFile.baseDir)
+            PatchParser.parse(patchFile.file.readText()).map { (path, diff) ->
+                val rebasedPath = relativeToProject(patchFile.baseDir.resolve(path))
+                rebasedPath to rebaseDiff(diff, baseRelative)
+            }
+        }.toMap()
+
+    private fun relativeToProject(path: Path): Path {
+        val normalizedProject = projectDir.toAbsolutePath().normalize()
+        val normalizedPath = path.toAbsolutePath().normalize()
+        return normalizedProject.relativize(normalizedPath)
+    }
+
+    private fun rebaseDiff(diff: String, baseRelative: Path): String {
+        if (baseRelative.toString().isEmpty()) return diff
+
+        val prefix = baseRelative.toString().replace('\\', '/')
+        return diff.lineSequence()
+            .joinToString("\n") { line ->
+                when {
+                    line.startsWith("diff --git ") -> rebaseGitHeader(line, prefix)
+                    line.startsWith("--- ") -> rebasePatchHeader(line, prefix)
+                    line.startsWith("+++ ") -> rebasePatchHeader(line, prefix)
+                    else -> line
+                }
+            } + if (diff.endsWith("\n")) "\n" else ""
+    }
+
+    private fun rebaseGitHeader(line: String, prefix: String): String {
+        val parts = line.split(" ")
+        if (parts.size != 4) return line
+        return listOf(
+            parts[0],
+            parts[1],
+            parts[2].prefixDiffPath(prefix),
+            parts[3].prefixDiffPath(prefix)
+        )
+            .joinToString(" ")
+    }
+
+    private fun rebasePatchHeader(line: String, prefix: String): String {
+        val marker = line.take(4)
+        val rest = line.drop(4)
+        val path = rest.substringBefore('\t')
+        val suffix = rest.removePrefix(path)
+        return marker + path.prefixDiffPath(prefix) + suffix
+    }
+
+    private fun String.prefixDiffPath(prefix: String): String = when {
+        this == "/dev/null" -> this
+        startsWith("a/") -> "a/$prefix/${removePrefix("a/")}"
+        startsWith("b/") -> "b/$prefix/${removePrefix("b/")}"
+        else -> "$prefix/$this"
+    }
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategy.kt
@@ -1,0 +1,188 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import io.github.skhokhlov.rewriterunner.RunnerLogger
+import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
+import io.github.skhokhlov.rewriterunner.config.ToolConfig
+import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
+import io.github.skhokhlov.rewriterunner.lst.utils.runProcess
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.streams.toList
+
+internal open class GradlePluginStrategy(
+    private val logger: RunnerLogger,
+    private val timeoutSeconds: Long,
+    private val rewritePluginVersion: String
+) : PluginBuildStrategy {
+    override fun run(
+        projectDir: Path,
+        activeRecipe: String,
+        recipeArtifacts: List<String>,
+        rewriteConfig: Path?,
+        rewriteConfigContent: String?,
+        dryRun: Boolean,
+        includeMavenCentral: Boolean,
+        repositories: List<RepositoryConfig>
+    ): PluginRunResult {
+        val effectiveRewriteConfig =
+            createRewriteConfigFile(rewriteConfigContent)
+                ?: rewriteConfig
+        val initScript =
+            generateInitScript(
+                activeRecipe = activeRecipe,
+                recipeArtifacts = recipeArtifacts,
+                rewriteConfig = effectiveRewriteConfig,
+                includeMavenCentral = includeMavenCentral,
+                repositories = repositories
+            )
+        return try {
+            DirectPluginExecutor(projectDir, dryRun, ::execute).run(
+                DirectPluginInvocation(
+                    dryRunCommand = buildCommand(projectDir, "rewriteDryRun", initScript),
+                    applyCommand = buildCommand(projectDir, "rewriteRun", initScript),
+                    patchFiles = { findPatchFiles(projectDir) },
+                    dryRunFailureMessage = { pluginFailureMessage("Gradle rewriteDryRun", it) },
+                    applyFailureMessage = { pluginFailureMessage("Gradle rewriteRun", it) }
+                )
+            )
+        } finally {
+            Files.deleteIfExists(initScript)
+            if (rewriteConfigContent != null && effectiveRewriteConfig != null) {
+                Files.deleteIfExists(effectiveRewriteConfig)
+            }
+        }
+    }
+
+    fun generateInitScript(
+        activeRecipe: String,
+        recipeArtifacts: List<String>,
+        rewriteConfig: Path?,
+        includeMavenCentral: Boolean,
+        repositories: List<RepositoryConfig>
+    ): Path {
+        val initScript = createPrivateTempFile("rewrite-runner-plugin-", ".gradle")
+        val text =
+            buildString {
+                appendLine("initscript {")
+                appendLine("    repositories {")
+                appendRepositoryDeclarations(includeMavenCentral, repositories, "        ")
+                appendLine("    }")
+                appendLine("    dependencies {")
+                appendLine(
+                    "        classpath(\"org.openrewrite:plugin:" +
+                        "$rewritePluginVersion\")"
+                )
+                appendLine("    }")
+                appendLine("}")
+                appendLine("gradle.beforeSettings { settings ->")
+                appendLine("    settings.pluginManagement {")
+                appendLine("        repositories {")
+                appendRepositoryDeclarations(includeMavenCentral, repositories, "            ")
+                appendLine("        }")
+                appendLine("    }")
+                appendLine("    try {")
+                appendLine("        settings.dependencyResolutionManagement {")
+                appendLine("            repositories {")
+                appendRepositoryDeclarations(includeMavenCentral, repositories, "                ")
+                appendLine("            }")
+                appendLine("        }")
+                appendLine("    } catch (MissingMethodException ignored) {")
+                appendLine(
+                    "        // Gradle versions before dependencyResolutionManagement still use project repositories."
+                )
+                appendLine("    }")
+                appendLine("}")
+                appendLine("rootProject {")
+                appendLine("    apply plugin: org.openrewrite.gradle.RewritePlugin")
+                appendLine("    rewrite {")
+                appendLine("        activeRecipe(\"${activeRecipe.groovyString()}\")")
+                rewriteConfig?.let {
+                    appendLine(
+                        "        configFile = file(\"${it.toAbsolutePath().toString().groovyString()}\")"
+                    )
+                }
+                appendLine("    }")
+                if (recipeArtifacts.isNotEmpty()) {
+                    appendLine("    dependencies {")
+                    recipeArtifacts.forEach {
+                        appendLine("        add(\"rewrite\", \"${it.groovyString()}\")")
+                    }
+                    appendLine("    }")
+                }
+                appendLine("}")
+                appendLine("allprojects {")
+                appendLine("    repositories {")
+                appendRepositoryDeclarations(includeMavenCentral, repositories, "        ")
+                appendLine("    }")
+                appendLine("}")
+            }
+        initScript.toFile().writeText(text, Charsets.UTF_8)
+        return initScript
+    }
+
+    private fun StringBuilder.appendRepositoryDeclarations(
+        includeMavenCentral: Boolean,
+        repositories: List<RepositoryConfig>,
+        indent: String
+    ) {
+        if (includeMavenCentral) {
+            appendLine("${indent}mavenCentral()")
+            appendLine("${indent}gradlePluginPortal()")
+        }
+        repositories.forEach { repo ->
+            appendLine("${indent}maven {")
+            appendLine("$indent    url = uri(\"${repo.url.groovyString()}\")")
+            if (repo.username != null || repo.password != null) {
+                appendLine("$indent    credentials {")
+                repo.username?.let {
+                    appendLine("$indent        username = \"${it.groovyString()}\"")
+                }
+                repo.password?.let {
+                    appendLine("$indent        password = \"${it.groovyString()}\"")
+                }
+                appendLine("$indent    }")
+            }
+            appendLine("$indent}")
+        }
+    }
+
+    open fun execute(projectDir: Path, command: List<String>): Int? = runProcess(
+        workDir = projectDir,
+        command = command,
+        timeoutSeconds = timeoutSeconds,
+        logger = logger
+    )
+
+    private fun buildCommand(projectDir: Path, task: String, initScript: Path): List<String> =
+        listOf(
+            resolveGradleCommand(projectDir),
+            task,
+            "--init-script",
+            initScript.toAbsolutePath().toString(),
+            "--no-daemon",
+            "--no-configuration-cache",
+            "--no-parallel",
+            "-S",
+            "-i"
+        )
+
+    private fun findPatchFiles(projectDir: Path): List<DirectPluginPatchFile> = Files.find(
+        projectDir,
+        Int.MAX_VALUE,
+        { path, attributes ->
+            attributes.isRegularFile &&
+                path.fileName.toString() == "rewrite.patch" &&
+                path.endsWith("build/reports/rewrite/rewrite.patch")
+        }
+    ).use { paths ->
+        paths.toList().sorted().map { path ->
+            DirectPluginPatchFile(
+                file = path,
+                baseDir = path.parent.parent.parent.parent
+            )
+        }.toList()
+    }
+
+    private fun String.groovyString(): String =
+        replace("\\", "\\\\").replace("\"", "\\\"").replace("$", "\\$")
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
@@ -1,0 +1,165 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import io.github.skhokhlov.rewriterunner.RunnerLogger
+import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
+import io.github.skhokhlov.rewriterunner.lst.utils.resolveMavenCommand
+import io.github.skhokhlov.rewriterunner.lst.utils.runProcess
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.streams.toList
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader
+
+private const val FALLBACK_POM_DISCOVERY_DEPTH = 6
+private val MAVEN_PATCH_PATH: Path = Path.of("target/site/rewrite/rewrite.patch")
+
+internal open class MavenPluginStrategy(
+    private val logger: RunnerLogger,
+    private val timeoutSeconds: Long,
+    private val rewritePluginVersion: String
+) : PluginBuildStrategy {
+    override fun run(
+        projectDir: Path,
+        activeRecipe: String,
+        recipeArtifacts: List<String>,
+        rewriteConfig: Path?,
+        rewriteConfigContent: String?,
+        dryRun: Boolean,
+        includeMavenCentral: Boolean,
+        repositories: List<RepositoryConfig>
+    ): PluginRunResult {
+        val effectiveRewriteConfig =
+            createRewriteConfigFile(rewriteConfigContent)
+                ?: rewriteConfig
+        return try {
+            DirectPluginExecutor(projectDir, dryRun, ::execute).run(
+                DirectPluginInvocation(
+                    dryRunCommand = buildCommand(
+                        projectDir = projectDir,
+                        goal = "dryRun",
+                        activeRecipe = activeRecipe,
+                        recipeArtifacts = recipeArtifacts,
+                        rewriteConfig = effectiveRewriteConfig
+                    ),
+                    applyCommand = buildCommand(
+                        projectDir = projectDir,
+                        goal = "run",
+                        activeRecipe = activeRecipe,
+                        recipeArtifacts = recipeArtifacts,
+                        rewriteConfig = effectiveRewriteConfig
+                    ),
+                    patchFiles = { findPatchFiles(projectDir) },
+                    dryRunFailureMessage = { pluginFailureMessage("Maven rewrite:dryRun", it) },
+                    applyFailureMessage = { pluginFailureMessage("Maven rewrite:run", it) }
+                )
+            )
+        } finally {
+            if (rewriteConfigContent != null && effectiveRewriteConfig != null) {
+                Files.deleteIfExists(effectiveRewriteConfig)
+            }
+        }
+    }
+
+    fun buildCommand(
+        projectDir: Path,
+        goal: String,
+        activeRecipe: String,
+        recipeArtifacts: List<String>,
+        rewriteConfig: Path?
+    ): List<String> = buildList {
+        add(resolveMavenCommand(projectDir))
+        add("-U")
+        add(
+            "org.openrewrite.maven:rewrite-maven-plugin:" +
+                "$rewritePluginVersion:$goal"
+        )
+        add("-Drewrite.activeRecipes=$activeRecipe")
+        if (recipeArtifacts.isNotEmpty()) {
+            add("-Drewrite.recipeArtifactCoordinates=${recipeArtifacts.joinToString(",")}")
+        }
+        rewriteConfig?.let {
+            add("-Drewrite.configLocation=${it.toAbsolutePath()}")
+        }
+    }
+
+    open fun execute(projectDir: Path, command: List<String>): Int? = runProcess(
+        workDir = projectDir,
+        command = command,
+        timeoutSeconds = timeoutSeconds,
+        logger = logger
+    )
+
+    private fun findPatchFiles(projectDir: Path): List<DirectPluginPatchFile> =
+        discoverMavenRoots(projectDir).mapNotNull { moduleDir ->
+            val patchFile = moduleDir.resolve(MAVEN_PATCH_PATH)
+            if (!patchFile.exists()) return@mapNotNull null
+
+            DirectPluginPatchFile(
+                file = patchFile,
+                baseDir = moduleDir
+            )
+        }.sortedBy { it.file }
+
+    private fun discoverMavenRoots(projectDir: Path): List<Path> {
+        val projectRoot = projectDir.toAbsolutePath().normalize()
+        return if (projectRoot.resolve("pom.xml").exists()) {
+            val roots = linkedSetOf<Path>()
+            collectDeclaredMavenRoots(
+                projectRoot = projectRoot,
+                moduleDir = projectRoot,
+                found = roots
+            )
+            roots.toList()
+        } else {
+            discoverFallbackPomRoots(projectRoot)
+        }
+    }
+
+    private fun collectDeclaredMavenRoots(
+        projectRoot: Path,
+        moduleDir: Path,
+        found: MutableSet<Path>
+    ) {
+        val normalizedModule = moduleDir.toAbsolutePath().normalize()
+        if (!normalizedModule.startsWith(projectRoot)) return
+        if (!normalizedModule.resolve("pom.xml").exists()) return
+        if (!found.add(normalizedModule)) return
+
+        for (module in readDeclaredModules(normalizedModule)) {
+            if (module.isBlank()) continue
+            collectDeclaredMavenRoots(
+                projectRoot = projectRoot,
+                moduleDir = normalizedModule.resolve(module),
+                found = found
+            )
+        }
+    }
+
+    private fun readDeclaredModules(moduleDir: Path): List<String> = try {
+        Files.newInputStream(moduleDir.resolve("pom.xml")).use { input ->
+            MavenXpp3Reader().read(input).modules
+        }
+    } catch (e: Exception) {
+        logger.warn("Maven plugin: failed to parse modules in ${moduleDir.fileName}: ${e.message}")
+        emptyList()
+    }
+
+    private fun discoverFallbackPomRoots(projectRoot: Path): List<Path> = try {
+        Files.find(
+            projectRoot,
+            FALLBACK_POM_DISCOVERY_DEPTH,
+            { path, attributes ->
+                attributes.isRegularFile &&
+                    path.fileName.toString() == "pom.xml"
+            }
+        ).use { paths ->
+            paths.toList()
+                .map { it.parent.toAbsolutePath().normalize() }
+                .distinct()
+                .sorted()
+        }
+    } catch (e: Exception) {
+        logger.warn("Maven plugin: failed to walk for pom.xml files: ${e.message}")
+        emptyList()
+    }
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PatchParser.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PatchParser.kt
@@ -1,0 +1,36 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import java.nio.file.Path
+
+/** Parses OpenRewrite's unified git patch output into one diff string per changed file. */
+internal object PatchParser {
+    private val diffHeader = Regex("(?m)^diff --git ")
+    private val oldPathHeader = Regex("""(?m)^---\s+(.+)$""")
+    private val newPathHeader = Regex("""(?m)^\+\+\+\s+(.+)$""")
+
+    fun parse(content: String): Map<Path, String> {
+        if (content.isBlank()) return emptyMap()
+
+        val starts = diffHeader.findAll(content).map { it.range.first }.toList()
+        if (starts.isEmpty()) return emptyMap()
+
+        return starts.mapIndexedNotNull { index, start ->
+            val end = starts.getOrNull(index + 1) ?: content.length
+            val diff = content.substring(start, end).trimEnd()
+            val path = extractPath(diff) ?: return@mapIndexedNotNull null
+            path to "$diff\n"
+        }.toMap()
+    }
+
+    private fun extractPath(diff: String): Path? {
+        val oldPath = oldPathHeader.find(diff)?.groupValues?.get(1)?.normalizeDiffPath()
+        val newPath = newPathHeader.find(diff)?.groupValues?.get(1)?.normalizeDiffPath()
+        return (newPath ?: oldPath)?.let(Path::of)
+    }
+
+    private fun String.normalizeDiffPath(): String? {
+        val path = substringBefore('\t').trim()
+        if (path == "/dev/null") return null
+        return path.removePrefix("a/").removePrefix("b/")
+    }
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginBuildStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginBuildStrategy.kt
@@ -1,0 +1,17 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
+import java.nio.file.Path
+
+internal interface PluginBuildStrategy {
+    fun run(
+        projectDir: Path,
+        activeRecipe: String,
+        recipeArtifacts: List<String>,
+        rewriteConfig: Path?,
+        rewriteConfigContent: String?,
+        dryRun: Boolean,
+        includeMavenCentral: Boolean,
+        repositories: List<RepositoryConfig>
+    ): PluginRunResult
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunner.kt
@@ -1,0 +1,93 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
+import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
+import io.github.skhokhlov.rewriterunner.RunnerLogger
+import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
+import io.github.skhokhlov.rewriterunner.config.ToolConfig
+import io.github.skhokhlov.rewriterunner.lst.utils.hasBuildGradle
+import java.nio.file.Path
+import kotlin.io.path.exists
+
+internal class PluginRecipeRunner(
+    private val logger: RunnerLogger = NoOpRunnerLogger,
+    timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+    rewriteGradlePluginVersion: String = ToolConfig.REWRITE_GRADLE_PLUGIN_VERSION,
+    rewriteMavenPluginVersion: String = ToolConfig.REWRITE_MAVEN_PLUGIN_VERSION,
+    private val gradleStrategy: PluginBuildStrategy =
+        GradlePluginStrategy(logger, timeoutSeconds, rewriteGradlePluginVersion),
+    private val mavenStrategy: PluginBuildStrategy =
+        MavenPluginStrategy(logger, timeoutSeconds, rewriteMavenPluginVersion)
+) {
+    /**
+     * Tries Gradle before Maven when both root build files are present.
+     */
+    fun run(
+        projectDir: Path,
+        activeRecipe: String,
+        recipeArtifacts: List<String>,
+        rewriteConfig: Path?,
+        rewriteConfigContent: String?,
+        dryRun: Boolean,
+        includeMavenCentral: Boolean,
+        repositories: List<RepositoryConfig>
+    ): PluginRunResult {
+        val hasGradle = hasBuildGradle(projectDir)
+        val hasPom = projectDir.resolve("pom.xml").exists()
+
+        if (!hasGradle && !hasPom) {
+            return PluginRunResult.Skipped("no Gradle or Maven build tool found")
+        }
+
+        val failures = mutableListOf<PluginRunResult.Failed>()
+
+        if (hasGradle) {
+            logger.info("      Trying Gradle OpenRewrite plugin")
+            when (
+                val result =
+                    gradleStrategy.run(
+                        projectDir = projectDir,
+                        activeRecipe = activeRecipe,
+                        recipeArtifacts = recipeArtifacts,
+                        rewriteConfig = rewriteConfig,
+                        rewriteConfigContent = rewriteConfigContent,
+                        dryRun = dryRun,
+                        includeMavenCentral = includeMavenCentral,
+                        repositories = repositories
+                    )
+            ) {
+                is PluginRunResult.Failed -> failures.add(result)
+                else -> return result
+            }
+        }
+
+        if (hasPom) {
+            logger.info("      Trying Maven OpenRewrite plugin")
+            when (
+                val result =
+                    mavenStrategy.run(
+                        projectDir = projectDir,
+                        activeRecipe = activeRecipe,
+                        recipeArtifacts = recipeArtifacts,
+                        rewriteConfig = rewriteConfig,
+                        rewriteConfigContent = rewriteConfigContent,
+                        dryRun = dryRun,
+                        includeMavenCentral = includeMavenCentral,
+                        repositories = repositories
+                    )
+            ) {
+                is PluginRunResult.Failed -> failures.add(result)
+                else -> return result
+            }
+        }
+
+        return failures
+            .takeIf { it.isNotEmpty() }
+            ?.let { PluginRunResult.Failed(it.joinToString(" ; ") { failure -> failure.reason }) }
+            ?: PluginRunResult.Skipped("no supported build tool found")
+    }
+
+    companion object {
+        const val DEFAULT_TIMEOUT_SECONDS = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS
+    }
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRunResult.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRunResult.kt
@@ -1,0 +1,15 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import java.nio.file.Path
+
+/** Result of attempting recipe execution through an official OpenRewrite build plugin. */
+sealed class PluginRunResult {
+    data class Success(val changedFiles: List<Path>, val diffs: Map<Path, String>) :
+        PluginRunResult()
+
+    data object NoChanges : PluginRunResult()
+
+    data class Failed(val reason: String) : PluginRunResult()
+
+    data class Skipped(val reason: String) : PluginRunResult()
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginTempFiles.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginTempFiles.kt
@@ -1,0 +1,40 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.FileAttribute
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+
+internal fun createPrivateTempFile(prefix: String, suffix: String): Path =
+    Files.createTempFile(prefix, suffix, *privateTempFileAttributes()).also {
+        it.toFile().deleteOnExit()
+    }
+
+internal fun createRewriteConfigFile(content: String?): Path? {
+    if (content == null) return null
+    val configFile = createPrivateTempFile("rewrite-runner-config-", ".yml")
+    configFile.toFile().writeText(content, Charsets.UTF_8)
+    return configFile
+}
+
+internal fun pluginFailureMessage(action: String, exitCode: Int?): String = if (exitCode == null) {
+    "$action did not start or timed out"
+} else {
+    "$action exited with $exitCode"
+}
+
+private fun privateTempFileAttributes(): Array<FileAttribute<*>> =
+    if ("posix" in FileSystems.getDefault().supportedFileAttributeViews()) {
+        arrayOf<FileAttribute<*>>(
+            PosixFilePermissions.asFileAttribute(
+                setOf(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE
+                )
+            )
+        )
+    } else {
+        emptyArray()
+    }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeArtifactResolver.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeArtifactResolver.kt
@@ -19,6 +19,12 @@ import org.eclipse.aether.util.filter.ScopeDependencyFilter
  * in the local Maven repository configured on [context]. Maven Central and any extra
  * repositories are supplied via [AetherContext.build].
  *
+ * Scope handling: recipe artifact resolution typically prunes `test`, `provided`, and
+ * `system` scopes at the Aether session level (see `AetherContext.build`'s
+ * `excludeScopesFromGraph` parameter). This resolver also applies a
+ * `ScopeDependencyFilter` (excluding `test` and `provided`) on dependency requests so
+ * only runtime/compile JARs are returned for recipe loading.
+ *
  * @param context Shared Maven Resolver context (system, session, remote repositories).
  *   Use [AetherContext.build] to create one.
  */

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerBuilderTest.kt
@@ -122,6 +122,30 @@ class RewriteRunnerBuilderTest :
             assertFalse(builder.dryRun)
         }
 
+        test("builder stores skipPluginRun true") {
+            val builder =
+                RewriteRunner.builder()
+                    .projectDir(tempDir)
+                    .activeRecipe("org.openrewrite.FindSourceFiles")
+                    .skipPluginRun(true)
+            assertTrue(builder.skipPluginRun)
+        }
+
+        test("builder stores timeout overrides") {
+            val builder =
+                RewriteRunner.builder()
+                    .projectDir(tempDir)
+                    .activeRecipe("org.openrewrite.FindSourceFiles")
+                    .processTimeoutSeconds(45)
+                    .pluginTimeoutSeconds(900)
+                    .resolverConnectTimeoutMs(10_000)
+                    .resolverRequestTimeoutMs(20_000)
+            assertEquals(45L, builder.processTimeoutSeconds)
+            assertEquals(900L, builder.pluginTimeoutSeconds)
+            assertEquals(10_000, builder.resolverConnectTimeoutMs)
+            assertEquals(20_000, builder.resolverRequestTimeoutMs)
+        }
+
         test("builder stores includeExtensions") {
             val extensions = listOf(".java", ".kt")
             val builder =
@@ -147,6 +171,19 @@ class RewriteRunnerBuilderTest :
         test("dryRun defaults to false") {
             val builder = RewriteRunner.builder()
             assertFalse(builder.dryRun)
+        }
+
+        test("skipPluginRun defaults to false") {
+            val builder = RewriteRunner.builder()
+            assertFalse(builder.skipPluginRun)
+        }
+
+        test("timeout overrides default to null") {
+            val builder = RewriteRunner.builder()
+            assertNull(builder.processTimeoutSeconds)
+            assertNull(builder.pluginTimeoutSeconds)
+            assertNull(builder.resolverConnectTimeoutMs)
+            assertNull(builder.resolverRequestTimeoutMs)
         }
 
         test("rewriteConfig defaults to null") {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
@@ -5,9 +5,13 @@ import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
+import kotlin.io.path.readText
 import kotlin.io.path.writeText
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+
+private val isWindows = System.getProperty("os.name", "").lowercase().contains("windows")
 
 class RewriteRunnerTest :
     FunSpec({
@@ -131,5 +135,86 @@ class RewriteRunnerTest :
                 .build()
                 .run()
             // No assertion needed — the test passes if no exception is thrown
+        }
+
+        // ─── plugin version config ──────────────────────────────────────────────
+
+        test("plugin-first Gradle run uses configured rewrite plugin version").config(
+            enabled = !isWindows
+        ) {
+            val marker = projectDir.resolve("plugin-version-used.txt")
+            val configFile = projectDir.resolve("rewriterunner.yml")
+            configFile.writeText("rewriteGradlePluginVersion: 7.20.0")
+            projectDir.resolve("build.gradle.kts").writeText("")
+            val gradlew = projectDir.resolve("gradlew").toFile()
+            gradlew.writeText(
+                """
+                #!/bin/sh
+                marker="${marker.toAbsolutePath()}"
+                init_script=""
+                previous=""
+                for arg in "${'$'}@"; do
+                    if [ "${'$'}previous" = "--init-script" ]; then
+                        init_script="${'$'}arg"
+                    fi
+                    previous="${'$'}arg"
+                done
+                if grep -q 'org.openrewrite:plugin:7.20.0' "${'$'}init_script"; then
+                    echo "${'$'}1" > "${'$'}marker"
+                    exit 0
+                fi
+                echo "configured Gradle plugin version was not used" > "${'$'}marker"
+                exit 1
+                """.trimIndent()
+            )
+            gradlew.setExecutable(true)
+
+            RewriteRunner.builder()
+                .projectDir(projectDir)
+                .activeRecipe("com.example.Recipe")
+                .configFile(configFile)
+                .dryRun(true)
+                .build()
+                .run()
+
+            assertEquals("rewriteDryRun", marker.readText().trim())
+        }
+
+        test("plugin-first Maven run uses configured rewrite plugin version").config(
+            enabled = !isWindows
+        ) {
+            val marker = projectDir.resolve("plugin-version-used.txt")
+            val configFile = projectDir.resolve("rewriterunner.yml")
+            configFile.writeText("rewriteMavenPluginVersion: 6.23.0")
+            projectDir.resolve("pom.xml").writeText("<project/>")
+            val mvnw = projectDir.resolve("mvnw").toFile()
+            mvnw.writeText(
+                """
+                #!/bin/sh
+                marker="${marker.toAbsolutePath()}"
+                for arg in "${'$'}@"; do
+                    if [ "${'$'}arg" = "org.openrewrite.maven:rewrite-maven-plugin:6.23.0:dryRun" ]; then
+                        echo "${'$'}arg" > "${'$'}marker"
+                        exit 0
+                    fi
+                done
+                echo "configured Maven plugin version was not used" > "${'$'}marker"
+                exit 1
+                """.trimIndent()
+            )
+            mvnw.setExecutable(true)
+
+            RewriteRunner.builder()
+                .projectDir(projectDir)
+                .activeRecipe("com.example.Recipe")
+                .configFile(configFile)
+                .dryRun(true)
+                .build()
+                .run()
+
+            assertEquals(
+                "org.openrewrite.maven:rewrite-maven-plugin:6.23.0:dryRun",
+                marker.readText().trim()
+            )
         }
     })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RunResultTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RunResultTest.kt
@@ -45,6 +45,18 @@ class RunResultTest :
             assertEquals(0, result.changeCount)
         }
 
+        test("rawDiffs count as changes when results are empty") {
+            val result =
+                RunResult(
+                    results = emptyList(),
+                    changedFiles = emptyList(),
+                    projectDir = projectDir,
+                    rawDiffs = mapOf(Paths.get("Foo.java") to "diff --git a/Foo.java b/Foo.java\n")
+                )
+            assertTrue(result.hasChanges)
+            assertEquals(1, result.changeCount)
+        }
+
         test("data class equals and copy work correctly") {
             val changedFiles = listOf(Paths.get("/tmp/project/Foo.java"))
             val r1 =

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfigTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfigTest.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner.config
 
+import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
 import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
@@ -185,6 +186,73 @@ class ToolConfigTest :
             configFile.writeText("downloadThreads: 8")
             val config = ToolConfig.load(configFile, NoOpRunnerLogger)
             assertEquals(8, config.downloadThreads)
+        }
+
+        // ─── Timeouts ─────────────────────────────────────────────────────────────
+
+        test("timeout settings default to central execution defaults") {
+            val config = ToolConfig(logger = NoOpRunnerLogger)
+            assertEquals(
+                ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS,
+                config.processTimeoutSeconds
+            )
+            assertEquals(
+                ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                config.pluginTimeoutSeconds
+            )
+            assertEquals(
+                ExecutionTimeouts.DEFAULT_RESOLVER_CONNECT_TIMEOUT_MS,
+                config.resolverConnectTimeoutMs
+            )
+            assertEquals(
+                ExecutionTimeouts.DEFAULT_RESOLVER_REQUEST_TIMEOUT_MS,
+                config.resolverRequestTimeoutMs
+            )
+        }
+
+        test("loads timeout settings from yaml") {
+            val configFile = tempDir.resolve("runner.yml")
+            configFile.writeText(
+                """
+                processTimeoutSeconds: 45
+                pluginTimeoutSeconds: 900
+                resolverConnectTimeoutMs: 10000
+                resolverRequestTimeoutMs: 20000
+                """.trimIndent()
+            )
+            val config = ToolConfig.load(configFile, NoOpRunnerLogger)
+            assertEquals(45L, config.processTimeoutSeconds)
+            assertEquals(900L, config.pluginTimeoutSeconds)
+            assertEquals(10_000, config.resolverConnectTimeoutMs)
+            assertEquals(20_000, config.resolverRequestTimeoutMs)
+        }
+
+        // ─── OpenRewrite plugin versions ─────────────────────────────────────────
+
+        test("rewrite plugin versions default to central constants") {
+            val config = ToolConfig(logger = NoOpRunnerLogger)
+            assertEquals(
+                ToolConfig.REWRITE_GRADLE_PLUGIN_VERSION,
+                config.rewriteGradlePluginVersion
+            )
+            assertEquals(
+                ToolConfig.REWRITE_MAVEN_PLUGIN_VERSION,
+                config.rewriteMavenPluginVersion
+            )
+        }
+
+        test("loads rewrite plugin versions from yaml") {
+            val configFile = tempDir.resolve("runner.yml")
+            configFile.writeText(
+                """
+                rewriteGradlePluginVersion: 7.20.0
+                rewriteMavenPluginVersion: 6.23.0
+                """.trimIndent()
+            )
+
+            val config = ToolConfig.load(configFile, NoOpRunnerLogger)
+            assertEquals("7.20.0", config.rewriteGradlePluginVersion)
+            assertEquals("6.23.0", config.rewriteMavenPluginVersion)
         }
 
         test("repository without credentials has null username and password") {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageTest.kt
@@ -49,6 +49,35 @@ class DependencyResolutionStageTest :
 
         fun staticParser() = StaticBuildFileParser(NoOpRunnerLogger)
 
+        test("resolveClasspath honors configured process timeout") {
+            projectDir.resolve("pom.xml").writeText("<project/>")
+            val mvnw = projectDir.resolve("mvnw").toFile()
+            mvnw.writeText(
+                """
+                #!/bin/sh
+                sleep 5
+                exit 0
+                """.trimIndent()
+            )
+            mvnw.setExecutable(true)
+            val timedStage =
+                DependencyResolutionStage(
+                    AetherContext.build(cacheDir.resolve("repository"), logger = NoOpRunnerLogger),
+                    NoOpRunnerLogger,
+                    processTimeoutSeconds = 1
+                )
+
+            val start = System.currentTimeMillis()
+            val result = timedStage.resolveClasspath(projectDir)
+            val elapsed = System.currentTimeMillis() - start
+
+            assertTrue(result.classpath.isEmpty(), "Timed-out Stage 2 should return no classpath")
+            assertTrue(
+                elapsed < 4_000,
+                "Configured 1s timeout should stop dependency:tree promptly, took ${elapsed}ms"
+            )
+        }
+
         // ─── Maven pom.xml parsing ────────────────────────────────────────────────
 
         test("parseMavenDependencies extracts compile-scoped dependencies") {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
@@ -264,6 +264,30 @@ class ProjectBuildStageTest :
                 "Should complete within 15 seconds without hanging, took ${elapsed}ms"
             )
         }
+
+        test("extractClasspath honors configured process timeout") {
+            projectDir.resolve("pom.xml").writeText("<project/>")
+            val mvnw = projectDir.resolve("mvnw").toFile()
+            mvnw.writeText(
+                """
+                #!/bin/sh
+                sleep 5
+                exit 0
+                """.trimIndent()
+            )
+            mvnw.setExecutable(true)
+
+            val timedStage = ProjectBuildStage(NoOpRunnerLogger, processTimeoutSeconds = 1)
+            val start = System.currentTimeMillis()
+            val result = timedStage.extractClasspath(projectDir)
+            val elapsed = System.currentTimeMillis() - start
+
+            assertNull(result, "Timed-out classpath extraction should fall through")
+            assertTrue(
+                elapsed < 4_000,
+                "Configured 1s timeout should stop the wrapper promptly, took ${elapsed}ms"
+            )
+        }
     })
 
 private fun assertTrue_compat(value: Boolean, message: String) {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/MarkerFactoryTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/MarkerFactoryTest.kt
@@ -1,0 +1,46 @@
+package io.github.skhokhlov.rewriterunner.lst.utils
+
+import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import org.openrewrite.marker.BuildTool
+
+class MarkerFactoryTest :
+    FunSpec({
+        var projectDir: Path = Path.of("")
+
+        beforeEach { projectDir = Files.createTempDirectory("mft-") }
+
+        afterEach { projectDir.toFile().deleteRecursively() }
+
+        test("maven metadata probe uses a short timeout cap") {
+            projectDir.resolve("pom.xml").writeText("<project/>")
+            projectDir.resolve("mvnw").writeText("")
+            var observedCommand: List<String>? = null
+            var observedTimeoutSeconds: Long? = null
+
+            val factory =
+                MarkerFactory(
+                    logger = NoOpRunnerLogger,
+                    staticParser = StaticBuildFileParser(NoOpRunnerLogger),
+                    versionDetector = VersionDetector(NoOpRunnerLogger),
+                    processTimeoutSeconds = 20,
+                    processRunner = { workDir, command, _, timeoutSeconds, _ ->
+                        assertEquals(projectDir, workDir)
+                        observedCommand = command
+                        observedTimeoutSeconds = timeoutSeconds
+                        null
+                    }
+                )
+
+            val marker = factory.detectBuildToolMarker(projectDir)
+
+            assertEquals(BuildTool.Type.Maven, marker?.type)
+            assertEquals("unknown", marker?.version)
+            assertEquals(listOf("./mvnw", "--version"), observedCommand)
+            assertEquals(5L, observedTimeoutSeconds)
+        }
+    })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatterTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatterTest.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner.output
 
+import io.github.skhokhlov.rewriterunner.RunResult
 import io.kotest.core.spec.style.FunSpec
 import java.io.ByteArrayOutputStream
 import java.io.PrintWriter
@@ -236,5 +237,58 @@ class ResultFormatterTest :
                 json.readTree(reportDir.resolve("openrewrite-report.json").readText())
             assertEquals(0, tree["totalChanged"].asInt())
             assertEquals(0, tree["results"].size())
+        }
+
+        // ─── Raw diff / plugin mode ──────────────────────────────────────────────
+
+        test("format RunResult prints raw diffs when OpenRewrite results are empty") {
+            val output =
+                captureOutput { pw ->
+                    ResultFormatter(OutputMode.DIFF, pw).format(
+                        RunResult(
+                            results = emptyList(),
+                            changedFiles = emptyList(),
+                            projectDir = reportDir,
+                            rawDiffs = mapOf(
+                                Path.of("Foo.java") to "diff --git a/Foo.java b/Foo.java\n"
+                            )
+                        )
+                    )
+                }
+            assertTrue(output.contains("diff --git a/Foo.java b/Foo.java"))
+        }
+
+        test("format RunResult files mode prints raw diff paths") {
+            val output =
+                captureOutput { pw ->
+                    ResultFormatter(OutputMode.FILES, pw).format(
+                        RunResult(
+                            results = emptyList(),
+                            changedFiles = emptyList(),
+                            projectDir = reportDir,
+                            rawDiffs = mapOf(Path.of("Foo.java") to "diff")
+                        )
+                    )
+                }
+            assertEquals("Foo.java", output.trim())
+        }
+
+        test("format RunResult report mode writes raw diff report") {
+            captureOutput { pw ->
+                ResultFormatter(OutputMode.REPORT, pw).format(
+                    RunResult(
+                        results = emptyList(),
+                        changedFiles = emptyList(),
+                        projectDir = reportDir,
+                        rawDiffs = mapOf(
+                            Path.of("Foo.java") to "diff --git a/Foo.java b/Foo.java\n"
+                        )
+                    )
+                )
+            }
+            val tree =
+                json.readTree(reportDir.resolve("openrewrite-report.json").readText())
+            assertEquals(1, tree["totalChanged"].asInt())
+            assertEquals("Foo.java", tree["results"][0]["filePath"].asText())
         }
     })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategyTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategyTest.kt
@@ -1,0 +1,377 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
+import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
+import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
+import io.github.skhokhlov.rewriterunner.config.ToolConfig.Companion.REWRITE_GRADLE_PLUGIN_VERSION
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class GradlePluginStrategyTest :
+    FunSpec({
+        var projectDir: Path = Path.of("")
+
+        beforeEach {
+            projectDir = Files.createTempDirectory("gps-")
+            projectDir.resolve("build.gradle.kts").writeText("")
+        }
+
+        afterEach { projectDir.toFile().deleteRecursively() }
+
+        test("generateInitScript wires recipe, artifacts, repositories, and config") {
+            val config = Files.createTempFile("rewrite", ".yml")
+            val strategy =
+                GradlePluginStrategy(
+                    NoOpRunnerLogger,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    REWRITE_GRADLE_PLUGIN_VERSION
+                )
+
+            val initScript =
+                strategy.generateInitScript(
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = listOf("com.example:recipes:1.0.0"),
+                    rewriteConfig = config,
+                    includeMavenCentral = false,
+                    repositories = listOf(RepositoryConfig(url = "https://repo.example.com/maven"))
+                )
+
+            val text = initScript.readText()
+            assertTrue(text.contains("classpath(\"org.openrewrite:plugin:"))
+            assertTrue(text.contains("activeRecipe(\"com.example.Recipe\")"))
+            assertTrue(text.contains("add(\"rewrite\", \"com.example:recipes:1.0.0\")"))
+            assertTrue(text.contains("configFile = file("))
+            assertTrue(text.contains("https://repo.example.com/maven"))
+            assertTrue(!text.contains("mavenCentral()"))
+            assertTrue(!text.contains("gradlePluginPortal()"))
+        }
+
+        test("generateInitScript uses configured rewrite Gradle plugin version") {
+            val strategy =
+                GradlePluginStrategy(
+                    logger = NoOpRunnerLogger,
+                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    rewritePluginVersion = "7.20.0"
+                )
+
+            val initScript =
+                strategy.generateInitScript(
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            val text = initScript.readText()
+            assertTrue(text.contains("classpath(\"org.openrewrite:plugin:7.20.0\")"))
+        }
+
+        test("generateInitScript adds repositories for plugin management and all projects") {
+            val strategy = GradlePluginStrategy(
+                logger = NoOpRunnerLogger,
+                timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                rewritePluginVersion = "7.20.0"
+            )
+
+            val initScript =
+                strategy.generateInitScript(
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    includeMavenCentral = true,
+                    repositories =
+                        listOf(
+                            RepositoryConfig(
+                                url = "https://repo.example.com/maven",
+                                username = "alice",
+                                password = "secret"
+                            )
+                        )
+                )
+
+            val text = initScript.readText()
+            assertTrue(text.contains("gradle.beforeSettings { settings ->"))
+            assertTrue(text.contains("settings.pluginManagement {"))
+            assertTrue(text.contains("settings.dependencyResolutionManagement {"))
+            assertTrue(text.contains("allprojects {"))
+            assertEquals(4, Regex("""\bmavenCentral\(\)""").findAll(text).count())
+            assertEquals(4, Regex("""\bgradlePluginPortal\(\)""").findAll(text).count())
+            assertEquals(
+                4,
+                Regex.fromLiteral("https://repo.example.com/maven").findAll(text).count()
+            )
+            assertEquals(4, Regex.fromLiteral("username = \"alice\"").findAll(text).count())
+            assertEquals(4, Regex.fromLiteral("password = \"secret\"").findAll(text).count())
+        }
+
+        test("generateInitScript adds recipe artifacts to root rewrite configuration only") {
+            val strategy = GradlePluginStrategy(
+                logger = NoOpRunnerLogger,
+                timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                rewritePluginVersion = "7.20.0"
+            )
+
+            val initScript =
+                strategy.generateInitScript(
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = listOf("org.openrewrite.recipe:rewrite-rewrite:0.21.1"),
+                    rewriteConfig = null,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            val text = initScript.readText()
+            val allprojectsStart = text.indexOf("allprojects {")
+            val allprojectsBody = text.substring(allprojectsStart)
+            assertTrue(text.contains("rootProject {"))
+            assertEquals(
+                1,
+                Regex.fromLiteral("apply plugin: org.openrewrite.gradle.RewritePlugin")
+                    .findAll(text)
+                    .count()
+            )
+            assertTrue(text.indexOf("add(\"rewrite\",") < allprojectsStart)
+            assertTrue(!text.contains("rewrite(\"org.openrewrite.recipe:rewrite-rewrite:0.21.1\")"))
+            assertTrue(!allprojectsBody.contains("add(\"rewrite\","))
+        }
+
+        test("run returns success and runs apply when dry run patch has changes") {
+            val commands = mutableListOf<List<String>>()
+            val strategy =
+                object : GradlePluginStrategy(
+                    logger = NoOpRunnerLogger,
+                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? {
+                        commands.add(command)
+                        if ("rewriteDryRun" in command) {
+                            projectDir.resolve("build/reports/rewrite").createDirectories()
+                            projectDir.resolve("build/reports/rewrite/rewrite.patch").writeText(
+                                """
+                                diff --git a/src/A.java b/src/A.java
+                                --- a/src/A.java
+                                +++ b/src/A.java
+                                @@ -1 +1 @@
+                                -class A {}
+                                +class A { }
+                                """.trimIndent()
+                            )
+                        }
+                        return 0
+                    }
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = false,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.Success>(result)
+            assertEquals(listOf("rewriteDryRun", "rewriteRun"), commands.map { it[1] })
+            assertEquals(listOf(projectDir.resolve("src/A.java")), result.changedFiles)
+        }
+
+        test("run detects patch files emitted by Gradle subprojects") {
+            val commands = mutableListOf<List<String>>()
+            val strategy =
+                object : GradlePluginStrategy(
+                    logger = NoOpRunnerLogger,
+                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? {
+                        commands.add(command)
+                        if ("rewriteDryRun" in command) {
+                            projectDir.resolve("module-a/build/reports/rewrite").createDirectories()
+                            val patchFile =
+                                projectDir.resolve(
+                                    "module-a/build/reports/rewrite/rewrite.patch"
+                                )
+                            patchFile.writeText(
+                                """
+                                diff --git a/src/main/java/A.java b/src/main/java/A.java
+                                --- a/src/main/java/A.java
+                                +++ b/src/main/java/A.java
+                                @@ -1 +1 @@
+                                -class A {}
+                                +class A { }
+                                """.trimIndent()
+                            )
+                        }
+                        return 0
+                    }
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = false,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.Success>(result)
+            assertEquals(listOf("rewriteDryRun", "rewriteRun"), commands.map { it[1] })
+            assertEquals(
+                listOf(projectDir.resolve("module-a/src/main/java/A.java")),
+                result.changedFiles
+            )
+            assertEquals(setOf(Path.of("module-a/src/main/java/A.java")), result.diffs.keys)
+            assertTrue(
+                result.diffs.getValue(Path.of("module-a/src/main/java/A.java"))
+                    .contains("diff --git a/module-a/src/main/java/A.java")
+            )
+        }
+
+        test("run returns no changes when patch file is absent") {
+            val strategy =
+                object : GradlePluginStrategy(
+                    logger = NoOpRunnerLogger,
+                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? = 0
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = false,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.NoChanges>(result)
+        }
+
+        test("run reports did not run when dry run execution returns null") {
+            val strategy =
+                object : GradlePluginStrategy(
+                    logger = NoOpRunnerLogger,
+                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? = null
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = true,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertEquals(
+                PluginRunResult.Failed("Gradle rewriteDryRun did not start or timed out"),
+                result
+            )
+        }
+
+        test("run returns failed when apply fails after successful dry run") {
+            val strategy =
+                object : GradlePluginStrategy(
+                    logger = NoOpRunnerLogger,
+                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? {
+                        if ("rewriteDryRun" in command) {
+                            projectDir.resolve("build/reports/rewrite").createDirectories()
+                            projectDir.resolve("build/reports/rewrite/rewrite.patch").writeText(
+                                """
+                                diff --git a/src/A.java b/src/A.java
+                                --- a/src/A.java
+                                +++ b/src/A.java
+                                @@ -1 +1 @@
+                                -class A {}
+                                +class A { }
+                                """.trimIndent()
+                            )
+                            return 0
+                        }
+                        return 2
+                    }
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = false,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertEquals(PluginRunResult.Failed("Gradle rewriteRun exited with 2"), result)
+        }
+
+        test("run honors configured plugin timeout") {
+            val gradlew = projectDir.resolve("gradlew").toFile()
+            gradlew.writeText(
+                """
+                #!/bin/sh
+                sleep 5
+                exit 0
+                """.trimIndent()
+            )
+            gradlew.setExecutable(true)
+
+            val strategy =
+                GradlePluginStrategy(
+                    NoOpRunnerLogger,
+                    timeoutSeconds = 1,
+                    REWRITE_GRADLE_PLUGIN_VERSION
+                )
+            val start = System.currentTimeMillis()
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = true,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+            val elapsed = System.currentTimeMillis() - start
+
+            assertIs<PluginRunResult.Failed>(result)
+            assertTrue(
+                elapsed < 4_000,
+                "Configured 1s timeout should stop rewriteDryRun promptly, took ${elapsed}ms"
+            )
+        }
+    })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
@@ -1,0 +1,323 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
+import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
+import io.github.skhokhlov.rewriterunner.config.ToolConfig.Companion.REWRITE_MAVEN_PLUGIN_VERSION
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class MavenPluginStrategyTest :
+    FunSpec({
+        var projectDir: Path = Path.of("")
+
+        beforeEach {
+            projectDir = Files.createTempDirectory("mps-")
+            projectDir.resolve("pom.xml").writeText("<project/>")
+        }
+
+        afterEach { projectDir.toFile().deleteRecursively() }
+
+        test("buildCommand includes active recipe, artifacts, and config location") {
+            val config = Files.createTempFile("rewrite", ".yml")
+            val strategy =
+                MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    REWRITE_MAVEN_PLUGIN_VERSION
+                )
+
+            val command =
+                strategy.buildCommand(
+                    projectDir = projectDir,
+                    goal = "dryRun",
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = listOf("com.example:recipes:1.0.0", "com.example:more:2.0.0"),
+                    rewriteConfig = config
+                )
+
+            assertEquals("mvn", command.first())
+            assertTrue(
+                command.any {
+                    it.contains("rewrite-maven-plugin") && it.endsWith(":dryRun")
+                }
+            )
+            assertTrue(command.contains("-Drewrite.activeRecipes=com.example.Recipe"))
+            assertTrue(
+                command.contains(
+                    "-Drewrite.recipeArtifactCoordinates=" +
+                        "com.example:recipes:1.0.0,com.example:more:2.0.0"
+                )
+            )
+            assertTrue(command.contains("-Drewrite.configLocation=${config.toAbsolutePath()}"))
+        }
+
+        test("buildCommand uses configured rewrite Maven plugin version") {
+            val strategy =
+                MavenPluginStrategy(
+                    logger = NoOpRunnerLogger,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    REWRITE_MAVEN_PLUGIN_VERSION
+                )
+
+            val command =
+                strategy.buildCommand(
+                    projectDir = projectDir,
+                    goal = "dryRun",
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null
+                )
+
+            assertTrue(
+                command.contains(
+                    "org.openrewrite.maven:rewrite-maven-plugin:" +
+                        "$REWRITE_MAVEN_PLUGIN_VERSION:dryRun"
+                )
+            )
+        }
+
+        test("run returns failed when dry run command exits non-zero") {
+            val strategy =
+                object : MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    REWRITE_MAVEN_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? = 1
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = true,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.Failed>(result)
+        }
+
+        test("run returns success without apply in dry-run mode") {
+            val commands = mutableListOf<List<String>>()
+            val strategy =
+                object : MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    REWRITE_MAVEN_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? {
+                        commands.add(command)
+                        projectDir.resolve("target/site/rewrite").createDirectories()
+                        projectDir.resolve("target/site/rewrite/rewrite.patch").writeText(
+                            """
+                            diff --git a/pom.xml b/pom.xml
+                            --- a/pom.xml
+                            +++ b/pom.xml
+                            @@ -1 +1 @@
+                            -<project/>
+                            +<project></project>
+                            """.trimIndent()
+                        )
+                        return 0
+                    }
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = true,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.Success>(result)
+            assertEquals(1, commands.size)
+            assertEquals(emptyList(), result.changedFiles)
+            assertEquals(setOf(Path.of("pom.xml")), result.diffs.keys)
+        }
+
+        test("run detects patch files emitted by Maven submodules") {
+            projectDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>root</artifactId>
+                  <version>1.0.0</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                    <module>module-a</module>
+                  </modules>
+                </project>
+                """.trimIndent()
+            )
+            projectDir.resolve("module-a").createDirectories()
+            projectDir.resolve("module-a/pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>module-a</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """.trimIndent()
+            )
+
+            val commands = mutableListOf<List<String>>()
+            val strategy =
+                object : MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    REWRITE_MAVEN_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? {
+                        commands.add(command)
+                        if (command.any { it.endsWith(":dryRun") }) {
+                            projectDir.resolve("module-a/target/site/rewrite").createDirectories()
+                            val patchFile =
+                                projectDir.resolve(
+                                    "module-a/target/site/rewrite/rewrite.patch"
+                                )
+                            patchFile.writeText(
+                                """
+                                diff --git a/src/main/java/A.java b/src/main/java/A.java
+                                --- a/src/main/java/A.java
+                                +++ b/src/main/java/A.java
+                                @@ -1 +1 @@
+                                -class A {}
+                                +class A { }
+                                """.trimIndent()
+                            )
+                        }
+                        return 0
+                    }
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = false,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.Success>(result)
+            assertEquals(2, commands.size)
+            assertEquals(
+                listOf(projectDir.resolve("module-a/src/main/java/A.java")),
+                result.changedFiles
+            )
+            assertEquals(setOf(Path.of("module-a/src/main/java/A.java")), result.diffs.keys)
+            assertTrue(
+                result.diffs.getValue(Path.of("module-a/src/main/java/A.java"))
+                    .contains("diff --git a/module-a/src/main/java/A.java")
+            )
+        }
+
+        test("run ignores patch files outside declared Maven module roots") {
+            projectDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>root</artifactId>
+                  <version>1.0.0</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                    <module>module-a</module>
+                  </modules>
+                </project>
+                """.trimIndent()
+            )
+            projectDir.resolve("module-a").createDirectories()
+            projectDir.resolve("module-a/pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>module-a</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """.trimIndent()
+            )
+
+            val strategy =
+                object : MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    REWRITE_MAVEN_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? {
+                        if (command.any { it.endsWith(":dryRun") }) {
+                            projectDir.resolve("module-a/target/site/rewrite").createDirectories()
+                            projectDir.resolve("module-a/target/site/rewrite/rewrite.patch")
+                                .writeText(
+                                    """
+                                    diff --git a/src/main/java/A.java b/src/main/java/A.java
+                                    --- a/src/main/java/A.java
+                                    +++ b/src/main/java/A.java
+                                    @@ -1 +1 @@
+                                    -class A {}
+                                    +class A { }
+                                    """.trimIndent()
+                                )
+
+                            projectDir.resolve("untracked/deep/module-b/target/site/rewrite")
+                                .createDirectories()
+                            projectDir
+                                .resolve(
+                                    "untracked/deep/module-b/target/site/rewrite/rewrite.patch"
+                                )
+                                .writeText(
+                                    """
+                                    diff --git a/src/main/java/Rogue.java b/src/main/java/Rogue.java
+                                    --- a/src/main/java/Rogue.java
+                                    +++ b/src/main/java/Rogue.java
+                                    @@ -1 +1 @@
+                                    -class Rogue {}
+                                    +class Rogue { }
+                                    """.trimIndent()
+                                )
+                        }
+                        return 0
+                    }
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = false,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.Success>(result)
+            assertEquals(setOf(Path.of("module-a/src/main/java/A.java")), result.diffs.keys)
+            assertEquals(
+                listOf(projectDir.resolve("module-a/src/main/java/A.java")),
+                result.changedFiles
+            )
+        }
+    })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/PatchParserTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/PatchParserTest.kt
@@ -1,0 +1,73 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PatchParserTest :
+    FunSpec({
+        test("splits git patch into per-file diffs") {
+            val patch =
+                """
+                diff --git a/src/A.java b/src/A.java
+                index 1111111..2222222 100644
+                --- a/src/A.java
+                +++ b/src/A.java
+                @@ -1 +1 @@
+                -class A {}
+                +class A { }
+                diff --git a/src/B.java b/src/B.java
+                index 3333333..4444444 100644
+                --- a/src/B.java
+                +++ b/src/B.java
+                @@ -1 +1 @@
+                -class B {}
+                +class B { }
+                """.trimIndent()
+
+            val diffs = PatchParser.parse(patch)
+
+            assertEquals(setOf(Path.of("src/A.java"), Path.of("src/B.java")), diffs.keys)
+            assertTrue(diffs.getValue(Path.of("src/A.java")).contains("+class A { }"))
+            assertTrue(diffs.getValue(Path.of("src/B.java")).contains("+class B { }"))
+        }
+
+        test("uses plus header path for newly created file") {
+            val patch =
+                """
+                diff --git a/new.txt b/new.txt
+                new file mode 100644
+                index 0000000..1111111
+                --- /dev/null
+                +++ b/new.txt
+                @@ -0,0 +1 @@
+                +hello
+                """.trimIndent()
+
+            val diffs = PatchParser.parse(patch)
+
+            assertEquals(setOf(Path.of("new.txt")), diffs.keys)
+        }
+
+        test("uses minus header path for deleted file") {
+            val patch =
+                """
+                diff --git a/old.txt b/old.txt
+                deleted file mode 100644
+                index 1111111..0000000
+                --- a/old.txt
+                +++ /dev/null
+                @@ -1 +0,0 @@
+                -hello
+                """.trimIndent()
+
+            val diffs = PatchParser.parse(patch)
+
+            assertEquals(setOf(Path.of("old.txt")), diffs.keys)
+        }
+
+        test("empty patch returns empty map") {
+            assertEquals(emptyMap(), PatchParser.parse(""))
+        }
+    })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunnerTest.kt
@@ -1,0 +1,97 @@
+package io.github.skhokhlov.rewriterunner.plugin
+
+import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class PluginRecipeRunnerTest :
+    FunSpec({
+        var projectDir: Path = Path.of("")
+
+        beforeEach { projectDir = Files.createTempDirectory("prr-") }
+
+        afterEach { projectDir.toFile().deleteRecursively() }
+
+        fun strategy(result: PluginRunResult): PluginBuildStrategy = object : PluginBuildStrategy {
+            override fun run(
+                projectDir: Path,
+                activeRecipe: String,
+                recipeArtifacts: List<String>,
+                rewriteConfig: Path?,
+                rewriteConfigContent: String?,
+                dryRun: Boolean,
+                includeMavenCentral: Boolean,
+                repositories: List<RepositoryConfig>
+            ): PluginRunResult = result
+        }
+
+        test("skips when no build tool is present") {
+            val runner =
+                PluginRecipeRunner(
+                    gradleStrategy = strategy(PluginRunResult.NoChanges),
+                    mavenStrategy = strategy(PluginRunResult.NoChanges)
+                )
+
+            val result =
+                runner.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = true,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.Skipped>(result)
+        }
+
+        test("tries maven when gradle fails") {
+            projectDir.resolve("build.gradle.kts").writeText("")
+            projectDir.resolve("pom.xml").writeText("<project/>")
+
+            val result =
+                PluginRecipeRunner(
+                    gradleStrategy = strategy(PluginRunResult.Failed("gradle failed")),
+                    mavenStrategy = strategy(PluginRunResult.NoChanges)
+                ).run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = true,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.NoChanges>(result)
+        }
+
+        test("returns combined failures when every detected tool fails") {
+            projectDir.resolve("build.gradle.kts").writeText("")
+            projectDir.resolve("pom.xml").writeText("<project/>")
+
+            val result =
+                PluginRecipeRunner(
+                    gradleStrategy = strategy(PluginRunResult.Failed("gradle failed")),
+                    mavenStrategy = strategy(PluginRunResult.Failed("maven failed"))
+                ).run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = true,
+                    includeMavenCentral = true,
+                    repositories = emptyList()
+                )
+
+            assertEquals(PluginRunResult.Failed("gradle failed ; maven failed"), result)
+        }
+    })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,13 +13,27 @@ Orchestrated by `RewriteRunner.run()`, delegated to by `RunCommand.call()`:
 
 | Step | Class | Description |
 |------|-------|-------------|
+| 0 | `PluginRecipeRunner` | Try official Gradle/Maven OpenRewrite plugin first; short-circuit on success |
 | 1 | `ToolConfig` | Load YAML config (env var interpolation, tilde expansion) |
-| 2 | `RecipeArtifactResolver` | Resolve recipe JARs from Maven coordinates |
+| 2 | `RecipeArtifactResolver` | Resolve recipe JARs from Maven coordinates for the fallback path |
 | 3 | `RecipeLoader` | Load recipe from JARs + optional `rewrite.yaml` |
 | 4 | `LstBuilder` | Build LST via 4-stage classpath pipeline + multi-language parsing |
 | 5 | `RecipeRunner` | Execute recipe, collect `List<Result>` |
 | 6 | — | Write changed files to disk (skipped when `dryRun = true`) |
 | 7 | `ResultFormatter` | Format output (diff / files / report) |
+
+## Stage 0: Plugin-First Execution
+
+`PluginRecipeRunner` checks the project root for Gradle or Maven build files and tries the official OpenRewrite plugin before the in-process LST pipeline:
+
+| Build tool | Strategy | Patch path |
+|------------|----------|------------|
+| Gradle | Generate a temporary init script, apply `org.openrewrite.gradle.RewritePlugin`, run `rewriteDryRun`, then `rewriteRun` when not in dry-run mode | `build/reports/rewrite/rewrite.patch` in each changed project |
+| Maven | Invoke `org.openrewrite.maven:rewrite-maven-plugin:<version>:dryRun`, then `:run` when not in dry-run mode | `target/site/rewrite/rewrite.patch` in each changed module |
+
+The dry-run goal always runs first so `PatchParser` can split `rewrite.patch` files into `RunResult.rawDiffs`. If the plugin returns non-empty patches and the apply goal succeeds (or the user requested `dryRun`), `RewriteRunner.run()` returns immediately with empty `results` and populated `rawDiffs`. Gradle project patches and Maven module patches are rebased to project-root-relative paths before formatting. `ResultFormatter.format(RunResult)` handles this raw-diff path for `diff`, `files`, and `report` output.
+
+If plugin execution is skipped or fails (no build file, non-zero exit, process start failure, timeout, missing recipe/plugin), the runner logs at info level and falls through to the LST pipeline. `--skip-plugin-run` / `Builder.skipPluginRun(true)` bypasses Stage 0.
 
 ## Maven Local Repository Strategy
 
@@ -67,6 +81,18 @@ The resolved classpath is **shared across all language parsers** — `JavaParser
 | `MarkerFactory` | `BuildTool`, `GitProvenance`, `OperatingSystemProvenance`, `BuildEnvironment`, `GradleProject` markers |
 
 `ProjectBuildStage` and `DependencyResolutionStage` remain injected into `LstBuilder` as `open` classes; the helper classes above are internal and are instantiated by `LstBuilder`.
+
+External process timeouts are configurable:
+
+| Timeout | Default | Applies to |
+|---------|---------|------------|
+| `pluginTimeoutSeconds` | 600 s | Stage 0 `rewriteDryRun` / `rewriteRun` plugin invocations |
+| `processTimeoutSeconds` | 120 s | Stage 1/2 build-tool subprocesses, compile attempts, and build-tool metadata commands |
+| `resolverConnectTimeoutMs` | 30000 ms | Maven Resolver TCP connections |
+| `resolverRequestTimeoutMs` | 60000 ms | Maven Resolver socket reads / requests |
+
+Stage 0 plugin versions are also configurable via `rewriteGradlePluginVersion`
+and `rewriteMavenPluginVersion`.
 
 ## File Routing by Extension
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -22,7 +22,7 @@ Chosen for **Gradle 9.0.0 + JDK 25 compatibility**:
 | Shadow plugin | `com.gradleup.shadow:9.0.0` | `com.github.johnrengelman.shadow` incompatible with Gradle 9 |
 | Maven Resolver | `2.0.16` | |
 | JVM toolchain | `21` | set via `kotlin { jvmToolchain(21) }` in `kotlin-convention` |
-| OpenRewrite | via `rewrite-recipe-bom:3.10.1` | |
+| OpenRewrite | via `rewrite-recipe-bom:3.28.0`; plugin-first path uses Gradle plugin `7.19.0` and Maven plugin `6.22.1` | |
 | Picocli | `4.7.6` | |
 | Jackson | `3.0.0` | |
 | Apache Maven Model | `3.9.12` | |

--- a/docs/dependency-resolution.md
+++ b/docs/dependency-resolution.md
@@ -48,7 +48,7 @@ The stage first extracts declared dependency coordinates from the build file wit
 
 | Build file | Strategy | Notes |
 |---|---|---|
-| `pom.xml` | `MavenXpp3Reader` | Skips `provided`, `system`, and unresolved property versions (`${...}`). Includes `test` scope (needed for test source type resolution). |
+| `pom.xml` | `MavenXpp3Reader` | Skips `runtime` and `system`, and unresolved property versions (`${...}`). Includes `provided` and `test` scopes (provided supplies compile-time types; test is needed for test source type resolution). |
 | `build.gradle.kts` / `build.gradle` — Gradle wrapper present | `gradle -q dependencies` task | Runs for root project and all subprojects found in `settings.gradle(.kts)`. Parses the tree output, resolves `1.0 -> 2.0` conflict notation to the final version. Returns `null` on non-zero exit or empty output. |
 | `build.gradle.kts` / `build.gradle` — no wrapper or task failed | Static regex | Extracts quoted `"group:artifact:version"` strings and `implementation("g","a","v")` three-arg forms. Best-effort: version catalog refs and BOM-managed versions are missed. |
 
@@ -64,9 +64,14 @@ All coordinate sources — including Maven POM parsing and static Gradle fallbac
 
 When the Gradle task (`gradle dependencies`) is used, it already returns the **full resolved transitive graph** (Gradle has already done conflict resolution). Those coordinates are resolved directly with `ArtifactRequest` — no re-traversal needed. This is why both paths (Gradle task output and static/Maven parsing) use the same `resolveArtifactsDirectly` method.
 
-#### No scope pruning in the session
+#### Scope handling for project classpath resolution
 
-The project context does **not** set `excludeScopesFromGraph`, so no `ScopeDependencySelector` is installed. `test`-scoped dependencies declared in the project's build file are included in the coordinate list and resolved normally.
+The project `AetherContext` is built without `excludeScopesFromGraph` (no session-level `ScopeDependencySelector`). To present a consistent compile-time view across fallback stages, the LST pipeline applies compile-time scope filtering as follows:
+
+- Stage 2 parsing excludes `runtime` and `system` scoped dependencies (runtime-only artifacts not required for compilation).
+- Stage 3 POM traversal applies a `ScopeDependencyFilter` to exclude `runtime` and `system` transitives when resolving declared coordinates.
+
+`provided` and `test` scopes are intentionally included so that compile-time types and test source files can be type-resolved. This approach avoids downloading unnecessary runtime-only POMs while ensuring types needed for compilation and test sources are available.
 
 ### Local repository
 
@@ -91,5 +96,5 @@ Both recipe and project `AetherContext` instances apply the following settings:
 | Repository `checksumPolicy` | `CHECKSUM_POLICY_IGNORE` | Don't fail or retry when a repository omits `.sha1` / `.sha256` files (common on corporate proxies and private registries) |
 | Repository update policy | `UPDATE_POLICY_DAILY` | Re-check remote metadata at most once per day; cached artifacts are reused within a day |
 | Parallel download threads | configurable (`--download-threads`, default 5) | Tune for network bandwidth vs resource constraints |
-| `CONNECT_TIMEOUT` | 30 s | Avoid hanging on slow connections |
-| `REQUEST_TIMEOUT` | 60 s | Abort if a server accepts the connection but never responds |
+| `CONNECT_TIMEOUT` | configurable (`resolverConnectTimeoutMs`, default 30 s) | Avoid hanging on slow connections |
+| `REQUEST_TIMEOUT` | configurable (`resolverRequestTimeoutMs`, default 60 s) | Abort if a server accepts the connection but never responds |

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -27,6 +27,11 @@ val result = RewriteRunner.builder()
 | `cacheDir(Path)` | `Path?` | from config / `~/.rewriterunner/cache` | Recipe JAR cache directory; stored under `<cacheDir>/repository`. Project deps always use `~/.m2/repository`. |
 | `configFile(Path)` | `Path?` | `<projectDir>/rewriterunner.yml`, then `~/.rewriterunner/rewriterunner.yml` | `rewriterunner.yml` tool config (case-insensitive name match). Pass `null` to use auto-discovery. |
 | `dryRun(Boolean)` | `Boolean` | `false` | Run without writing files to disk |
+| `skipPluginRun(Boolean)` | `Boolean` | `false` | Bypass official Gradle/Maven plugin execution and use the in-process LST pipeline directly |
+| `processTimeoutSeconds(Long)` | `Long?` | from config / `120` | Timeout for build-tool subprocesses in the fallback LST pipeline |
+| `pluginTimeoutSeconds(Long)` | `Long?` | from config / `600` | Timeout for official Gradle/Maven plugin invocations in Stage 0 |
+| `resolverConnectTimeoutMs(Int)` | `Int?` | from config / `30000` | TCP connection timeout for Maven Resolver artifact downloads |
+| `resolverRequestTimeoutMs(Int)` | `Int?` | from config / `60000` | Socket read/request timeout for Maven Resolver artifact downloads |
 | `includeExtensions(List<String>)` | `List` | `[]` | Restrict to these extensions (e.g. `[".java", ".kt"]`); overrides `parse.includeExtensions` from config file |
 | `excludeExtensions(List<String>)` | `List` | `[]` | Skip these extensions; overrides `parse.excludeExtensions` from config file |
 | `excludePaths(List<String>)` | `List` | `[]` | Glob patterns (relative to project root) to skip during parsing; overrides `parse.excludePaths` from config file |
@@ -55,6 +60,7 @@ Return type of `RewriteRunner.run()`.
 | `results` | `List<Result>` | Raw OpenRewrite results (one per changed file). Empty means no changes. |
 | `changedFiles` | `List<Path>` | Files written to disk during this run. Empty when `dryRun = true` or no changes. |
 | `projectDir` | `Path` | Resolved project directory (same as `Builder.projectDir`) |
+| `rawDiffs` | `Map<Path, String>` | Unified diffs from the plugin-first path. Empty when the in-process LST path runs. |
 | `hasChanges` | `Boolean` | `true` when the recipe produced at least one change, regardless of `dryRun` |
 | `changeCount` | `Int` | Number of changed source files |
 
@@ -84,13 +90,13 @@ import io.github.skhokhlov.rewriterunner.output.ResultFormatter
 val result = runner.run()
 
 // Print unified diffs to stdout
-ResultFormatter(OutputMode.DIFF).format(result.results, result.projectDir)
+ResultFormatter(OutputMode.DIFF).format(result)
 
 // Print one changed-file path per line to stdout
-ResultFormatter(OutputMode.FILES).format(result.results, result.projectDir)
+ResultFormatter(OutputMode.FILES).format(result)
 
 // Write openrewrite-report.json to the project directory
-ResultFormatter(OutputMode.REPORT).format(result.results, result.projectDir)
+ResultFormatter(OutputMode.REPORT).format(result)
 ```
 
 ### OutputMode
@@ -115,10 +121,13 @@ ResultFormatter(outputMode: OutputMode, writer: PrintWriter)
 
 ```kotlin
 fun format(results: List<Result>, reportDir: Path? = null)
+fun format(runResult: RunResult)
 ```
 
 - `results` — the list from `RunResult.results`. May be empty; prints `"No changes produced."` / `"No files changed."` for `DIFF` / `FILES` modes.
 - `reportDir` — directory where `openrewrite-report.json` is written. Ignored for `DIFF` and `FILES` modes. Defaults to the current directory (`.`).
+
+Use `format(runResult)` when you want formatted output that also supports Stage 0 plugin results stored in `RunResult.rawDiffs`.
 
 ## ToolConfig YAML
 
@@ -136,6 +145,13 @@ parse:
   includeExtensions: [".java", ".kt"]   # restrict to these; overridden by CLI flag
   excludeExtensions: [".xml"]           # skip these; overridden by CLI flag
   excludePaths: ["generated/", "vendor/"] # glob patterns relative to project root
+
+processTimeoutSeconds: 120
+pluginTimeoutSeconds: 600
+rewriteGradlePluginVersion: 7.32.1
+rewriteMavenPluginVersion: 6.38.0
+resolverConnectTimeoutMs: 30000
+resolverRequestTimeoutMs: 60000
 ```
 
 ### ToolConfig fields
@@ -146,6 +162,12 @@ parse:
 | `repositories` | `List<RepositoryConfig>` | `[]` | Extra Maven repos for resolution |
 | `parse` | `ParseConfig` | defaults | File inclusion/exclusion config |
 | `includeMavenCentral` | `Boolean` | `true` | Include Maven Central as a remote repository. Set `false` to restrict to only the repositories listed in `repositories`. |
+| `processTimeoutSeconds` | `Long` | `120` | Timeout for Stage 1/2 build-tool subprocesses, compile attempts, and build-tool metadata commands. |
+| `pluginTimeoutSeconds` | `Long` | `600` | Timeout for Stage 0 official OpenRewrite plugin invocations. |
+| `rewriteGradlePluginVersion` | `String` | `7.32.1` | Version of `org.openrewrite:plugin` used for Stage 0 Gradle plugin execution. |
+| `rewriteMavenPluginVersion` | `String` | `6.38.0` | Version of `org.openrewrite.maven:rewrite-maven-plugin` used for Stage 0 Maven plugin execution. |
+| `resolverConnectTimeoutMs` | `Int` | `30000` | TCP connection timeout for Maven Resolver artifact downloads. |
+| `resolverRequestTimeoutMs` | `Int` | `60000` | Socket read/request timeout for Maven Resolver artifact downloads. |
 
 ### RepositoryConfig fields
 


### PR DESCRIPTION
## Summary
- Introduce a plugin-first execution path so recipe artifacts can be built and run through the plugin pipeline before falling back to the standard runner flow.
- Refine the build, dependency resolution, and recipe execution stages to better separate project build concerns from plugin execution concerns.
- Improve result formatting, timeouts, marker handling, and process execution so the pipeline behaves more predictably across Maven, Gradle, and multi-language projects.
- Expand CLI and integration coverage for Java, Kotlin, Groovy, Maven, XML, and mixed-language projects, including dedicated plugin-first scenarios.
- Update documentation and project guidance to reflect the new architecture, build behavior, and library API expectations.

## Testing
- Added and updated unit tests for runner construction, config handling, build stages, dependency resolution, plugin strategies, patch parsing, recipe execution, and result formatting.
- Added integration tests covering standard project types and the new plugin-first execution flow.
- Validated the updated behavior with the existing test suite coverage added alongside the change set; no separate manual run was requested.