### PR TITLE
feat!: Migrate user-facing timeout API/config from *Seconds / *Ms pri…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,10 @@ java -jar cli/build/libs/cli-1.0-SNAPSHOT-all.jar --help
 | `--config` | | Path to `rewriterunner.yml` | `<projectDir>/rewriterunner.yml`, then `~/.rewriterunner/rewriterunner.yml` |
 | `--dry-run` | | Run without writing to disk | `false` |
 | `--skip-plugin-run` | | Skip official plugin-first execution and use the LST pipeline directly | `false` |
-| `--process-timeout-seconds` | | Build-tool subprocess timeout for the fallback LST pipeline | `120` |
-| `--plugin-timeout-seconds` | | Stage 0 Gradle/Maven plugin timeout | `600` |
-| `--resolver-connect-timeout-ms` | | Maven Resolver TCP connection timeout | `30000` |
-| `--resolver-request-timeout-ms` | | Maven Resolver socket/request timeout | `60000` |
+| `--process-timeout` | | Build-tool subprocess timeout for the fallback LST pipeline | `120s` |
+| `--plugin-timeout` | | Stage 0 Gradle/Maven plugin timeout | `10m` |
+| `--resolver-connect-timeout` | | Maven Resolver TCP connection timeout | `30s` |
+| `--resolver-request-timeout` | | Maven Resolver socket/request timeout | `60s` |
 | `--include-extensions` | | Comma-separated file types to parse | — |
 | `--exclude-extensions` | | Comma-separated file types to skip | — |
 | `--info` | | Enable INFO-level logging to stderr | `false` |

--- a/README.md
+++ b/README.md
@@ -106,12 +106,14 @@ dependencies {
 ```kotlin
 import io.github.skhokhlov.rewriterunner.RewriteRunner
 import java.nio.file.Paths
+import java.time.Duration
 
 fun main() {
     val result = RewriteRunner.builder()
         .projectDir(Paths.get("/path/to/project"))
         .activeRecipe("org.openrewrite.java.format.AutoFormat")
         .recipeArtifact("org.openrewrite.recipe:rewrite-static-analysis:LATEST")
+        .processTimeout(Duration.ofSeconds(120))
         .dryRun(true)   // preview changes without writing to disk
         .build()
         .run()
@@ -127,6 +129,7 @@ fun main() {
 import io.github.skhokhlov.rewriterunner.RewriteRunner;
 import io.github.skhokhlov.rewriterunner.RunResult;
 import java.nio.file.Paths;
+import java.time.Duration;
 
 public class Example {
     public static void main(String[] args) {
@@ -134,6 +137,7 @@ public class Example {
             .projectDir(Paths.get("/path/to/project"))
             .activeRecipe("org.openrewrite.java.format.AutoFormat")
             .recipeArtifact("org.openrewrite.recipe:rewrite-static-analysis:LATEST")
+            .processTimeout(Duration.ofSeconds(120))
             .dryRun(true)
             .build()
             .run();
@@ -311,10 +315,10 @@ Usage: rewrite-runner [-h] [--dry-run] [--skip-plugin-run] [--info] [--debug]
                           [--active-recipe=<recipe>]
                           [--cache-dir=<path>] [--config=<path>]
                           [--download-threads=<n>]
-                          [--process-timeout-seconds=<seconds>]
-                          [--plugin-timeout-seconds=<seconds>]
-                          [--resolver-connect-timeout-ms=<ms>]
-                          [--resolver-request-timeout-ms=<ms>]
+                          [--process-timeout=<duration>]
+                          [--plugin-timeout=<duration>]
+                          [--resolver-connect-timeout=<duration>]
+                          [--resolver-request-timeout=<duration>]
                           [--output=<mode>] [--project-dir=<path>]
                           [--rewrite-config=<path>]
                           [--exclude-extensions=<ext>[,<ext>...]]
@@ -334,10 +338,10 @@ Usage: rewrite-runner [-h] [--dry-run] [--skip-plugin-run] [--info] [--debug]
 | `--dry-run` | Run recipe but do not write changes to disk | `false` |
 | `--skip-plugin-run` | Skip plugin-first execution; use full LST pipeline directly | `false` |
 | `--download-threads` | Number of parallel artifact download threads | `5` |
-| `--process-timeout-seconds` | Timeout for build-tool subprocesses in the fallback LST pipeline | `120` |
-| `--plugin-timeout-seconds` | Timeout for plugin-first Gradle/Maven invocations | `600` |
-| `--resolver-connect-timeout-ms` | TCP connection timeout for Maven Resolver downloads | `30000` |
-| `--resolver-request-timeout-ms` | Socket read/request timeout for Maven Resolver downloads | `60000` |
+| `--process-timeout` | Timeout for build-tool subprocesses in the fallback LST pipeline. Accepts `ms`, `s`, `m`, `h`, `d`, or ISO-8601 values. | `120s` |
+| `--plugin-timeout` | Timeout for plugin-first Gradle/Maven invocations. Accepts `ms`, `s`, `m`, `h`, `d`, or ISO-8601 values. | `10m` |
+| `--resolver-connect-timeout` | TCP connection timeout for Maven Resolver downloads. Accepts `ms`, `s`, `m`, `h`, `d`, or ISO-8601 values. | `30s` |
+| `--resolver-request-timeout` | Socket read/request timeout for Maven Resolver downloads. Accepts `ms`, `s`, `m`, `h`, `d`, or ISO-8601 values. | `60s` |
 | `--include-extensions` | Comma-separated file extensions to parse (e.g. `.java,.kt`) | all supported |
 | `--exclude-extensions` | Comma-separated file extensions to skip | — |
 | `--no-maven-central` | Disable Maven Central; use only repositories from the config file | `false` |
@@ -429,6 +433,7 @@ Create `rewriterunner.yml` to configure repositories and caching for your enviro
 2. `~/.rewriterunner/rewriterunner.yml` — global fallback, shared across all projects
 
 File name matching is case-insensitive (e.g. `RewriteRunner.yml` also works). Override either default with `--config <path>`.
+Duration values require units such as `30000ms`, `120s`, `10m`, `2h`, `1d`, or ISO-8601 values such as `PT2M`.
 
 ```yaml
 repositories:
@@ -439,12 +444,12 @@ repositories:
 cacheDir: ~/.rewriterunner/cache
 
 downloadThreads: 5   # parallel artifact download threads (default: 5)
-processTimeoutSeconds: 120        # fallback LST build-tool subprocess timeout
-pluginTimeoutSeconds: 600         # plugin-first rewriteDryRun/rewriteRun timeout
+processTimeout: 120s              # fallback LST build-tool subprocess timeout
+pluginTimeout: 10m                # plugin-first rewriteDryRun/rewriteRun timeout
 rewriteGradlePluginVersion: 7.32.1
 rewriteMavenPluginVersion: 6.38.0
-resolverConnectTimeoutMs: 30000   # Maven Resolver TCP connection timeout
-resolverRequestTimeoutMs: 60000   # Maven Resolver socket/request timeout
+resolverConnectTimeout: 30s       # Maven Resolver TCP connection timeout
+resolverRequestTimeout: 60s       # Maven Resolver socket/request timeout
 
 parse:
   includeExtensions: [".java", ".kt", ".xml"]

--- a/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
+++ b/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
@@ -1,9 +1,11 @@
 package io.github.skhokhlov.rewriterunner.cli
 
 import io.github.skhokhlov.rewriterunner.RewriteRunner
+import io.github.skhokhlov.rewriterunner.config.DurationParser
 import io.github.skhokhlov.rewriterunner.output.OutputMode
 import io.github.skhokhlov.rewriterunner.output.ResultFormatter
 import java.nio.file.Path
+import java.time.Duration
 import java.util.concurrent.Callable
 import picocli.CommandLine
 import picocli.CommandLine.Command
@@ -123,34 +125,44 @@ class RunCommand : Callable<Int> {
     var downloadThreads: Int? = null
 
     @Option(
-        names = ["--process-timeout-seconds"],
+        names = ["--process-timeout"],
         description = [
             "Timeout for build-tool subprocesses in the fallback LST pipeline.",
-            "Defaults to 120."
-        ]
+            "Use values like 120s, 10m, or PT2M. Defaults to 120s."
+        ],
+        converter = [DurationConverter::class]
     )
-    var processTimeoutSeconds: Long? = null
+    var processTimeout: Duration? = null
 
     @Option(
-        names = ["--plugin-timeout-seconds"],
-        description = ["Timeout for plugin-first Gradle/Maven invocations. Defaults to 600."]
+        names = ["--plugin-timeout"],
+        description = [
+            "Timeout for plugin-first Gradle/Maven invocations.",
+            "Use values like 10m, 600s, or PT10M. Defaults to 10m."
+        ],
+        converter = [DurationConverter::class]
     )
-    var pluginTimeoutSeconds: Long? = null
+    var pluginTimeout: Duration? = null
 
     @Option(
-        names = ["--resolver-connect-timeout-ms"],
-        description = ["TCP connection timeout for Maven Resolver downloads. Defaults to 30000."]
+        names = ["--resolver-connect-timeout"],
+        description = [
+            "TCP connection timeout for Maven Resolver downloads.",
+            "Use values like 30s, 30000ms, or PT30S. Defaults to 30s."
+        ],
+        converter = [DurationConverter::class]
     )
-    var resolverConnectTimeoutMs: Int? = null
+    var resolverConnectTimeout: Duration? = null
 
     @Option(
-        names = ["--resolver-request-timeout-ms"],
+        names = ["--resolver-request-timeout"],
         description = [
             "Socket read/request timeout for Maven Resolver downloads.",
-            "Defaults to 60000."
-        ]
+            "Use values like 60s, 1m, or PT1M. Defaults to 60s."
+        ],
+        converter = [DurationConverter::class]
     )
-    var resolverRequestTimeoutMs: Int? = null
+    var resolverRequestTimeout: Duration? = null
 
     override fun call(): Int {
         val logger =
@@ -171,10 +183,10 @@ class RunCommand : Callable<Int> {
             configFile?.let { builder.configFile(it) }
             if (noMavenCentral) builder.includeMavenCentral(false)
             downloadThreads?.let { builder.downloadThreads(it) }
-            processTimeoutSeconds?.let { builder.processTimeoutSeconds(it) }
-            pluginTimeoutSeconds?.let { builder.pluginTimeoutSeconds(it) }
-            resolverConnectTimeoutMs?.let { builder.resolverConnectTimeoutMs(it) }
-            resolverRequestTimeoutMs?.let { builder.resolverRequestTimeoutMs(it) }
+            processTimeout?.let { builder.processTimeout(it) }
+            pluginTimeout?.let { builder.pluginTimeout(it) }
+            resolverConnectTimeout?.let { builder.resolverConnectTimeout(it) }
+            resolverRequestTimeout?.let { builder.resolverRequestTimeout(it) }
 
             val runResult = builder.build().run()
 
@@ -207,4 +219,12 @@ private class OutputModeConverter : ITypeConverter<OutputMode> {
                 "Unknown output mode '$value'. Valid values: " +
                     OutputMode.entries.joinToString(", ") { it.name.lowercase() }
             )
+}
+
+private class DurationConverter : ITypeConverter<Duration> {
+    override fun convert(value: String): Duration = try {
+        DurationParser.parse(value)
+    } catch (e: IllegalArgumentException) {
+        throw CommandLine.TypeConversionException(e.message)
+    }
 }

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
@@ -7,9 +7,11 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintWriter
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import picocli.CommandLine
@@ -191,29 +193,43 @@ class RunCommandTest :
             CommandLine(cmd).parseArgs(
                 "--active-recipe",
                 "io.github.skhokhlov.rewriterunner.MyRecipe",
-                "--process-timeout-seconds",
-                "45",
-                "--plugin-timeout-seconds",
-                "900",
-                "--resolver-connect-timeout-ms",
-                "10000",
-                "--resolver-request-timeout-ms",
-                "20000"
+                "--process-timeout",
+                "45s",
+                "--plugin-timeout",
+                "15m",
+                "--resolver-connect-timeout",
+                "10000ms",
+                "--resolver-request-timeout",
+                "20s"
             )
-            assertEquals(45L, cmd.processTimeoutSeconds)
-            assertEquals(900L, cmd.pluginTimeoutSeconds)
-            assertEquals(10_000, cmd.resolverConnectTimeoutMs)
-            assertEquals(20_000, cmd.resolverRequestTimeoutMs)
+            assertEquals(Duration.ofSeconds(45), cmd.processTimeout)
+            assertEquals(Duration.ofMinutes(15), cmd.pluginTimeout)
+            assertEquals(Duration.ofMillis(10_000), cmd.resolverConnectTimeout)
+            assertEquals(Duration.ofSeconds(20), cmd.resolverRequestTimeout)
         }
 
         test("--help output mentions timeout options") {
             val baos = ByteArrayOutputStream()
             cli().setOut(PrintWriter(baos)).execute("--help")
             val help = baos.toString()
-            assertTrue(help.contains("--process-timeout-seconds"))
-            assertTrue(help.contains("--plugin-timeout-seconds"))
-            assertTrue(help.contains("--resolver-connect-timeout-ms"))
-            assertTrue(help.contains("--resolver-request-timeout-ms"))
+            assertTrue(help.contains("--process-timeout"))
+            assertTrue(help.contains("--plugin-timeout"))
+            assertTrue(help.contains("--resolver-connect-timeout"))
+            assertTrue(help.contains("--resolver-request-timeout"))
+            assertFalse(help.contains("--process-timeout-seconds"))
+            assertFalse(help.contains("--plugin-timeout-seconds"))
+            assertFalse(help.contains("--resolver-connect-timeout-ms"))
+            assertFalse(help.contains("--resolver-request-timeout-ms"))
+        }
+
+        test("old timeout options are rejected") {
+            val code = cli().execute(
+                "--active-recipe",
+                "io.github.skhokhlov.rewriterunner.MyRecipe",
+                "--process-timeout-seconds",
+                "45"
+            )
+            assertNotEquals(0, code)
         }
 
         test("multiple --recipe-artifact flags are collected into a list") {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/AetherContext.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/AetherContext.kt
@@ -1,7 +1,10 @@
 package io.github.skhokhlov.rewriterunner
 
+import io.github.skhokhlov.rewriterunner.config.DurationParser
 import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
+import io.github.skhokhlov.rewriterunner.config.ToolConfig.Companion.DOWNLOAD_THREADS
 import java.nio.file.Path
+import java.time.Duration
 import org.eclipse.aether.ConfigurationProperties
 import org.eclipse.aether.RepositorySystem
 import org.eclipse.aether.RepositorySystemSession
@@ -54,9 +57,9 @@ class AetherContext(
          *   default (`~/.m2/repository`) to reuse the user's existing local repository.
          * @param extraRepositories Additional remote Maven repositories beyond Maven Central.
          *   Credentials from [RepositoryConfig] are applied when present.
-         * @param connectTimeoutMs TCP connection timeout in milliseconds. Defaults to 30 000.
-         * @param requestTimeoutMs Socket read / request timeout in milliseconds. Defaults to
-         *   60 000. An explicit value prevents hanging when a remote server accepts the TCP
+         * @param connectTimeout TCP connection timeout. Defaults to 30 s.
+         * @param requestTimeout Socket read / request timeout. Defaults to 60 s.
+         *   An explicit value prevents hanging when a remote server accepts the TCP
          *   connection but never sends an HTTP response.
          * @param downloadThreads Number of parallel artifact download threads used by the
          *   connector. Defaults to 5. Increase for faster downloads on high-bandwidth networks;
@@ -71,9 +74,9 @@ class AetherContext(
         fun build(
             localRepoDir: Path,
             extraRepositories: List<RepositoryConfig> = emptyList(),
-            connectTimeoutMs: Int = ExecutionTimeouts.DEFAULT_RESOLVER_CONNECT_TIMEOUT_MS,
-            requestTimeoutMs: Int = ExecutionTimeouts.DEFAULT_RESOLVER_REQUEST_TIMEOUT_MS,
-            downloadThreads: Int = 5,
+            connectTimeout: Duration = ExecutionTimeouts.DEFAULT_RESOLVER_CONNECT_TIMEOUT,
+            requestTimeout: Duration = ExecutionTimeouts.DEFAULT_RESOLVER_REQUEST_TIMEOUT,
+            downloadThreads: Int = DOWNLOAD_THREADS,
             excludeScopesFromGraph: Collection<String> = emptyList(),
             includeMavenCentral: Boolean = true,
             logger: RunnerLogger
@@ -122,8 +125,14 @@ class AetherContext(
                         )
                     }
                 )
-                .setConfigProperty(ConfigurationProperties.CONNECT_TIMEOUT, connectTimeoutMs)
-                .setConfigProperty(ConfigurationProperties.REQUEST_TIMEOUT, requestTimeoutMs)
+                .setConfigProperty(
+                    ConfigurationProperties.CONNECT_TIMEOUT,
+                    DurationParser.toMillisInt(connectTimeout, "resolverConnectTimeout")
+                )
+                .setConfigProperty(
+                    ConfigurationProperties.REQUEST_TIMEOUT,
+                    DurationParser.toMillisInt(requestTimeout, "resolverRequestTimeout")
+                )
                 .setConfigProperty("aether.connector.basic.threads", downloadThreads)
                 // Disable downloading remote prefix-filter index files (Maven Resolver 2.x).
                 // Without this, Maven Resolver downloads large /.index/prefixes.txt files from

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionTimeouts.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionTimeouts.kt
@@ -1,9 +1,11 @@
 package io.github.skhokhlov.rewriterunner
 
+import java.time.Duration
+
 /** Central defaults for external execution and resolver network timeouts. */
 object ExecutionTimeouts {
-    const val DEFAULT_PROCESS_TIMEOUT_SECONDS = 120L
-    const val DEFAULT_PLUGIN_TIMEOUT_SECONDS = 600L
-    const val DEFAULT_RESOLVER_CONNECT_TIMEOUT_MS = 30_000
-    const val DEFAULT_RESOLVER_REQUEST_TIMEOUT_MS = 60_000
+    val DEFAULT_PROCESS_TIMEOUT: Duration = Duration.ofSeconds(120)
+    val DEFAULT_PLUGIN_TIMEOUT: Duration = Duration.ofMinutes(10)
+    val DEFAULT_RESOLVER_CONNECT_TIMEOUT: Duration = Duration.ofSeconds(30)
+    val DEFAULT_RESOLVER_REQUEST_TIMEOUT: Duration = Duration.ofSeconds(60)
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner
 
+import io.github.skhokhlov.rewriterunner.config.DurationParser
 import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
 import io.github.skhokhlov.rewriterunner.lst.LstBuilder
@@ -11,6 +12,7 @@ import io.github.skhokhlov.rewriterunner.recipe.RecipeRunner
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.time.Duration
 import kotlin.io.path.exists
 
 /**
@@ -73,25 +75,25 @@ class RewriteRunner private constructor(private val config: Builder) {
                 Paths.get(System.getProperty("user.home"), ".rewriterunner")
             )
         val toolConfig = ToolConfig.load(effectiveConfigFile, logger)
-        val effectiveProcessTimeoutSeconds =
-            positiveLong(
-                config.processTimeoutSeconds ?: toolConfig.processTimeoutSeconds,
-                "processTimeoutSeconds"
+        val effectiveProcessTimeout =
+            DurationParser.requirePositive(
+                config.processTimeout ?: toolConfig.processTimeout,
+                "processTimeout"
             )
-        val effectivePluginTimeoutSeconds =
-            positiveLong(
-                config.pluginTimeoutSeconds ?: toolConfig.pluginTimeoutSeconds,
-                "pluginTimeoutSeconds"
+        val effectivePluginTimeout =
+            DurationParser.requirePositive(
+                config.pluginTimeout ?: toolConfig.pluginTimeout,
+                "pluginTimeout"
             )
-        val effectiveResolverConnectTimeoutMs =
-            positiveInt(
-                config.resolverConnectTimeoutMs ?: toolConfig.resolverConnectTimeoutMs,
-                "resolverConnectTimeoutMs"
+        val effectiveResolverConnectTimeout =
+            DurationParser.requirePositive(
+                config.resolverConnectTimeout ?: toolConfig.resolverConnectTimeout,
+                "resolverConnectTimeout"
             )
-        val effectiveResolverRequestTimeoutMs =
-            positiveInt(
-                config.resolverRequestTimeoutMs ?: toolConfig.resolverRequestTimeoutMs,
-                "resolverRequestTimeoutMs"
+        val effectiveResolverRequestTimeout =
+            DurationParser.requirePositive(
+                config.resolverRequestTimeout ?: toolConfig.resolverRequestTimeout,
+                "resolverRequestTimeout"
             )
 
         // Stage 0: let the project's own build tool run the official OpenRewrite plugin first.
@@ -100,7 +102,7 @@ class RewriteRunner private constructor(private val config: Builder) {
             val pluginResult =
                 PluginRecipeRunner(
                     logger = logger,
-                    timeoutSeconds = effectivePluginTimeoutSeconds,
+                    timeout = effectivePluginTimeout,
                     rewriteGradlePluginVersion = toolConfig.rewriteGradlePluginVersion,
                     rewriteMavenPluginVersion = toolConfig.rewriteMavenPluginVersion
                 ).run(
@@ -151,10 +153,10 @@ class RewriteRunner private constructor(private val config: Builder) {
         }
         val effectiveToolConfig =
             toolConfig.copy(
-                processTimeoutSeconds = effectiveProcessTimeoutSeconds,
-                pluginTimeoutSeconds = effectivePluginTimeoutSeconds,
-                resolverConnectTimeoutMs = effectiveResolverConnectTimeoutMs,
-                resolverRequestTimeoutMs = effectiveResolverRequestTimeoutMs
+                processTimeout = effectiveProcessTimeout,
+                pluginTimeout = effectivePluginTimeout,
+                resolverConnectTimeout = effectiveResolverConnectTimeout,
+                resolverRequestTimeout = effectiveResolverRequestTimeout
             )
         val effectiveIncludeMavenCentral =
             config.includeMavenCentral ?: toolConfig.includeMavenCentral
@@ -167,8 +169,8 @@ class RewriteRunner private constructor(private val config: Builder) {
         val recipeAetherContext = AetherContext.build(
             localRepoDir = recipeLocalRepoDir,
             extraRepositories = effectiveRepositories,
-            connectTimeoutMs = effectiveResolverConnectTimeoutMs,
-            requestTimeoutMs = effectiveResolverRequestTimeoutMs,
+            connectTimeout = effectiveResolverConnectTimeout,
+            requestTimeout = effectiveResolverRequestTimeout,
             downloadThreads = effectiveDownloadThreads,
             // Prune test/provided/system scope nodes from the graph during collection so
             // their POMs are never fetched. Recipes only need compile/runtime JARs to run.
@@ -182,8 +184,8 @@ class RewriteRunner private constructor(private val config: Builder) {
         val projectAetherContext = AetherContext.build(
             localRepoDir = mavenLocalRepoDir,
             extraRepositories = effectiveRepositories,
-            connectTimeoutMs = effectiveResolverConnectTimeoutMs,
-            requestTimeoutMs = effectiveResolverRequestTimeoutMs,
+            connectTimeout = effectiveResolverConnectTimeout,
+            requestTimeout = effectiveResolverRequestTimeout,
             downloadThreads = effectiveDownloadThreads,
             includeMavenCentral = effectiveIncludeMavenCentral,
             logger = logger
@@ -353,13 +355,13 @@ class RewriteRunner private constructor(private val config: Builder) {
             private set
         internal var downloadThreads: Int? = null
             private set
-        internal var processTimeoutSeconds: Long? = null
+        internal var processTimeout: Duration? = null
             private set
-        internal var pluginTimeoutSeconds: Long? = null
+        internal var pluginTimeout: Duration? = null
             private set
-        internal var resolverConnectTimeoutMs: Int? = null
+        internal var resolverConnectTimeout: Duration? = null
             private set
-        internal var resolverRequestTimeoutMs: Int? = null
+        internal var resolverRequestTimeout: Duration? = null
             private set
         internal var repositories: List<RepositoryConfig> = emptyList()
             private set
@@ -461,19 +463,18 @@ class RewriteRunner private constructor(private val config: Builder) {
          * Timeout for non-plugin build-tool subprocesses, including LST Stage 1,
          * Stage 2, compile attempts, and build-tool metadata commands.
          */
-        fun processTimeoutSeconds(seconds: Long): Builder =
-            apply { processTimeoutSeconds = seconds }
+        fun processTimeout(timeout: Duration): Builder = apply { processTimeout = timeout }
 
         /** Timeout for official OpenRewrite Gradle/Maven plugin invocations in Stage 0. */
-        fun pluginTimeoutSeconds(seconds: Long): Builder = apply { pluginTimeoutSeconds = seconds }
+        fun pluginTimeout(timeout: Duration): Builder = apply { pluginTimeout = timeout }
 
         /** TCP connection timeout for Maven Resolver artifact downloads. */
-        fun resolverConnectTimeoutMs(milliseconds: Int): Builder =
-            apply { resolverConnectTimeoutMs = milliseconds }
+        fun resolverConnectTimeout(timeout: Duration): Builder =
+            apply { resolverConnectTimeout = timeout }
 
         /** Socket read/request timeout for Maven Resolver artifact downloads. */
-        fun resolverRequestTimeoutMs(milliseconds: Int): Builder =
-            apply { resolverRequestTimeoutMs = milliseconds }
+        fun resolverRequestTimeout(timeout: Duration): Builder =
+            apply { resolverRequestTimeout = timeout }
 
         /**
          * Override whether Maven Central is included as a remote repository.
@@ -550,16 +551,6 @@ class RewriteRunner private constructor(private val config: Builder) {
             }
         } catch (_: Exception) {
             null
-        }
-
-        private fun positiveLong(value: Long, name: String): Long {
-            require(value > 0) { "$name must be greater than 0: $value" }
-            return value
-        }
-
-        private fun positiveInt(value: Int, name: String): Int {
-            require(value > 0) { "$name must be greater than 0: $value" }
-            return value
         }
     }
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/DurationParser.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/DurationParser.kt
@@ -1,0 +1,77 @@
+package io.github.skhokhlov.rewriterunner.config
+
+import java.time.Duration
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.deser.std.StdDeserializer
+
+/** Parses user-facing timeout values such as `120s`, `10m`, `30000ms`, or `PT2M`. */
+object DurationParser {
+    private val humanDurationPattern = Regex("""^(\d+)(ms|s|m|h|d)$""")
+
+    fun parse(value: String, fieldName: String = "duration"): Duration {
+        val text = value.trim()
+        require(text.isNotEmpty()) { "$fieldName must not be empty" }
+
+        val duration = humanDurationPattern.matchEntire(text.lowercase())?.let { match ->
+            val amount = match.groupValues[1].toLong()
+            when (match.groupValues[2]) {
+                "ms" -> Duration.ofMillis(amount)
+                "s" -> Duration.ofSeconds(amount)
+                "m" -> Duration.ofMinutes(amount)
+                "h" -> Duration.ofHours(amount)
+                "d" -> Duration.ofDays(amount)
+                else -> error("unreachable")
+            }
+        } ?: parseIsoDuration(text, fieldName)
+
+        return requirePositive(duration, fieldName)
+    }
+
+    fun requirePositive(duration: Duration, fieldName: String): Duration {
+        require(!duration.isZero && !duration.isNegative) {
+            "$fieldName must be greater than 0: $duration"
+        }
+        return duration
+    }
+
+    fun toMillisInt(duration: Duration, fieldName: String): Int {
+        requirePositive(duration, fieldName)
+        val millis = duration.toMillis()
+        require(millis > 0) { "$fieldName must be at least 1ms: $duration" }
+        require(millis <= Int.MAX_VALUE) {
+            "$fieldName must be <= ${Int.MAX_VALUE}ms: $duration"
+        }
+        return millis.toInt()
+    }
+
+    private fun parseIsoDuration(text: String, fieldName: String): Duration {
+        if (!text.startsWith("P", ignoreCase = true)) {
+            throw IllegalArgumentException(
+                "$fieldName must include a duration unit (ms, s, m, h, d) or use ISO-8601, " +
+                    "for example 120s or PT2M"
+            )
+        }
+        return try {
+            Duration.parse(text.uppercase())
+        } catch (e: Exception) {
+            throw IllegalArgumentException(
+                "$fieldName must include a valid duration unit (ms, s, m, h, d) or " +
+                    "ISO-8601 value, for example 120s or PT2M",
+                e
+            )
+        }
+    }
+}
+
+internal class DurationConfigDeserializer : StdDeserializer<Duration>(Duration::class.java) {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Duration {
+        val fieldName = p.currentName() ?: "duration"
+        val value = if (p.currentToken().isNumeric) {
+            p.getLongValue().toString()
+        } else {
+            p.getValueAsString()
+        } ?: throw IllegalArgumentException("$fieldName must be a duration string")
+        return DurationParser.parse(value, fieldName)
+    }
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
@@ -6,8 +6,10 @@ import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.time.Duration
 import kotlin.io.path.exists
 import kotlin.io.path.readText
+import tools.jackson.databind.module.SimpleModule
 import tools.jackson.dataformat.yaml.YAMLMapper
 import tools.jackson.module.kotlin.KotlinModule
 
@@ -64,16 +66,14 @@ data class ParseConfig(
  *   Defaults to `~/.rewriterunner/cache`.
  * @property parse File parsing configuration controlling which extensions and paths are
  *   included or excluded from the LST-building stage.
- * @property processTimeoutSeconds Timeout for build-tool subprocesses in the fallback
- *   LST pipeline.
- * @property pluginTimeoutSeconds Timeout for official Gradle/Maven plugin invocations
- *   in Stage 0.
+ * @property processTimeout Timeout for build-tool subprocesses in the fallback LST pipeline.
+ * @property pluginTimeout Timeout for official Gradle/Maven plugin invocations in Stage 0.
  * @property rewriteGradlePluginVersion Version of the official OpenRewrite Gradle plugin
  *   used by Stage 0 plugin-first execution.
  * @property rewriteMavenPluginVersion Version of the official OpenRewrite Maven plugin
  *   used by Stage 0 plugin-first execution.
- * @property resolverConnectTimeoutMs TCP connection timeout for Maven Resolver downloads.
- * @property resolverRequestTimeoutMs Socket read/request timeout for Maven Resolver downloads.
+ * @property resolverConnectTimeout TCP connection timeout for Maven Resolver downloads.
+ * @property resolverRequestTimeout Socket read/request timeout for Maven Resolver downloads.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ToolConfig(
@@ -81,13 +81,13 @@ data class ToolConfig(
     val cacheDir: String = "~/.rewriterunner/cache",
     val parse: ParseConfig = ParseConfig(),
     val includeMavenCentral: Boolean = true,
-    val downloadThreads: Int = 5,
-    val processTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS,
-    val pluginTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+    val downloadThreads: Int = DOWNLOAD_THREADS,
+    val processTimeout: Duration = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT,
+    val pluginTimeout: Duration = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
     val rewriteGradlePluginVersion: String = REWRITE_GRADLE_PLUGIN_VERSION,
     val rewriteMavenPluginVersion: String = REWRITE_MAVEN_PLUGIN_VERSION,
-    val resolverConnectTimeoutMs: Int = ExecutionTimeouts.DEFAULT_RESOLVER_CONNECT_TIMEOUT_MS,
-    val resolverRequestTimeoutMs: Int = ExecutionTimeouts.DEFAULT_RESOLVER_REQUEST_TIMEOUT_MS,
+    val resolverConnectTimeout: Duration = ExecutionTimeouts.DEFAULT_RESOLVER_CONNECT_TIMEOUT,
+    val resolverRequestTimeout: Duration = ExecutionTimeouts.DEFAULT_RESOLVER_REQUEST_TIMEOUT,
     val logger: RunnerLogger = NoOpRunnerLogger
 ) {
     /** Returns [cacheDir] with `~` expanded to the user home directory and environment
@@ -114,9 +114,14 @@ data class ToolConfig(
     companion object {
         const val REWRITE_GRADLE_PLUGIN_VERSION = "7.32.1"
         const val REWRITE_MAVEN_PLUGIN_VERSION = "6.38.0"
+        const val DOWNLOAD_THREADS = 5
 
         private val yaml = YAMLMapper.builder()
             .addModule(KotlinModule.Builder().build())
+            .addModule(
+                SimpleModule()
+                    .addDeserializer(Duration::class.java, DurationConfigDeserializer())
+            )
             .build()
 
         /**
@@ -131,12 +136,48 @@ data class ToolConfig(
          */
         fun load(configFile: Path?, logger: RunnerLogger): ToolConfig {
             if (configFile != null && configFile.exists()) {
-                val text = interpolateEnvVars(configFile.readText(), logger)
-                return yaml.readValue(text, ToolConfig::class.java).copy(logger = logger)
+                val rawText = configFile.readText()
+                val text = interpolateEnvVars(rawText, logger)
+                return try {
+                    rejectLegacyTimeoutFields(text)
+                    yaml.readValue(text, ToolConfig::class.java).copy(logger = logger)
+                } catch (e: Exception) {
+                    throw unwrapConfigException(e)
+                }
             }
             return ToolConfig(
                 logger = logger
             )
+        }
+
+        private fun rejectLegacyTimeoutFields(text: String) {
+            val parsed = yaml.readValue(text, Map::class.java) ?: return
+            val keys = parsed.keys.mapNotNull { it?.toString() }
+            val legacyName = keys.firstOrNull { it in LEGACY_TIMEOUT_FIELDS } ?: return
+            val replacement = LEGACY_TIMEOUT_FIELDS.getValue(legacyName)
+            throw IllegalArgumentException(
+                "Legacy timeout field '$legacyName' is no longer supported; " +
+                    "use '$replacement' with a Duration value such as 120s, 10m, or 30000ms"
+            )
+        }
+
+        private val LEGACY_TIMEOUT_FIELDS =
+            mapOf(
+                "processTimeoutSeconds" to "processTimeout",
+                "pluginTimeoutSeconds" to "pluginTimeout",
+                "resolverConnectTimeoutMs" to "resolverConnectTimeout",
+                "resolverRequestTimeoutMs" to "resolverRequestTimeout"
+            )
+
+        private fun unwrapConfigException(e: Exception): Exception {
+            var cause: Throwable? = e
+            while (cause != null) {
+                if (cause is IllegalArgumentException) {
+                    return IllegalArgumentException(cause.message, cause)
+                }
+                cause = cause.cause
+            }
+            return e
         }
 
         private fun interpolateEnvVars(text: String, logger: RunnerLogger): String =

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
@@ -14,6 +14,7 @@ import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveMavenCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.runProcess
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.exists
 import org.eclipse.aether.artifact.DefaultArtifact
 import org.eclipse.aether.resolution.ArtifactRequest
@@ -62,7 +63,7 @@ import org.eclipse.aether.resolution.ArtifactResolutionException
 open class DependencyResolutionStage(
     private val aetherContext: AetherContext,
     protected val logger: RunnerLogger,
-    private val processTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS
+    private val processTimeout: Duration = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT
 ) {
     private val staticParser = StaticBuildFileParser(logger)
 
@@ -183,7 +184,7 @@ open class DependencyResolutionStage(
             projectDir,
             listOf(mvnCmd, "dependency:tree"),
             captureStdout = output,
-            timeoutSeconds = processTimeoutSeconds,
+            timeout = processTimeout,
             logger = logger
         ) ?: return null
         if (result != 0) {
@@ -278,7 +279,7 @@ open class DependencyResolutionStage(
                 "--no-configuration-cache"
             ) + tasks,
             captureStdout = output,
-            timeoutSeconds = processTimeoutSeconds,
+            timeout = processTimeout,
             logger = logger
         ) ?: return null
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
@@ -77,20 +77,20 @@ open class LstBuilder(
     private val aetherContext: AetherContext = AetherContext.build(
         localRepoDir = Paths.get(System.getProperty("user.home"), ".m2", "repository"),
         extraRepositories = toolConfig.resolvedRepositories(),
-        connectTimeoutMs = toolConfig.resolverConnectTimeoutMs,
-        requestTimeoutMs = toolConfig.resolverRequestTimeoutMs,
+        connectTimeout = toolConfig.resolverConnectTimeout,
+        requestTimeout = toolConfig.resolverRequestTimeout,
         downloadThreads = toolConfig.downloadThreads,
         includeMavenCentral = toolConfig.includeMavenCentral,
         logger = logger
     ),
     private val projectBuildStage: ProjectBuildStage = ProjectBuildStage(
         logger,
-        toolConfig.processTimeoutSeconds
+        toolConfig.processTimeout
     ),
     private val depResolutionStage: DependencyResolutionStage = DependencyResolutionStage(
         aetherContext,
         logger,
-        toolConfig.processTimeoutSeconds
+        toolConfig.processTimeout
     ),
     private val buildFileParseStage: BuildFileParseStage = BuildFileParseStage(
         aetherContext,
@@ -102,7 +102,7 @@ open class LstBuilder(
     private val staticParser = StaticBuildFileParser(logger)
     private val gradleDslClasspathResolver = GradleDslClasspathResolver(logger, versionDetector)
     private val markerFactory =
-        MarkerFactory(logger, staticParser, versionDetector, toolConfig.processTimeoutSeconds)
+        MarkerFactory(logger, staticParser, versionDetector, toolConfig.processTimeout)
 
     // ─── Thin delegation methods for backward-compatible test access ──────────
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
@@ -8,6 +8,7 @@ import io.github.skhokhlov.rewriterunner.lst.utils.resolveMavenCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.runProcess
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.exists
 
 /**
@@ -54,7 +55,7 @@ import kotlin.io.path.exists
  */
 open class ProjectBuildStage(
     protected val logger: RunnerLogger,
-    private val processTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS
+    private val processTimeout: Duration = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT
 ) {
     /**
      * Attempts to extract the project's compile classpath by invoking the build tool.
@@ -91,7 +92,7 @@ open class ProjectBuildStage(
             val result = runProcess(
                 projectDir,
                 mvnCommand,
-                timeoutSeconds = processTimeoutSeconds,
+                timeout = processTimeout,
                 logger = logger
             ) ?: return null
 
@@ -145,7 +146,7 @@ open class ProjectBuildStage(
                 projectDir,
                 gradleCommand,
                 captureStdout = output,
-                timeoutSeconds = processTimeoutSeconds,
+                timeout = processTimeout,
                 logger = logger
             ) ?: return null
 
@@ -234,7 +235,7 @@ open class ProjectBuildStage(
                 runProcess(
                     projectDir,
                     command,
-                    timeoutSeconds = processTimeoutSeconds,
+                    timeout = processTimeout,
                     logger = logger
                 ) ?: return false
             if (result == 0) {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/MarkerFactory.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/MarkerFactory.kt
@@ -4,6 +4,7 @@ import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.lst.utils.StaticBuildFileParser
 import java.nio.file.Path
+import java.time.Duration
 import java.util.UUID
 import kotlin.io.path.exists
 import org.openrewrite.SourceFile
@@ -33,10 +34,10 @@ internal class MarkerFactory(
     private val logger: RunnerLogger,
     private val staticParser: StaticBuildFileParser,
     private val versionDetector: VersionDetector,
-    private val processTimeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS,
+    private val processTimeout: Duration = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT,
     private val processRunner: ProcessRunner = ::runProcess
 ) {
-    private val metadataProbeTimeoutSeconds = minOf(processTimeoutSeconds, 5)
+    private val metadataProbeTimeout = minOf(processTimeout, Duration.ofSeconds(5))
 
     fun buildEnvironment(): BuildEnvironment? = try {
         BuildEnvironment.build { key -> System.getenv(key) }
@@ -103,7 +104,8 @@ internal class MarkerFactory(
             projectDir,
             listOf(mvnCmd, "--version"),
             output,
-            metadataProbeTimeoutSeconds,
+            metadataProbeTimeout,
+            "processTimeout",
             logger
         )
         if (result == 0) {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
@@ -2,10 +2,12 @@ package io.github.skhokhlov.rewriterunner.lst.utils
 
 import io.github.skhokhlov.rewriterunner.ExecutionTimeouts
 import io.github.skhokhlov.rewriterunner.RunnerLogger
+import io.github.skhokhlov.rewriterunner.config.DurationParser
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.exists
 
@@ -13,12 +15,13 @@ internal typealias ProcessRunner = (
     workDir: Path,
     command: List<String>,
     captureStdout: StringBuilder?,
-    timeoutSeconds: Long,
+    timeout: Duration,
+    timeoutName: String,
     logger: RunnerLogger
 ) -> Int?
 
 /**
- * Runs an external process in [workDir] and waits up to [timeoutSeconds] for it to finish.
+ * Runs an external process in [workDir] and waits up to [timeout] for it to finish.
  *
  * Both stdout and stderr are always drained on background threads to prevent OS pipe-buffer
  * deadlock (~64 KB limit). Each line is logged at DEBUG level (visible with `--debug`).
@@ -31,9 +34,11 @@ internal fun runProcess(
     workDir: Path,
     command: List<String>,
     captureStdout: StringBuilder? = null,
-    timeoutSeconds: Long = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS,
+    timeout: Duration = ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT,
+    timeoutName: String = "processTimeout",
     logger: RunnerLogger
 ): Int? {
+    DurationParser.requirePositive(timeout, timeoutName)
     val pb = ProcessBuilder(command).directory(workDir.toFile())
 
     val process =
@@ -63,13 +68,14 @@ internal fun runProcess(
     val stdoutThread = drainStream(process.inputStream, "stdout")
     val stderrThread = drainStream(process.errorStream, "stderr")
 
-    val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+    val timeoutMillis = timeout.toMillis().coerceAtLeast(1)
+    val finished = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
     if (!finished) {
         process.destroyForcibly()
         closeProcessStreams(process)
         stdoutThread.join(TIMEOUT_DRAIN_JOIN_MILLIS)
         stderrThread.join(TIMEOUT_DRAIN_JOIN_MILLIS)
-        logger.warn("Process ${command.first()} timed out after ${timeoutSeconds}s")
+        logger.warn("Process ${command.first()} timed out after $timeout")
         return null
     }
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategy.kt
@@ -7,11 +7,12 @@ import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.runProcess
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.streams.toList
 
 internal open class GradlePluginStrategy(
     private val logger: RunnerLogger,
-    private val timeoutSeconds: Long,
+    private val timeout: Duration,
     private val rewritePluginVersion: String
 ) : PluginBuildStrategy {
     override fun run(
@@ -149,7 +150,8 @@ internal open class GradlePluginStrategy(
     open fun execute(projectDir: Path, command: List<String>): Int? = runProcess(
         workDir = projectDir,
         command = command,
-        timeoutSeconds = timeoutSeconds,
+        timeout = timeout,
+        timeoutName = "pluginTimeout",
         logger = logger
     )
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
@@ -6,6 +6,7 @@ import io.github.skhokhlov.rewriterunner.lst.utils.resolveMavenCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.runProcess
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.exists
 import kotlin.streams.toList
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader
@@ -15,7 +16,7 @@ private val MAVEN_PATCH_PATH: Path = Path.of("target/site/rewrite/rewrite.patch"
 
 internal open class MavenPluginStrategy(
     private val logger: RunnerLogger,
-    private val timeoutSeconds: Long,
+    private val timeout: Duration,
     private val rewritePluginVersion: String
 ) : PluginBuildStrategy {
     override fun run(
@@ -87,7 +88,8 @@ internal open class MavenPluginStrategy(
     open fun execute(projectDir: Path, command: List<String>): Int? = runProcess(
         workDir = projectDir,
         command = command,
-        timeoutSeconds = timeoutSeconds,
+        timeout = timeout,
+        timeoutName = "pluginTimeout",
         logger = logger
     )
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunner.kt
@@ -7,17 +7,18 @@ import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
 import io.github.skhokhlov.rewriterunner.lst.utils.hasBuildGradle
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.exists
 
 internal class PluginRecipeRunner(
     private val logger: RunnerLogger = NoOpRunnerLogger,
-    timeoutSeconds: Long = DEFAULT_TIMEOUT_SECONDS,
+    timeout: Duration = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
     rewriteGradlePluginVersion: String = ToolConfig.REWRITE_GRADLE_PLUGIN_VERSION,
     rewriteMavenPluginVersion: String = ToolConfig.REWRITE_MAVEN_PLUGIN_VERSION,
     private val gradleStrategy: PluginBuildStrategy =
-        GradlePluginStrategy(logger, timeoutSeconds, rewriteGradlePluginVersion),
+        GradlePluginStrategy(logger, timeout, rewriteGradlePluginVersion),
     private val mavenStrategy: PluginBuildStrategy =
-        MavenPluginStrategy(logger, timeoutSeconds, rewriteMavenPluginVersion)
+        MavenPluginStrategy(logger, timeout, rewriteMavenPluginVersion)
 ) {
     /**
      * Tries Gradle before Maven when both root build files are present.
@@ -85,9 +86,5 @@ internal class PluginRecipeRunner(
             .takeIf { it.isNotEmpty() }
             ?.let { PluginRunResult.Failed(it.joinToString(" ; ") { failure -> failure.reason }) }
             ?: PluginRunResult.Skipped("no supported build tool found")
-    }
-
-    companion object {
-        const val DEFAULT_TIMEOUT_SECONDS = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS
     }
 }

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/AetherContextTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/AetherContextTest.kt
@@ -4,10 +4,12 @@ import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.eclipse.aether.ConfigurationProperties
 import org.eclipse.aether.repository.RepositoryPolicy
 import org.eclipse.aether.util.graph.selector.AndDependencySelector
 
@@ -116,6 +118,23 @@ class AetherContextTest :
                 1,
                 ctx.session.configProperties["aether.connector.basic.threads"],
                 "Download threads should be 1"
+            )
+        }
+
+        test("build converts resolver Duration values to millisecond config properties") {
+            val ctx = AetherContext.build(
+                localRepoDir = tempDir.resolve("repo"),
+                connectTimeout = Duration.ofMillis(12_345),
+                requestTimeout = Duration.ofSeconds(67),
+                logger = NoOpRunnerLogger
+            )
+            assertEquals(
+                12_345,
+                ctx.session.configProperties[ConfigurationProperties.CONNECT_TIMEOUT]
+            )
+            assertEquals(
+                67_000,
+                ctx.session.configProperties[ConfigurationProperties.REQUEST_TIMEOUT]
             )
         }
 

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerBuilderTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.time.Duration
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -136,14 +137,14 @@ class RewriteRunnerBuilderTest :
                 RewriteRunner.builder()
                     .projectDir(tempDir)
                     .activeRecipe("org.openrewrite.FindSourceFiles")
-                    .processTimeoutSeconds(45)
-                    .pluginTimeoutSeconds(900)
-                    .resolverConnectTimeoutMs(10_000)
-                    .resolverRequestTimeoutMs(20_000)
-            assertEquals(45L, builder.processTimeoutSeconds)
-            assertEquals(900L, builder.pluginTimeoutSeconds)
-            assertEquals(10_000, builder.resolverConnectTimeoutMs)
-            assertEquals(20_000, builder.resolverRequestTimeoutMs)
+                    .processTimeout(Duration.ofSeconds(45))
+                    .pluginTimeout(Duration.ofMinutes(15))
+                    .resolverConnectTimeout(Duration.ofSeconds(10))
+                    .resolverRequestTimeout(Duration.ofSeconds(20))
+            assertEquals(Duration.ofSeconds(45), builder.processTimeout)
+            assertEquals(Duration.ofMinutes(15), builder.pluginTimeout)
+            assertEquals(Duration.ofSeconds(10), builder.resolverConnectTimeout)
+            assertEquals(Duration.ofSeconds(20), builder.resolverRequestTimeout)
         }
 
         test("builder stores includeExtensions") {
@@ -180,10 +181,10 @@ class RewriteRunnerBuilderTest :
 
         test("timeout overrides default to null") {
             val builder = RewriteRunner.builder()
-            assertNull(builder.processTimeoutSeconds)
-            assertNull(builder.pluginTimeoutSeconds)
-            assertNull(builder.resolverConnectTimeoutMs)
-            assertNull(builder.resolverRequestTimeoutMs)
+            assertNull(builder.processTimeout)
+            assertNull(builder.pluginTimeout)
+            assertNull(builder.resolverConnectTimeout)
+            assertNull(builder.resolverRequestTimeout)
         }
 
         test("rewriteConfig defaults to null") {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
@@ -4,6 +4,7 @@ import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
@@ -135,6 +136,40 @@ class RewriteRunnerTest :
                 .build()
                 .run()
             // No assertion needed — the test passes if no exception is thrown
+        }
+
+        // ─── timeout propagation ────────────────────────────────────────────────
+
+        test("builder process timeout override reaches fallback ToolConfig").config(
+            enabled = !isWindows
+        ) {
+            projectDir.resolve("pom.xml").writeText("<project/>")
+            projectDir.resolve("Hello.java").writeText("class Hello {}")
+            val completedMarker = projectDir.resolve("mvnw-completed")
+            val mvnw = projectDir.resolve("mvnw").toFile()
+            mvnw.writeText(
+                """
+                #!/bin/sh
+                sleep 2
+                touch "${completedMarker.toAbsolutePath()}"
+                exit 0
+                """.trimIndent()
+            )
+            mvnw.setExecutable(true)
+
+            RewriteRunner.builder()
+                .projectDir(projectDir)
+                .activeRecipe("org.openrewrite.FindSourceFiles")
+                .cacheDir(cacheDir)
+                .skipPluginRun(true)
+                .processTimeout(Duration.ofMillis(100))
+                .build()
+                .run()
+
+            assertFalse(
+                completedMarker.exists(),
+                "Configured process timeout should stop the wrapper before it completes"
+            )
         }
 
         // ─── plugin version config ──────────────────────────────────────────────

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfigTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfigTest.kt
@@ -5,8 +5,10 @@ import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -193,24 +195,69 @@ class ToolConfigTest :
         test("timeout settings default to central execution defaults") {
             val config = ToolConfig(logger = NoOpRunnerLogger)
             assertEquals(
-                ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT_SECONDS,
-                config.processTimeoutSeconds
+                ExecutionTimeouts.DEFAULT_PROCESS_TIMEOUT,
+                config.processTimeout
             )
             assertEquals(
-                ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
-                config.pluginTimeoutSeconds
+                ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
+                config.pluginTimeout
             )
             assertEquals(
-                ExecutionTimeouts.DEFAULT_RESOLVER_CONNECT_TIMEOUT_MS,
-                config.resolverConnectTimeoutMs
+                ExecutionTimeouts.DEFAULT_RESOLVER_CONNECT_TIMEOUT,
+                config.resolverConnectTimeout
             )
             assertEquals(
-                ExecutionTimeouts.DEFAULT_RESOLVER_REQUEST_TIMEOUT_MS,
-                config.resolverRequestTimeoutMs
+                ExecutionTimeouts.DEFAULT_RESOLVER_REQUEST_TIMEOUT,
+                config.resolverRequestTimeout
             )
         }
 
-        test("loads timeout settings from yaml") {
+        test("loads human unit timeout settings from yaml") {
+            val configFile = tempDir.resolve("runner.yml")
+            configFile.writeText(
+                """
+                processTimeout: 45s
+                pluginTimeout: 15m
+                resolverConnectTimeout: 10000ms
+                resolverRequestTimeout: 20s
+                """.trimIndent()
+            )
+            val config = ToolConfig.load(configFile, NoOpRunnerLogger)
+            assertEquals(Duration.ofSeconds(45), config.processTimeout)
+            assertEquals(Duration.ofMinutes(15), config.pluginTimeout)
+            assertEquals(Duration.ofMillis(10_000), config.resolverConnectTimeout)
+            assertEquals(Duration.ofSeconds(20), config.resolverRequestTimeout)
+        }
+
+        test("loads ISO-8601 timeout settings from yaml") {
+            val configFile = tempDir.resolve("runner.yml")
+            configFile.writeText(
+                """
+                processTimeout: PT2M
+                pluginTimeout: PT10M
+                resolverConnectTimeout: PT30S
+                resolverRequestTimeout: PT1M
+                """.trimIndent()
+            )
+            val config = ToolConfig.load(configFile, NoOpRunnerLogger)
+            assertEquals(Duration.ofMinutes(2), config.processTimeout)
+            assertEquals(Duration.ofMinutes(10), config.pluginTimeout)
+            assertEquals(Duration.ofSeconds(30), config.resolverConnectTimeout)
+            assertEquals(Duration.ofMinutes(1), config.resolverRequestTimeout)
+        }
+
+        test("bare numeric timeout values are rejected") {
+            val configFile = tempDir.resolve("runner.yml")
+            configFile.writeText("processTimeout: 120")
+
+            val error = assertFailsWith<IllegalArgumentException> {
+                ToolConfig.load(configFile, NoOpRunnerLogger)
+            }
+            assertTrue(error.message.orEmpty().contains("processTimeout"))
+            assertTrue(error.message.orEmpty().contains("unit"))
+        }
+
+        test("legacy timeout field names are rejected with migration guidance") {
             val configFile = tempDir.resolve("runner.yml")
             configFile.writeText(
                 """
@@ -220,11 +267,29 @@ class ToolConfigTest :
                 resolverRequestTimeoutMs: 20000
                 """.trimIndent()
             )
+
+            val error = assertFailsWith<IllegalArgumentException> {
+                ToolConfig.load(configFile, NoOpRunnerLogger)
+            }
+            assertTrue(error.message.orEmpty().contains("processTimeoutSeconds"))
+            assertTrue(error.message.orEmpty().contains("use 'processTimeout'"))
+        }
+
+        test("legacy timeout names inside block scalar content are not rejected") {
+            val configFile = tempDir.resolve("runner.yml")
+            configFile.writeText(
+                """
+                processTimeout: 120s
+                notes: |
+                  Example legacy config:
+                  processTimeoutSeconds: 45
+                  pluginTimeoutSeconds: 900
+                """.trimIndent()
+            )
+
             val config = ToolConfig.load(configFile, NoOpRunnerLogger)
-            assertEquals(45L, config.processTimeoutSeconds)
-            assertEquals(900L, config.pluginTimeoutSeconds)
-            assertEquals(10_000, config.resolverConnectTimeoutMs)
-            assertEquals(20_000, config.resolverRequestTimeoutMs)
+
+            assertEquals(Duration.ofSeconds(120), config.processTimeout)
         }
 
         // ─── OpenRewrite plugin versions ─────────────────────────────────────────

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageTest.kt
@@ -8,6 +8,7 @@ import io.github.skhokhlov.rewriterunner.lst.utils.StaticBuildFileParser
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import java.util.jar.JarOutputStream
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
@@ -64,7 +65,7 @@ class DependencyResolutionStageTest :
                 DependencyResolutionStage(
                     AetherContext.build(cacheDir.resolve("repository"), logger = NoOpRunnerLogger),
                     NoOpRunnerLogger,
-                    processTimeoutSeconds = 1
+                    processTimeout = Duration.ofSeconds(1)
                 )
 
             val start = System.currentTimeMillis()

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
@@ -4,6 +4,7 @@ import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.writeText
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -277,7 +278,8 @@ class ProjectBuildStageTest :
             )
             mvnw.setExecutable(true)
 
-            val timedStage = ProjectBuildStage(NoOpRunnerLogger, processTimeoutSeconds = 1)
+            val timedStage =
+                ProjectBuildStage(NoOpRunnerLogger, processTimeout = Duration.ofSeconds(1))
             val start = System.currentTimeMillis()
             val result = timedStage.extractClasspath(projectDir)
             val elapsed = System.currentTimeMillis() - start

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/MarkerFactoryTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/MarkerFactoryTest.kt
@@ -4,6 +4,7 @@ import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import org.openrewrite.marker.BuildTool
@@ -20,18 +21,18 @@ class MarkerFactoryTest :
             projectDir.resolve("pom.xml").writeText("<project/>")
             projectDir.resolve("mvnw").writeText("")
             var observedCommand: List<String>? = null
-            var observedTimeoutSeconds: Long? = null
+            var observedTimeout: Duration? = null
 
             val factory =
                 MarkerFactory(
                     logger = NoOpRunnerLogger,
                     staticParser = StaticBuildFileParser(NoOpRunnerLogger),
                     versionDetector = VersionDetector(NoOpRunnerLogger),
-                    processTimeoutSeconds = 20,
-                    processRunner = { workDir, command, _, timeoutSeconds, _ ->
+                    processTimeout = Duration.ofSeconds(20),
+                    processRunner = { workDir, command, _, timeout, _, _ ->
                         assertEquals(projectDir, workDir)
                         observedCommand = command
-                        observedTimeoutSeconds = timeoutSeconds
+                        observedTimeout = timeout
                         null
                     }
                 )
@@ -41,6 +42,6 @@ class MarkerFactoryTest :
             assertEquals(BuildTool.Type.Maven, marker?.type)
             assertEquals("unknown", marker?.version)
             assertEquals(listOf("./mvnw", "--version"), observedCommand)
-            assertEquals(5L, observedTimeoutSeconds)
+            assertEquals(Duration.ofSeconds(5), observedTimeout)
         }
     })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategyTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategyTest.kt
@@ -7,6 +7,7 @@ import io.github.skhokhlov.rewriterunner.config.ToolConfig.Companion.REWRITE_GRA
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Duration
 import kotlin.io.path.createDirectories
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
@@ -30,7 +31,7 @@ class GradlePluginStrategyTest :
             val strategy =
                 GradlePluginStrategy(
                     NoOpRunnerLogger,
-                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     REWRITE_GRADLE_PLUGIN_VERSION
                 )
 
@@ -57,7 +58,7 @@ class GradlePluginStrategyTest :
             val strategy =
                 GradlePluginStrategy(
                     logger = NoOpRunnerLogger,
-                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    timeout = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     rewritePluginVersion = "7.20.0"
                 )
 
@@ -77,7 +78,7 @@ class GradlePluginStrategyTest :
         test("generateInitScript adds repositories for plugin management and all projects") {
             val strategy = GradlePluginStrategy(
                 logger = NoOpRunnerLogger,
-                timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                timeout = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                 rewritePluginVersion = "7.20.0"
             )
 
@@ -115,7 +116,7 @@ class GradlePluginStrategyTest :
         test("generateInitScript adds recipe artifacts to root rewrite configuration only") {
             val strategy = GradlePluginStrategy(
                 logger = NoOpRunnerLogger,
-                timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                timeout = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                 rewritePluginVersion = "7.20.0"
             )
 
@@ -148,7 +149,7 @@ class GradlePluginStrategyTest :
             val strategy =
                 object : GradlePluginStrategy(
                     logger = NoOpRunnerLogger,
-                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    timeout = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? {
@@ -192,7 +193,7 @@ class GradlePluginStrategyTest :
             val strategy =
                 object : GradlePluginStrategy(
                     logger = NoOpRunnerLogger,
-                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    timeout = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? {
@@ -247,7 +248,7 @@ class GradlePluginStrategyTest :
             val strategy =
                 object : GradlePluginStrategy(
                     logger = NoOpRunnerLogger,
-                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    timeout = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? = 0
@@ -272,7 +273,7 @@ class GradlePluginStrategyTest :
             val strategy =
                 object : GradlePluginStrategy(
                     logger = NoOpRunnerLogger,
-                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    timeout = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? = null
@@ -300,7 +301,7 @@ class GradlePluginStrategyTest :
             val strategy =
                 object : GradlePluginStrategy(
                     logger = NoOpRunnerLogger,
-                    timeoutSeconds = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    timeout = ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     rewritePluginVersion = REWRITE_GRADLE_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? {
@@ -351,7 +352,7 @@ class GradlePluginStrategyTest :
             val strategy =
                 GradlePluginStrategy(
                     NoOpRunnerLogger,
-                    timeoutSeconds = 1,
+                    timeout = Duration.ofSeconds(1),
                     REWRITE_GRADLE_PLUGIN_VERSION
                 )
             val start = System.currentTimeMillis()

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
@@ -28,7 +28,7 @@ class MavenPluginStrategyTest :
             val strategy =
                 MavenPluginStrategy(
                     NoOpRunnerLogger,
-                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     REWRITE_MAVEN_PLUGIN_VERSION
                 )
 
@@ -61,7 +61,7 @@ class MavenPluginStrategyTest :
             val strategy =
                 MavenPluginStrategy(
                     logger = NoOpRunnerLogger,
-                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     REWRITE_MAVEN_PLUGIN_VERSION
                 )
 
@@ -86,7 +86,7 @@ class MavenPluginStrategyTest :
             val strategy =
                 object : MavenPluginStrategy(
                     NoOpRunnerLogger,
-                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     REWRITE_MAVEN_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? = 1
@@ -112,7 +112,7 @@ class MavenPluginStrategyTest :
             val strategy =
                 object : MavenPluginStrategy(
                     NoOpRunnerLogger,
-                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     REWRITE_MAVEN_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? {
@@ -181,7 +181,7 @@ class MavenPluginStrategyTest :
             val strategy =
                 object : MavenPluginStrategy(
                     NoOpRunnerLogger,
-                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     REWRITE_MAVEN_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? {
@@ -262,7 +262,7 @@ class MavenPluginStrategyTest :
             val strategy =
                 object : MavenPluginStrategy(
                     NoOpRunnerLogger,
-                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT_SECONDS,
+                    ExecutionTimeouts.DEFAULT_PLUGIN_TIMEOUT,
                     REWRITE_MAVEN_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeArtifactResolverTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeArtifactResolverTest.kt
@@ -254,7 +254,7 @@ class RecipeArtifactResolverTest :
         // ─── Timeout behaviour ────────────────────────────────────────────────────
 
         test(
-            "resolve completes within requestTimeoutMs when remote server accepts but never responds"
+            "resolve completes within resolver request timeout when remote server accepts but never responds"
         ) {
             // Regression test: without an explicit REQUEST_TIMEOUT the Maven Resolver
             // default is 30 minutes, causing the process to hang indefinitely when a
@@ -303,7 +303,7 @@ class RecipeArtifactResolverTest :
             blackHole.close()
             assertTrue(
                 elapsedMs < 10_000,
-                "resolve() must honour requestTimeoutMs and complete in <10 s; took ${elapsedMs}ms"
+                "resolve() must honour resolver request timeout and complete in <10 s; took ${elapsedMs}ms"
             )
         }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,10 +86,10 @@ External process timeouts are configurable:
 
 | Timeout | Default | Applies to |
 |---------|---------|------------|
-| `pluginTimeoutSeconds` | 600 s | Stage 0 `rewriteDryRun` / `rewriteRun` plugin invocations |
-| `processTimeoutSeconds` | 120 s | Stage 1/2 build-tool subprocesses, compile attempts, and build-tool metadata commands |
-| `resolverConnectTimeoutMs` | 30000 ms | Maven Resolver TCP connections |
-| `resolverRequestTimeoutMs` | 60000 ms | Maven Resolver socket reads / requests |
+| `pluginTimeout` | `10m` | Stage 0 `rewriteDryRun` / `rewriteRun` plugin invocations |
+| `processTimeout` | `120s` | Stage 1/2 build-tool subprocesses, compile attempts, and build-tool metadata commands |
+| `resolverConnectTimeout` | `30s` | Maven Resolver TCP connections |
+| `resolverRequestTimeout` | `60s` | Maven Resolver socket reads / requests |
 
 Stage 0 plugin versions are also configurable via `rewriteGradlePluginVersion`
 and `rewriteMavenPluginVersion`.

--- a/docs/dependency-resolution.md
+++ b/docs/dependency-resolution.md
@@ -96,5 +96,5 @@ Both recipe and project `AetherContext` instances apply the following settings:
 | Repository `checksumPolicy` | `CHECKSUM_POLICY_IGNORE` | Don't fail or retry when a repository omits `.sha1` / `.sha256` files (common on corporate proxies and private registries) |
 | Repository update policy | `UPDATE_POLICY_DAILY` | Re-check remote metadata at most once per day; cached artifacts are reused within a day |
 | Parallel download threads | configurable (`--download-threads`, default 5) | Tune for network bandwidth vs resource constraints |
-| `CONNECT_TIMEOUT` | configurable (`resolverConnectTimeoutMs`, default 30 s) | Avoid hanging on slow connections |
-| `REQUEST_TIMEOUT` | configurable (`resolverRequestTimeoutMs`, default 60 s) | Abort if a server accepts the connection but never responds |
+| `CONNECT_TIMEOUT` | configurable (`resolverConnectTimeout`, default `30s`) | Avoid hanging on slow connections |
+| `REQUEST_TIMEOUT` | configurable (`resolverRequestTimeout`, default `60s`) | Abort if a server accepts the connection but never responds |

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -5,10 +5,13 @@
 Programmatic entry point. Use `RewriteRunner.builder()` to configure, `.build().run()` to execute.
 
 ```kotlin
+import java.time.Duration
+
 val result = RewriteRunner.builder()
     .projectDir(Paths.get("/path/to/project"))
     .activeRecipe("org.openrewrite.java.format.AutoFormat")
     .recipeArtifact("org.openrewrite.recipe:rewrite-java:LATEST")
+    .processTimeout(Duration.ofSeconds(120))
     .dryRun(true)
     .build()
     .run()
@@ -28,10 +31,10 @@ val result = RewriteRunner.builder()
 | `configFile(Path)` | `Path?` | `<projectDir>/rewriterunner.yml`, then `~/.rewriterunner/rewriterunner.yml` | `rewriterunner.yml` tool config (case-insensitive name match). Pass `null` to use auto-discovery. |
 | `dryRun(Boolean)` | `Boolean` | `false` | Run without writing files to disk |
 | `skipPluginRun(Boolean)` | `Boolean` | `false` | Bypass official Gradle/Maven plugin execution and use the in-process LST pipeline directly |
-| `processTimeoutSeconds(Long)` | `Long?` | from config / `120` | Timeout for build-tool subprocesses in the fallback LST pipeline |
-| `pluginTimeoutSeconds(Long)` | `Long?` | from config / `600` | Timeout for official Gradle/Maven plugin invocations in Stage 0 |
-| `resolverConnectTimeoutMs(Int)` | `Int?` | from config / `30000` | TCP connection timeout for Maven Resolver artifact downloads |
-| `resolverRequestTimeoutMs(Int)` | `Int?` | from config / `60000` | Socket read/request timeout for Maven Resolver artifact downloads |
+| `processTimeout(Duration)` | `Duration?` | from config / `120s` | Timeout for build-tool subprocesses in the fallback LST pipeline |
+| `pluginTimeout(Duration)` | `Duration?` | from config / `10m` | Timeout for official Gradle/Maven plugin invocations in Stage 0 |
+| `resolverConnectTimeout(Duration)` | `Duration?` | from config / `30s` | TCP connection timeout for Maven Resolver artifact downloads |
+| `resolverRequestTimeout(Duration)` | `Duration?` | from config / `60s` | Socket read/request timeout for Maven Resolver artifact downloads |
 | `includeExtensions(List<String>)` | `List` | `[]` | Restrict to these extensions (e.g. `[".java", ".kt"]`); overrides `parse.includeExtensions` from config file |
 | `excludeExtensions(List<String>)` | `List` | `[]` | Skip these extensions; overrides `parse.excludeExtensions` from config file |
 | `excludePaths(List<String>)` | `List` | `[]` | Glob patterns (relative to project root) to skip during parsing; overrides `parse.excludePaths` from config file |
@@ -131,7 +134,7 @@ Use `format(runResult)` when you want formatted output that also supports Stage 
 
 ## ToolConfig YAML
 
-Config file (`rewriterunner.yml`) loaded via `--config` CLI flag or `configFile()` builder method. File name matching is case-insensitive. Auto-discovered from `<projectDir>/rewriterunner.yml` (project-level) then `~/.rewriterunner/rewriterunner.yml` (global fallback) when not explicitly provided. Supports `${ENV_VAR}` interpolation and `~` expansion in all string fields.
+Config file (`rewriterunner.yml`) loaded via `--config` CLI flag or `configFile()` builder method. File name matching is case-insensitive. Auto-discovered from `<projectDir>/rewriterunner.yml` (project-level) then `~/.rewriterunner/rewriterunner.yml` (global fallback) when not explicitly provided. Supports `${ENV_VAR}` interpolation and `~` expansion in all string fields. Duration fields require units such as `30000ms`, `120s`, `10m`, `2h`, or ISO-8601 values like `PT2M`.
 
 ```yaml
 cacheDir: ~/.rewriterunner/cache   # default
@@ -146,12 +149,12 @@ parse:
   excludeExtensions: [".xml"]           # skip these; overridden by CLI flag
   excludePaths: ["generated/", "vendor/"] # glob patterns relative to project root
 
-processTimeoutSeconds: 120
-pluginTimeoutSeconds: 600
+processTimeout: 120s
+pluginTimeout: 10m
 rewriteGradlePluginVersion: 7.32.1
 rewriteMavenPluginVersion: 6.38.0
-resolverConnectTimeoutMs: 30000
-resolverRequestTimeoutMs: 60000
+resolverConnectTimeout: 30s
+resolverRequestTimeout: 60s
 ```
 
 ### ToolConfig fields
@@ -162,12 +165,12 @@ resolverRequestTimeoutMs: 60000
 | `repositories` | `List<RepositoryConfig>` | `[]` | Extra Maven repos for resolution |
 | `parse` | `ParseConfig` | defaults | File inclusion/exclusion config |
 | `includeMavenCentral` | `Boolean` | `true` | Include Maven Central as a remote repository. Set `false` to restrict to only the repositories listed in `repositories`. |
-| `processTimeoutSeconds` | `Long` | `120` | Timeout for Stage 1/2 build-tool subprocesses, compile attempts, and build-tool metadata commands. |
-| `pluginTimeoutSeconds` | `Long` | `600` | Timeout for Stage 0 official OpenRewrite plugin invocations. |
+| `processTimeout` | `Duration` | `120s` | Timeout for Stage 1/2 build-tool subprocesses, compile attempts, and build-tool metadata commands. |
+| `pluginTimeout` | `Duration` | `10m` | Timeout for Stage 0 official OpenRewrite plugin invocations. |
 | `rewriteGradlePluginVersion` | `String` | `7.32.1` | Version of `org.openrewrite:plugin` used for Stage 0 Gradle plugin execution. |
 | `rewriteMavenPluginVersion` | `String` | `6.38.0` | Version of `org.openrewrite.maven:rewrite-maven-plugin` used for Stage 0 Maven plugin execution. |
-| `resolverConnectTimeoutMs` | `Int` | `30000` | TCP connection timeout for Maven Resolver artifact downloads. |
-| `resolverRequestTimeoutMs` | `Int` | `60000` | Socket read/request timeout for Maven Resolver artifact downloads. |
+| `resolverConnectTimeout` | `Duration` | `30s` | TCP connection timeout for Maven Resolver artifact downloads. |
+| `resolverRequestTimeout` | `Duration` | `60s` | Socket read/request timeout for Maven Resolver artifact downloads. |
 
 ### RepositoryConfig fields
 


### PR DESCRIPTION
…mitives to java.time.Duration.

Make this a breaking rename: old CLI flags, YAML fields, and builder methods are removed rather than kept as aliases. Use human duration literals as the documented format, e.g. 120s, 10m, 30000ms; also accept ISO-8601 java.time.Duration strings like PT2M.