### PR TITLE
fix(lst): close pom.xml streams passed to MavenXpp3Reader

### DIFF
--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStage.kt
@@ -158,7 +158,8 @@ open class BuildFileParseStage(
     private fun collectModuleDirs(dir: Path, found: MutableSet<Path>, depth: Int) {
         if (depth >= 3) return
         try {
-            val model = MavenXpp3Reader().read(dir.resolve("pom.xml").toFile().inputStream())
+            val model =
+                dir.resolve("pom.xml").toFile().inputStream().use { MavenXpp3Reader().read(it) }
             for (module in model.modules) {
                 val moduleDir = dir.resolve(module)
                 if (moduleDir.resolve("pom.xml").exists() && found.add(moduleDir)) {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/StaticBuildFileParser.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/StaticBuildFileParser.kt
@@ -34,7 +34,7 @@ internal class StaticBuildFileParser(private val logger: RunnerLogger) {
     fun parseMavenDependencies(projectDir: Path): List<String> {
         val pomFile = projectDir.resolve("pom.xml")
         return try {
-            val model = MavenXpp3Reader().read(pomFile.toFile().inputStream())
+            val model = pomFile.toFile().inputStream().use { MavenXpp3Reader().read(it) }
             model.dependencies
                 .filter { it.scope !in listOf("runtime", "system") }
                 .mapNotNull { dep ->

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/VersionDetector.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/VersionDetector.kt
@@ -111,7 +111,8 @@ internal class VersionDetector(private val logger: RunnerLogger) {
      */
     private fun detectMavenKotlinVersion(dir: Path): Pair<String, String>? {
         return try {
-            val model = MavenXpp3Reader().read(dir.resolve("pom.xml").toFile().inputStream())
+            val model =
+                dir.resolve("pom.xml").toFile().inputStream().use { MavenXpp3Reader().read(it) }
             val kotlinPlugin = model.build?.plugins?.find { it.artifactId == "kotlin-maven-plugin" }
             val dom = kotlinPlugin?.configuration as? Xpp3Dom
             val jvmTarget = dom?.getChild("jvmTarget")?.value
@@ -158,7 +159,8 @@ internal class VersionDetector(private val logger: RunnerLogger) {
     private fun detectMavenJavaVersion(projectDir: Path): Pair<String, String>? {
         return try {
             val model =
-                MavenXpp3Reader().read(projectDir.resolve("pom.xml").toFile().inputStream())
+                projectDir.resolve("pom.xml").toFile().inputStream()
+                    .use { MavenXpp3Reader().read(it) }
 
             val compilerPlugin =
                 model.build?.plugins?.find { it.artifactId == "maven-compiler-plugin" }

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/PomFileHandleLeakTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/PomFileHandleLeakTest.kt
@@ -1,0 +1,108 @@
+package io.github.skhokhlov.rewriterunner.lst.utils
+
+import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests guarding against file-descriptor leaks when reading `pom.xml`
+ * via `MavenXpp3Reader`. The reader does not close streams it is given, so each
+ * call site must wrap the input stream in `.use { }`.
+ *
+ * Strategy: count entries under `/proc/self/fd` (Linux) or `/dev/fd` (macOS)
+ * before and after a tight loop. If a call site leaks one FD per invocation,
+ * the count grows by [LOOP_COUNT]; with the fix it stays within a small constant.
+ */
+class PomFileHandleLeakTest :
+    FunSpec({
+        // Per-process FD directory. Null on platforms without one (e.g. Windows);
+        // tests below short-circuit when null.
+        val fdDir =
+            listOf(Path.of("/proc/self/fd"), Path.of("/dev/fd"))
+                .firstOrNull { Files.exists(it) }
+
+        val pomXml =
+            """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>leak-probe</artifactId>
+                <version>1.0</version>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <release>17</release>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <artifactId>kotlin-maven-plugin</artifactId>
+                            <configuration>
+                                <jvmTarget>17</jvmTarget>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+            """.trimIndent()
+
+        fun openFdCount(): Int = Files.list(fdDir!!).use { it.count().toInt() }
+
+        var projectDir: Path = Path.of("")
+        beforeEach {
+            projectDir = Files.createTempDirectory("pomleak-")
+            projectDir.resolve("pom.xml").writeText(pomXml)
+        }
+        afterEach { projectDir.toFile().deleteRecursively() }
+
+        // Allow some slack: GC, JIT, classloader caches, etc. may open a few FDs.
+        val tolerance = 25
+        val loopCount = 200
+
+        test("StaticBuildFileParser.parseMavenDependencies does not leak file handles") {
+            if (fdDir == null) return@test
+            val parser = StaticBuildFileParser(NoOpRunnerLogger)
+            // Warm up so any one-shot caches are populated before measuring.
+            repeat(5) { parser.parseMavenDependencies(projectDir) }
+
+            val before = openFdCount()
+            repeat(loopCount) { parser.parseMavenDependencies(projectDir) }
+            val after = openFdCount()
+
+            assertTrue(
+                after - before < tolerance,
+                "Expected FD count to stay bounded; before=$before after=$after"
+            )
+        }
+
+        test("VersionDetector reads pom.xml without leaking file handles") {
+            if (fdDir == null) return@test
+            val detector = VersionDetector(NoOpRunnerLogger)
+            val sourceFile = projectDir.resolve("src/main/java/Demo.java")
+            Files.createDirectories(sourceFile.parent)
+            sourceFile.writeText("class Demo {}")
+
+            // Warm up.
+            repeat(5) {
+                detector.detectJavaVersionForFile(sourceFile, projectDir, mutableMapOf())
+                detector.detectKotlinVersionForFile(sourceFile, projectDir, mutableMapOf())
+            }
+
+            val before = openFdCount()
+            repeat(loopCount) {
+                // Fresh cache each time so the pom.xml is actually re-read.
+                detector.detectJavaVersionForFile(sourceFile, projectDir, mutableMapOf())
+                detector.detectKotlinVersionForFile(sourceFile, projectDir, mutableMapOf())
+            }
+            val after = openFdCount()
+
+            assertTrue(
+                after - before < tolerance,
+                "Expected FD count to stay bounded; before=$before after=$after"
+            )
+        }
+    })


### PR DESCRIPTION
MavenXpp3Reader.read(InputStream) does not close the stream it is given, so each call site that passed File.inputStream() directly leaked a file descriptor per invocation. The two VersionDetector sites are the most damaging because they fire once per source file in the walk-up loop.

Wrap each read in Kotlin's .use { } and add a regression test that counts entries under /proc/self/fd or /dev/fd before and after a 200-iteration loop.