### PR TITLE
fix(lst): exclude build output descriptors from Stage 3 fallback disc…

### DIFF
--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStage.kt
@@ -2,6 +2,7 @@ package io.github.skhokhlov.rewriterunner.lst
 
 import io.github.skhokhlov.rewriterunner.AetherContext
 import io.github.skhokhlov.rewriterunner.RunnerLogger
+import io.github.skhokhlov.rewriterunner.lst.utils.FileCollector
 import io.github.skhokhlov.rewriterunner.lst.utils.StaticBuildFileParser
 import io.github.skhokhlov.rewriterunner.lst.utils.hasBuildGradle
 import java.nio.file.Files
@@ -54,6 +55,7 @@ open class BuildFileParseStage(
     private val aetherContext: AetherContext,
     private val logger: RunnerLogger
 ) {
+    private val descriptorDiscoveryExcludedDirNames = FileCollector.DEFAULT_EXCLUDED_DIRS + "bin"
     private val staticParser = StaticBuildFileParser(logger)
 
     /**
@@ -175,7 +177,8 @@ open class BuildFileParseStage(
     private fun walkForPomDirs(projectDir: Path, found: MutableSet<Path>) {
         try {
             Files.walk(projectDir, 3).use { stream ->
-                stream.filter { path -> path.fileName?.toString() == "pom.xml" }
+                stream.filter { path -> !isInDescriptorDiscoveryExcludedDir(projectDir, path) }
+                    .filter { path -> path.fileName?.toString() == "pom.xml" }
                     .forEach { pomFile -> found.add(pomFile.parent) }
             }
         } catch (e: Exception) {
@@ -194,6 +197,7 @@ open class BuildFileParseStage(
         try {
             Files.walk(projectDir, 3).use { stream ->
                 stream.filter { path ->
+                    if (isInDescriptorDiscoveryExcludedDir(projectDir, path)) return@filter false
                     val name = path.fileName?.toString() ?: return@filter false
                     path.parent != projectDir &&
                         (name == "build.gradle" || name == "build.gradle.kts")
@@ -205,5 +209,12 @@ open class BuildFileParseStage(
             logger.warn("Stage 3: failed to walk Gradle build files in subdirs: ${e.message}")
         }
         return coords
+    }
+
+    private fun isInDescriptorDiscoveryExcludedDir(projectDir: Path, path: Path): Boolean {
+        val relative = projectDir.relativize(path)
+        return relative.any { segment ->
+            segment.fileName?.toString() in descriptorDiscoveryExcludedDirNames
+        }
     }
 }

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStageTest.kt
@@ -188,6 +188,82 @@ class BuildFileParseStageTest :
             assertTrue(capturedCoords.any { it.contains("commons-lang3") })
         }
 
+        test("Maven fallback discovery ignores pom.xml files in build output dirs") {
+            resetTracking()
+            val appDir = projectDir.resolve("app").also { it.createDirectories() }
+            appDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>app</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                            <version>3.12.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """.trimIndent()
+            )
+            val targetDir = appDir.resolve("target").also { it.createDirectories() }
+            targetDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example.generated</groupId>
+                    <artifactId>generated</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                            <version>32.0.0-jre</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """.trimIndent()
+            )
+
+            fakeStage().resolveClasspath(projectDir)
+
+            assertTrue(traversalCalled)
+            assertTrue(capturedCoords.any { it.contains("commons-lang3") })
+            assertFalse(
+                capturedCoords.any { it.contains("guava") },
+                "Generated pom.xml under target/ must not contribute coordinates"
+            )
+        }
+
+        test("Maven fallback discovery keeps real pom.xml files at depth three") {
+            resetTracking()
+            val apiDir = projectDir.resolve("services/api").also { it.createDirectories() }
+            apiDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>api</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                            <version>2.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """.trimIndent()
+            )
+
+            fakeStage().resolveClasspath(projectDir)
+
+            assertTrue(traversalCalled)
+            assertTrue(capturedCoords.any { it == "org.slf4j:slf4j-api:2.0.0" })
+        }
+
         // ─── Maven: traversal returns JARs ────────────────────────────────────────
 
         test("Maven: resolveWithPomTraversal returns JARs → resolveClasspath returns them") {
@@ -376,6 +452,35 @@ class BuildFileParseStageTest :
 
             assertTrue(traversalCalled)
             assertTrue(capturedCoords.any { it.contains("commons-lang3") })
+        }
+
+        test("Gradle fallback discovery ignores build files in build output dirs") {
+            resetTracking()
+            val appDir = projectDir.resolve("app").also { it.createDirectories() }
+            appDir.resolve("build.gradle").writeText(
+                """
+                dependencies {
+                    implementation 'org.apache.commons:commons-lang3:3.12.0'
+                }
+                """.trimIndent()
+            )
+            val tmpDir = projectDir.resolve("build/tmp").also { it.createDirectories() }
+            tmpDir.resolve("build.gradle").writeText(
+                """
+                dependencies {
+                    implementation 'com.google.guava:guava:32.0.0-jre'
+                }
+                """.trimIndent()
+            )
+
+            fakeStage().resolveClasspath(projectDir)
+
+            assertTrue(traversalCalled)
+            assertTrue(capturedCoords.any { it.contains("commons-lang3") })
+            assertFalse(
+                capturedCoords.any { it.contains("guava") },
+                "Generated build.gradle under build/ must not contribute coordinates"
+            )
         }
 
         // ─── Mixed Maven + Gradle ─────────────────────────────────────────────────


### PR DESCRIPTION
…overy

Stage 3 fallback discovery walked project subdirectories for pom.xml and Gradle build files without filtering generated build output directories. That allowed descriptors under paths like target/, build/, .gradle/, out/, dist/, or bin/ to contribute dependency coordinates to the static classpath fallback.

Reuse the file collector's default excluded directory names, add bin for descriptor discovery, and apply the relative-path filter to both Maven and Gradle fallback walks. Declared Maven module traversal is unchanged.

Add regression coverage for generated pom.xml and build.gradle files under build output directories, while preserving discovery of legitimate build files within the existing depth limit.

Fixes #126 