### PR TITLE
feat!(core): expose ExecutionDiagnostics on RunResult

### DIFF
--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionDiagnostics.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionDiagnostics.kt
@@ -1,0 +1,37 @@
+package io.github.skhokhlov.rewriterunner
+
+/** Which path produced the recipe run (and the classpath behind it, when applicable). */
+enum class UsedExecutionStage {
+    /** Stage 0 — official OpenRewrite Gradle/Maven plugin handled the recipe internally;
+     *  we never observed the classpath directly. */
+    PLUGIN,
+
+    /** Stage 1 — project's own build tool extracted the compile classpath. */
+    BUILD_TOOL,
+
+    /** Stage 2 — `mvn dependency:tree` / `gradle dependencies` + Maven Resolver. */
+    DEPENDENCY_RESOLUTION,
+
+    /** Stage 3 — static build-file parse + POM traversal via Maven Resolver. */
+    DIRECT_PARSE,
+
+    /** Stage 4 — local Maven/Gradle cache scan, no network. */
+    LOCAL_REPOSITORY
+}
+
+/**
+ * Diagnostic info about which execution path produced the run and how its classpath
+ * was assembled.
+ *
+ * @property stageUsed The stage that produced the run, or `null` when every LST
+ *   stage produced an empty classpath (recipe ran semantically blind — see #68).
+ * @property resolvedJarCount Number of `.jar` entries on the LST classpath (project
+ *   class directories excluded). `0` when [stageUsed] is [UsedExecutionStage.PLUGIN]
+ *   (the plugin handled resolution internally) or `null`.
+ */
+data class ExecutionDiagnostics(val stageUsed: UsedExecutionStage?, val resolvedJarCount: Int) {
+    companion object {
+        val PLUGIN = ExecutionDiagnostics(UsedExecutionStage.PLUGIN, 0)
+        val EMPTY = ExecutionDiagnostics(null, 0)
+    }
+}

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
@@ -3,6 +3,7 @@ package io.github.skhokhlov.rewriterunner
 import io.github.skhokhlov.rewriterunner.config.DurationParser
 import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
+import io.github.skhokhlov.rewriterunner.lst.LstBuildResult
 import io.github.skhokhlov.rewriterunner.lst.LstBuilder
 import io.github.skhokhlov.rewriterunner.plugin.PluginRecipeRunner
 import io.github.skhokhlov.rewriterunner.plugin.PluginRunResult
@@ -126,7 +127,8 @@ class RewriteRunner private constructor(private val config: Builder) {
                         results = emptyList(),
                         changedFiles = pluginResult.changedFiles,
                         projectDir = config.projectDir,
-                        rawDiffs = pluginResult.diffs
+                        rawDiffs = pluginResult.diffs,
+                        executionDiagnostics = ExecutionDiagnostics.PLUGIN
                     )
                 }
 
@@ -135,7 +137,8 @@ class RewriteRunner private constructor(private val config: Builder) {
                     return RunResult(
                         results = emptyList(),
                         changedFiles = emptyList(),
-                        projectDir = config.projectDir
+                        projectDir = config.projectDir,
+                        executionDiagnostics = ExecutionDiagnostics.PLUGIN
                     )
                 }
 
@@ -252,13 +255,14 @@ class RewriteRunner private constructor(private val config: Builder) {
                     toolConfig.parse
                 }
             val lstStart = System.currentTimeMillis()
-            val sourceFiles =
+            val lstBuildResult: LstBuildResult =
                 lstBuilder.build(
                     projectDir = config.projectDir,
                     parseConfig = effectiveParseConfig,
                     includeExtensionsCli = config.includeExtensions,
                     excludeExtensionsCli = config.excludeExtensions
                 )
+            val sourceFiles = lstBuildResult.sourceFiles
             logger.lifecycle(
                 "      LST built: ${sourceFiles.size} file(s) in ${System.currentTimeMillis() - lstStart}ms"
             )
@@ -314,7 +318,8 @@ class RewriteRunner private constructor(private val config: Builder) {
             RunResult(
                 results = results,
                 changedFiles = writtenFiles,
-                projectDir = config.projectDir
+                projectDir = config.projectDir,
+                executionDiagnostics = lstBuildResult.executionDiagnostics
             )
         }
     }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RunResult.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RunResult.kt
@@ -14,12 +14,15 @@ import org.openrewrite.Result
  * @property projectDir The project directory that was analysed, for reference.
  * @property rawDiffs Unified diffs keyed by relative file path. Populated when the
  *   plugin-first path succeeds and no raw OpenRewrite [Result] objects are available.
+ * @property executionDiagnostics Diagnostic info about which execution path produced
+ *   the run. See [ExecutionDiagnostics] and [UsedExecutionStage] for details.
  */
 data class RunResult(
     val results: List<Result>,
     val changedFiles: List<Path>,
     val projectDir: Path,
-    val rawDiffs: Map<Path, String> = emptyMap()
+    val rawDiffs: Map<Path, String> = emptyMap(),
+    val executionDiagnostics: ExecutionDiagnostics
 ) {
     /** `true` when the recipe produced at least one change, regardless of whether
      *  changes were written to disk. */

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LocalRepositoryStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LocalRepositoryStage.kt
@@ -45,7 +45,7 @@ import kotlin.io.path.exists
  * @param projectDir Root directory of the project, used to locate project-local
  *   cache roots (`.m2/repository`, `.gradle/caches`).
  */
-class LocalRepositoryStage(private val projectDir: Path, val logger: RunnerLogger) {
+open class LocalRepositoryStage(private val projectDir: Path, val logger: RunnerLogger) {
     private val m2Roots: List<Path> = listOf(
         Paths.get(System.getProperty("user.home"), ".m2", "repository"),
         projectDir.resolve(".m2").resolve("repository")
@@ -72,7 +72,7 @@ class LocalRepositoryStage(private val projectDir: Path, val logger: RunnerLogge
      *   Coordinates with no local cache hit are omitted; their types will appear as
      *   `JavaType.Unknown` in the LST.
      */
-    fun findAvailableJars(declaredCoordinates: List<String>): List<Path> {
+    open fun findAvailableJars(declaredCoordinates: List<String>): List<Path> {
         val found = mutableListOf<Path>()
         val notFound = mutableListOf<String>()
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
@@ -1,7 +1,9 @@
 package io.github.skhokhlov.rewriterunner.lst
 
 import io.github.skhokhlov.rewriterunner.AetherContext
+import io.github.skhokhlov.rewriterunner.ExecutionDiagnostics
 import io.github.skhokhlov.rewriterunner.RunnerLogger
+import io.github.skhokhlov.rewriterunner.UsedExecutionStage
 import io.github.skhokhlov.rewriterunner.config.ParseConfig
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
 import io.github.skhokhlov.rewriterunner.lst.utils.ClasspathResolutionResult
@@ -42,6 +44,12 @@ import org.openrewrite.protobuf.ProtoParser
 import org.openrewrite.toml.TomlParser
 import org.openrewrite.xml.XmlParser
 import org.openrewrite.yaml.YamlParser
+
+/** Result of a single [LstBuilder.build] invocation. */
+data class LstBuildResult(
+    val sourceFiles: List<SourceFile>,
+    val executionDiagnostics: ExecutionDiagnostics
+)
 
 /**
  * Orchestrates the 4-stage LST building pipeline and multi-language file parsing.
@@ -129,7 +137,7 @@ open class LstBuilder(
      * @param excludeExtensionsCli File extensions to skip. Overrides [parseConfig] when non-empty.
      * @param ctx OpenRewrite execution context. Defaults to an [org.openrewrite.InMemoryExecutionContext]
      *   that logs parse warnings without aborting.
-     * @return The list of all parsed [org.openrewrite.SourceFile]s, one per source file found.
+     * @return An [LstBuildResult] containing the parsed source files and execution diagnostics.
      */
     fun build(
         projectDir: Path,
@@ -137,7 +145,7 @@ open class LstBuilder(
         includeExtensionsCli: List<String> = emptyList(),
         excludeExtensionsCli: List<String> = emptyList(),
         ctx: ExecutionContext = InMemoryExecutionContext {}
-    ): List<SourceFile> {
+    ): LstBuildResult {
         val pendingErrors = mutableListOf<Throwable>()
         val parseCtx = object : DelegatingExecutionContext(ctx) {
             private val errorConsumer = Consumer<Throwable> { t ->
@@ -487,7 +495,7 @@ open class LstBuilder(
         logger.info("LST build complete: ${allSources.size} SourceFile(s)")
 
         // ── Attach provenance markers to every source file ────────────────────
-        return allSources.map { sf ->
+        val withMarkers = allSources.map { sf ->
             var markers = sf.markers
             buildEnv?.let { markers = markers.addIfAbsent(it) }
             gitProvenance?.let { markers = markers.addIfAbsent(it) }
@@ -495,6 +503,13 @@ open class LstBuilder(
             buildToolMarker?.let { markers = markers.addIfAbsent(it) }
             if (markers === sf.markers) sf else sf.withMarkers(markers)
         }
+
+        val resolvedJarCount = classpath.count { it.toString().endsWith(".jar") }
+        val diagnostics = ExecutionDiagnostics(
+            stageUsed = resolutionResult.stageUsed,
+            resolvedJarCount = resolvedJarCount
+        )
+        return LstBuildResult(withMarkers, diagnostics)
     }
 
     // ─── Overrideable parser factories (for testing fallback paths) ──────────
@@ -526,6 +541,10 @@ open class LstBuilder(
         )
         .buildscriptClasspath(gradleDslClasspath)
         .build()
+
+    /** Creates the [LocalRepositoryStage] used for Stage 4. Overrideable in tests. */
+    protected open fun createLocalRepositoryStage(projectDir: Path): LocalRepositoryStage =
+        LocalRepositoryStage(projectDir, logger)
 
     // ─── Classpath resolution (4 stages) ─────────────────────────────────────
 
@@ -614,7 +633,11 @@ open class LstBuilder(
                         "rewrite-gradle recipes may not apply. Run with --info for details."
                 )
             }
-            return ClasspathResolutionResult(stage1 + classDirs, gradleData)
+            return ClasspathResolutionResult(
+                classpath = stage1 + classDirs,
+                gradleProjectData = gradleData,
+                stageUsed = UsedExecutionStage.BUILD_TOOL
+            )
         }
 
         logger.warn(
@@ -640,7 +663,8 @@ open class LstBuilder(
             logger.info("Stage 2 succeeded: ${stage2Result.classpath.size} JAR(s)")
             return ClasspathResolutionResult(
                 classpath = stage2Result.classpath + classDirs,
-                gradleProjectData = stage2GradleData
+                gradleProjectData = stage2GradleData,
+                stageUsed = UsedExecutionStage.DEPENDENCY_RESOLUTION
             )
         }
 
@@ -662,13 +686,17 @@ open class LstBuilder(
                 logger.info("Appending ${classDirs.size} project class dir(s) to classpath")
             }
             logger.info("Stage 3 succeeded: ${stage3.size} JAR(s)")
-            return ClasspathResolutionResult(stage3 + classDirs, stage2GradleData)
+            return ClasspathResolutionResult(
+                classpath = stage3 + classDirs,
+                gradleProjectData = stage2GradleData,
+                stageUsed = UsedExecutionStage.DIRECT_PARSE
+            )
         }
 
         logger.warn("Stage 3 failed — falling through to Stage 4")
 
         logger.info("Stage 4: scanning local Maven/Gradle caches")
-        val localRepositoryStage = LocalRepositoryStage(projectDir, logger)
+        val localRepositoryStage = createLocalRepositoryStage(projectDir)
         val declaredCoords = gatherDeclaredCoordinates(projectDir)
         val stage4 = localRepositoryStage.findAvailableJars(declaredCoords)
         val classDirs = projectClassDirs(projectDir)
@@ -680,7 +708,11 @@ open class LstBuilder(
         } else {
             logger.info("Stage 4: using ${stage4.size} locally cached JAR(s)")
         }
-        return ClasspathResolutionResult(stage4 + classDirs, stage2GradleData)
+        return ClasspathResolutionResult(
+            classpath = stage4 + classDirs,
+            gradleProjectData = stage2GradleData,
+            stageUsed = if (stage4.isEmpty()) null else UsedExecutionStage.LOCAL_REPOSITORY
+        )
     }
 
     /**

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ClasspathResolutionResult.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ClasspathResolutionResult.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner.lst.utils
 
+import io.github.skhokhlov.rewriterunner.UsedExecutionStage
 import java.nio.file.Path
 
 /**
@@ -9,8 +10,11 @@ import java.nio.file.Path
  * @param gradleProjectData Per-Gradle-project configuration data keyed by Gradle project path
  *   (e.g. `":"` for root, `":api"` for a subproject). `null` for Maven projects, or when
  *   the `gradle dependencies` task could not be run.
+ * @param stageUsed Which pipeline stage produced the classpath, or `null` when every stage
+ *   produced an empty result.
  */
 data class ClasspathResolutionResult(
     val classpath: List<Path>,
-    val gradleProjectData: Map<String, GradleProjectData>? = null
+    val gradleProjectData: Map<String, GradleProjectData>? = null,
+    val stageUsed: UsedExecutionStage? = null
 )

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner
 
+import io.github.skhokhlov.rewriterunner.UsedExecutionStage
 import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
@@ -206,15 +207,21 @@ class RewriteRunnerTest :
             )
             gradlew.setExecutable(true)
 
-            RewriteRunner.builder()
-                .projectDir(projectDir)
-                .activeRecipe("com.example.Recipe")
-                .configFile(configFile)
-                .dryRun(true)
-                .build()
-                .run()
+            val result =
+                RewriteRunner.builder()
+                    .projectDir(projectDir)
+                    .activeRecipe("com.example.Recipe")
+                    .configFile(configFile)
+                    .dryRun(true)
+                    .build()
+                    .run()
 
             assertEquals("rewriteDryRun", marker.readText().trim())
+            assertEquals(
+                UsedExecutionStage.PLUGIN,
+                result.executionDiagnostics.stageUsed,
+                "Plugin-first path should report stageUsed == PLUGIN"
+            )
         }
 
         test("plugin-first Maven run uses configured rewrite plugin version").config(

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RunResultTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RunResultTest.kt
@@ -6,6 +6,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+private val emptyDiagnostics = ExecutionDiagnostics.EMPTY
+
 class RunResultTest :
     FunSpec({
         val projectDir = Paths.get("/tmp/project")
@@ -15,7 +17,8 @@ class RunResultTest :
                 RunResult(
                     results = emptyList(),
                     changedFiles = emptyList(),
-                    projectDir = projectDir
+                    projectDir = projectDir,
+                    executionDiagnostics = emptyDiagnostics
                 )
             assertFalse(result.hasChanges)
         }
@@ -29,7 +32,8 @@ class RunResultTest :
                 RunResult(
                     results = emptyList(),
                     changedFiles = emptyList(),
-                    projectDir = projectDir
+                    projectDir = projectDir,
+                    executionDiagnostics = emptyDiagnostics
                 )
             assertFalse(result.hasChanges, "Empty results → hasChanges must be false")
             assertEquals(0, result.changeCount, "Empty results → changeCount must be 0")
@@ -40,7 +44,8 @@ class RunResultTest :
                 RunResult(
                     results = emptyList(),
                     changedFiles = emptyList(),
-                    projectDir = projectDir
+                    projectDir = projectDir,
+                    executionDiagnostics = emptyDiagnostics
                 )
             assertEquals(0, result.changeCount)
         }
@@ -51,7 +56,8 @@ class RunResultTest :
                     results = emptyList(),
                     changedFiles = emptyList(),
                     projectDir = projectDir,
-                    rawDiffs = mapOf(Paths.get("Foo.java") to "diff --git a/Foo.java b/Foo.java\n")
+                    rawDiffs = mapOf(Paths.get("Foo.java") to "diff --git a/Foo.java b/Foo.java\n"),
+                    executionDiagnostics = emptyDiagnostics
                 )
             assertTrue(result.hasChanges)
             assertEquals(1, result.changeCount)
@@ -63,7 +69,8 @@ class RunResultTest :
                 RunResult(
                     results = emptyList(),
                     changedFiles = changedFiles,
-                    projectDir = projectDir
+                    projectDir = projectDir,
+                    executionDiagnostics = emptyDiagnostics
                 )
             val r2 = r1.copy()
             assertEquals(r1, r2)
@@ -76,7 +83,8 @@ class RunResultTest :
                 RunResult(
                     results = emptyList(),
                     changedFiles = emptyList(),
-                    projectDir = projectDir
+                    projectDir = projectDir,
+                    executionDiagnostics = emptyDiagnostics
                 )
             val str = result.toString()
             assertTrue(str.contains("RunResult"), "toString should include class name")
@@ -85,7 +93,12 @@ class RunResultTest :
         test("changedFiles is accessible on result") {
             val files = listOf(Paths.get("/tmp/a.java"), Paths.get("/tmp/b.java"))
             val result =
-                RunResult(results = emptyList(), changedFiles = files, projectDir = projectDir)
+                RunResult(
+                    results = emptyList(),
+                    changedFiles = files,
+                    projectDir = projectDir,
+                    executionDiagnostics = emptyDiagnostics
+                )
             assertEquals(2, result.changedFiles.size)
             assertTrue(result.changedFiles.contains(Paths.get("/tmp/a.java")))
         }

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/GradleProjectMarkerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/GradleProjectMarkerTest.kt
@@ -151,7 +151,7 @@ class GradleProjectMarkerTest :
                 lstBuilderWithGradleData(throwOnKtsParser = true).build(
                     projectDir,
                     includeExtensionsCli = listOf(".kts")
-                )
+                ).sourceFiles
             assertTrue(sources.isNotEmpty(), "Expected at least one parsed source file")
             assertTrue(
                 sources.any { it.markers.findFirst(GradleProject::class.java).isPresent },
@@ -165,7 +165,7 @@ class GradleProjectMarkerTest :
                 lstBuilderWithGradleData(throwOnGroovyParser = true).build(
                     projectDir,
                     includeExtensionsCli = listOf(".gradle")
-                )
+                ).sourceFiles
             assertTrue(sources.isNotEmpty(), "Expected at least one parsed source file")
             assertTrue(
                 sources.any { it.markers.findFirst(GradleProject::class.java).isPresent },
@@ -183,7 +183,7 @@ class GradleProjectMarkerTest :
                 lstBuilderWithStage1Success(gradleData = minimalGradleData).build(
                     projectDir,
                     includeExtensionsCli = listOf(".kts")
-                )
+                ).sourceFiles
             assertTrue(sources.isNotEmpty(), "Expected at least one parsed source file")
             assertTrue(
                 sources.any { it.markers.findFirst(GradleProject::class.java).isPresent },
@@ -300,7 +300,7 @@ class GradleProjectMarkerTest :
             val sources = lstBuilderWithStage1Success(gradleData = gradleData).build(
                 projectDir,
                 includeExtensionsCli = listOf(".kts", ".gradle")
-            )
+            ).sourceFiles
 
             fun markerFor(path: String): GradleProject {
                 val source = sources.singleOrNull { it.sourcePath.toString() == path }
@@ -362,7 +362,7 @@ class GradleProjectMarkerTest :
             val sources = lstBuilderWithStage1Success(gradleData = gradleData).build(
                 projectDir,
                 includeExtensionsCli = listOf(".kts")
-            )
+            ).sourceFiles
             val marker = sources
                 .single { it.sourcePath.toString() == "build.gradle.kts" }
                 .markers.findFirst(GradleProject::class.java).orElse(null)
@@ -412,7 +412,7 @@ class GradleProjectMarkerTest :
             val sources = lstBuilderWithStage1Success(gradleData = gradleData).build(
                 projectDir,
                 includeExtensionsCli = listOf(".kts")
-            )
+            ).sourceFiles
             val marker = sources
                 .single { it.sourcePath.toString() == "build.gradle.kts" }
                 .markers.findFirst(GradleProject::class.java).orElse(null)

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/JavaVersionDetectionTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/JavaVersionDetectionTest.kt
@@ -64,7 +64,7 @@ class JavaVersionDetectionTest :
         fun buildAndGetJavaVersion(): JavaVersion {
             projectDir.resolve("Hello.java").writeText("class Hello {}")
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java"))
+                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
             val javaFile = sources.single { it.sourcePath.toString().endsWith(".java") }
             val marker = javaFile.markers.findFirst(JavaVersion::class.java).orElse(null)
             assertNotNull(
@@ -78,7 +78,10 @@ class JavaVersionDetectionTest :
             val absPath = projectDir.resolve(relativeFilePath)
             Files.createDirectories(absPath.parent)
             absPath.writeText("class ${absPath.toFile().nameWithoutExtension} {}")
-            val sources = lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java"))
+            val sources = lstBuilder().build(
+                projectDir,
+                includeExtensionsCli = listOf(".java")
+            ).sourceFiles
             val javaFile = sources.single { it.sourcePath.toString() == relativeFilePath }
             val marker = javaFile.markers.findFirst(JavaVersion::class.java).orElse(null)
             assertNotNull(marker, "JavaVersion marker must be present on parsed Java source file")
@@ -810,7 +813,7 @@ class JavaVersionDetectionTest :
             absWorld.writeText("class World {}")
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java"))
+                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
             val helloMarker =
                 sources
                     .single { it.sourcePath.toString() == "subproject1/src/main/java/Hello.java" }
@@ -856,7 +859,7 @@ class JavaVersionDetectionTest :
             absBeta.writeText("class Beta {}")
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java"))
+                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
             val alphaMarker =
                 sources
                     .single { it.sourcePath.toString() == "subproject1/src/Alpha.java" }

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/JavaVersionParsingTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/JavaVersionParsingTest.kt
@@ -85,7 +85,7 @@ class JavaVersionParsingTest :
          */
         fun buildAndInspect(fileName: String): JavaVersion {
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java"))
+                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
             val javaFile =
                 sources.singleOrNull { it.sourcePath.toString().endsWith(fileName) }
             assertNotNull(
@@ -477,7 +477,7 @@ class JavaVersionParsingTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java"))
+                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
             val javaFile =
                 sources.singleOrNull { it.sourcePath.toString().endsWith("Shapes17.java") }
             assertNotNull(javaFile, "Shapes17.java must be present in parsed sources")
@@ -512,7 +512,7 @@ class JavaVersionParsingTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java"))
+                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
             val javaFile =
                 sources.singleOrNull { it.sourcePath.toString().endsWith("Patterns21.java") }
             assertNotNull(javaFile, "Patterns21.java must be present in parsed sources")
@@ -559,7 +559,7 @@ class JavaVersionParsingTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java"))
+                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
             val javaFiles = sources.filter { it.sourcePath.toString().endsWith(".java") }
             assertTrue(
                 javaFiles.size == 2,

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/KotlinVersionDetectionTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/KotlinVersionDetectionTest.kt
@@ -63,7 +63,10 @@ class KotlinVersionDetectionTest :
 
         fun buildAndGetKotlinVersion(fileName: String = "Hello.kt"): JavaVersion {
             projectDir.resolve(fileName).writeText("fun main() {}")
-            val sources = lstBuilder().build(projectDir, includeExtensionsCli = listOf(".kt"))
+            val sources = lstBuilder().build(
+                projectDir,
+                includeExtensionsCli = listOf(".kt")
+            ).sourceFiles
             val ktFile = sources.single { it.sourcePath.toString().endsWith(".kt") }
             val marker = ktFile.markers.findFirst(JavaVersion::class.java).orElse(null)
             assertNotNull(marker, "JavaVersion marker must be present on parsed Kotlin source file")
@@ -291,7 +294,10 @@ class KotlinVersionDetectionTest :
             val absPath = projectDir.resolve("subproject1/src/main/kotlin/Hello.kt")
             Files.createDirectories(absPath.parent)
             absPath.writeText("fun main() {}")
-            val sources = lstBuilder().build(projectDir, includeExtensionsCli = listOf(".kt"))
+            val sources = lstBuilder().build(
+                projectDir,
+                includeExtensionsCli = listOf(".kt")
+            ).sourceFiles
             val marker = sources
                 .single { it.sourcePath.toString() == "subproject1/src/main/kotlin/Hello.kt" }
                 .markers.findFirst(JavaVersion::class.java).orElse(null)
@@ -312,7 +318,10 @@ class KotlinVersionDetectionTest :
             val absPath = projectDir.resolve("subproject1/src/main/kotlin/Hello.kt")
             Files.createDirectories(absPath.parent)
             absPath.writeText("fun main() {}")
-            val sources = lstBuilder().build(projectDir, includeExtensionsCli = listOf(".kt"))
+            val sources = lstBuilder().build(
+                projectDir,
+                includeExtensionsCli = listOf(".kt")
+            ).sourceFiles
             val marker = sources
                 .single { it.sourcePath.toString() == "subproject1/src/main/kotlin/Hello.kt" }
                 .markers.findFirst(JavaVersion::class.java).orElse(null)
@@ -331,7 +340,10 @@ class KotlinVersionDetectionTest :
             )
             projectDir.resolve("script.kts").writeText("println(\"hello\")")
 
-            val sources = lstBuilder().build(projectDir, includeExtensionsCli = listOf(".kts"))
+            val sources = lstBuilder().build(
+                projectDir,
+                includeExtensionsCli = listOf(".kts")
+            ).sourceFiles
             val ktsFile = sources.single { it.sourcePath.toString() == "script.kts" }
             val marker = ktsFile.markers.findFirst(JavaVersion::class.java).orElse(null)
             assertNotNull(marker, "JavaVersion marker must be present on .kts file")

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
@@ -3,6 +3,7 @@ package io.github.skhokhlov.rewriterunner.lst
 import io.github.skhokhlov.rewriterunner.AetherContext
 import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
 import io.github.skhokhlov.rewriterunner.RunnerLogger
+import io.github.skhokhlov.rewriterunner.UsedExecutionStage
 import io.github.skhokhlov.rewriterunner.config.ParseConfig
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
 import io.github.skhokhlov.rewriterunner.lst.utils.ClasspathResolutionResult
@@ -14,6 +15,7 @@ import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.openrewrite.maven.tree.MavenResolutionResult
 
@@ -85,7 +87,7 @@ class LstBuilderTest :
             val sources = lstBuilder().build(
                 projectDir = projectDir,
                 includeExtensionsCli = listOf(".java")
-            )
+            ).sourceFiles
 
             assertEquals(1, sources.size, "Only .java file should be parsed")
             assertTrue(sources.first().sourcePath.toString().endsWith(".java"))
@@ -100,7 +102,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     excludeExtensionsCli = listOf(".xml", ".properties")
-                )
+                ).sourceFiles
 
             val paths = sources.map { it.sourcePath.toString() }
             assertTrue(paths.none { it.endsWith(".xml") }, "XML files should be excluded")
@@ -140,7 +142,7 @@ class LstBuilderTest :
                     depResolutionStage = noOpDepStage
                 )
 
-            val sources = builder.build(projectDir = projectDir)
+            val sources = builder.build(projectDir = projectDir).sourceFiles
             assertEquals(1, sources.size)
             assertTrue(sources.first().sourcePath.toString().endsWith(".yaml"))
         }
@@ -177,7 +179,7 @@ class LstBuilderTest :
             val sources = builder.build(
                 projectDir = projectDir,
                 includeExtensionsCli = listOf(".java")
-            )
+            ).sourceFiles
             assertEquals(1, sources.size)
             assertTrue(sources.first().sourcePath.toString().endsWith(".java"))
         }
@@ -201,7 +203,7 @@ class LstBuilderTest :
             projectDir.resolve("hello.proto").writeText("syntax = \"proto3\";\npackage example;")
             projectDir.resolve("Dockerfile").writeText("FROM ubuntu:22.04")
 
-            val sources = lstBuilder().build(projectDir = projectDir)
+            val sources = lstBuilder().build(projectDir = projectDir).sourceFiles
 
             val paths = sources.map { it.sourcePath.toString() }
             assertTrue(paths.any { it.endsWith(".java") }, "Java should be parsed")
@@ -231,7 +233,10 @@ class LstBuilderTest :
             projectDir.resolve("script.kts").writeText("// plain kts script")
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".kts"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".kts")
+                ).sourceFiles
 
             val paths = sources.map { it.sourcePath.toString() }
             assertEquals(3, sources.size, "All three .kts files should be parsed")
@@ -250,7 +255,7 @@ class LstBuilderTest :
             val sources = lstBuilder().build(
                 projectDir = projectDir,
                 includeExtensionsCli = listOf(".groovy", ".gradle")
-            )
+            ).sourceFiles
 
             val paths = sources.map { it.sourcePath.toString() }
             assertEquals(2, sources.size, "Both .groovy and .gradle files should be parsed")
@@ -262,7 +267,10 @@ class LstBuilderTest :
             projectDir.resolve("app.yml").writeText("spring:\n  port: 8080")
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".yml"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".yml")
+                ).sourceFiles
             assertEquals(1, sources.size)
         }
 
@@ -274,7 +282,10 @@ class LstBuilderTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".toml"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".toml")
+                ).sourceFiles
             assertEquals(1, sources.size, "TOML file should be parsed")
             assertTrue(sources.first().sourcePath.toString().endsWith(".toml"))
         }
@@ -285,7 +296,10 @@ class LstBuilderTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".hcl"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".hcl")
+                ).sourceFiles
             assertEquals(1, sources.size, "HCL file should be parsed")
         }
 
@@ -295,7 +309,10 @@ class LstBuilderTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".tf"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".tf")
+                ).sourceFiles
             assertEquals(1, sources.size, "Terraform (.tf) file should be parsed")
         }
 
@@ -306,7 +323,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".tfvars")
-                )
+                ).sourceFiles
             assertEquals(1, sources.size, "Terraform variable (.tfvars) file should be parsed")
         }
 
@@ -323,7 +340,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".hcl", ".tf", ".tfvars")
-                )
+                ).sourceFiles
             assertEquals(3, sources.size, "All three HCL-family extensions should be parsed")
         }
 
@@ -333,7 +350,10 @@ class LstBuilderTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".proto"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".proto")
+                ).sourceFiles
             assertEquals(1, sources.size, "Protobuf file should be parsed")
         }
 
@@ -346,7 +366,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".dockerfile")
-                )
+                ).sourceFiles
             assertEquals(1, sources.size, ".dockerfile extension should be parsed")
         }
 
@@ -359,7 +379,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".containerfile")
-                )
+                ).sourceFiles
             assertEquals(1, sources.size, ".containerfile extension should be parsed")
         }
 
@@ -370,7 +390,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".dockerfile")
-                )
+                ).sourceFiles
             assertEquals(1, sources.size, "Dockerfile (no extension) should be parsed by name")
             assertEquals("Dockerfile", sources.first().sourcePath.toString())
         }
@@ -382,7 +402,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".dockerfile")
-                )
+                ).sourceFiles
             assertEquals(1, sources.size, "Dockerfile.dev should be parsed by name prefix")
         }
 
@@ -395,7 +415,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".dockerfile")
-                )
+                ).sourceFiles
             assertEquals(1, sources.size, "Containerfile (no extension) should be parsed by name")
         }
 
@@ -407,7 +427,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".properties")
-                )
+                ).sourceFiles
             val paths = sources.map { it.sourcePath.toString() }
             assertTrue(
                 paths.none { it == "Dockerfile" },
@@ -430,7 +450,10 @@ class LstBuilderTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".xml"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".xml")
+                ).sourceFiles
             assertEquals(1, sources.size, "pom.xml should be parsed")
             val pom = sources.first()
             assertEquals("pom.xml", pom.sourcePath.toString())
@@ -446,7 +469,10 @@ class LstBuilderTest :
             ).writeText("<configuration><key>value</key></configuration>")
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".xml"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".xml")
+                ).sourceFiles
             assertEquals(1, sources.size, "config.xml should be parsed")
             assertFalse(
                 sources.first().markers.findFirst(MavenResolutionResult::class.java).isPresent,
@@ -465,7 +491,10 @@ class LstBuilderTest :
             projectDir.resolve("logback.xml").writeText("<configuration/>")
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".xml"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".xml")
+                ).sourceFiles
             assertEquals(3, sources.size, "All 3 xml files should be parsed")
             val paths = sources.map { it.sourcePath.toString() }
             assertTrue(paths.contains("pom.xml"))
@@ -496,7 +525,7 @@ class LstBuilderTest :
                 lstBuilder().build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".properties")
-                )
+                ).sourceFiles
             assertTrue(
                 sources.none { it.sourcePath.toString() == "pom.xml" },
                 "pom.xml should not be parsed when .xml is not in effective set"
@@ -628,7 +657,10 @@ class LstBuilderTest :
             projectDir.resolve("Hello.java").writeText("class Hello {}")
 
             val sources =
-                lstBuilder().build(projectDir = projectDir, includeExtensionsCli = listOf(".java"))
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".java")
+                ).sourceFiles
 
             assertEquals(
                 1,
@@ -708,7 +740,7 @@ class LstBuilderTest :
                 lstBuilder(buildTool = failingCompileTool).build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".java")
-                )
+                ).sourceFiles
 
             assertEquals(
                 1,
@@ -735,7 +767,7 @@ class LstBuilderTest :
                 lstBuilder(buildTool = compilingBuildTool).build(
                     projectDir = projectDir,
                     includeExtensionsCli = listOf(".java")
-                )
+                ).sourceFiles
 
             assertEquals(
                 1,
@@ -1070,7 +1102,7 @@ class LstBuilderTest :
             val sources = lstBuilder(logger = capturingLogger).build(
                 projectDir = projectDir,
                 includeExtensionsCli = listOf(".xml")
-            )
+            ).sourceFiles
 
             // If the XML parser drops the broken file, reportParseFailures should warn about it
             if (sources.size == 1) {
@@ -1079,5 +1111,117 @@ class LstBuilderTest :
                     "When file is dropped, expected warning mentioning 'broken.xml' but got: $warnings"
                 )
             }
+        }
+
+        // ─── ExecutionDiagnostics ─────────────────────────────────────────────────
+
+        test(
+            "executionDiagnostics stageUsed is BUILD_TOOL and resolvedJarCount > 0 when stage 1 succeeds"
+        ) {
+            val fakeJar = projectDir.resolve("fake.jar").also { it.writeText("") }
+            val successBuildTool =
+                object : ProjectBuildStage(NoOpRunnerLogger) {
+                    override fun extractClasspath(projectDir: Path): List<Path> = listOf(fakeJar)
+                }
+            projectDir.resolve("Hello.java").writeText("class Hello {}")
+
+            val lstBuildResult =
+                lstBuilder(buildTool = successBuildTool).build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".java")
+                )
+
+            assertEquals(
+                UsedExecutionStage.BUILD_TOOL,
+                lstBuildResult.executionDiagnostics.stageUsed,
+                "Stage 1 success should set stageUsed to BUILD_TOOL"
+            )
+            assertTrue(
+                lstBuildResult.executionDiagnostics.resolvedJarCount > 0,
+                "resolvedJarCount should be > 0 when stage 1 returns JARs"
+            )
+        }
+
+        test(
+            "executionDiagnostics stageUsed is null and resolvedJarCount is 0 when all stages empty"
+        ) {
+            projectDir.resolve("Hello.java").writeText("class Hello {}")
+
+            val lstBuildResult =
+                lstBuilder().build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".java")
+                )
+
+            assertNull(
+                lstBuildResult.executionDiagnostics.stageUsed,
+                "All stages empty → stageUsed should be null (blind run)"
+            )
+            assertEquals(
+                0,
+                lstBuildResult.executionDiagnostics.resolvedJarCount,
+                "All stages empty → resolvedJarCount should be 0"
+            )
+        }
+
+        test("executionDiagnostics stageUsed is LOCAL_REPOSITORY when only stage 4 finds JARs") {
+            val fakeJar = projectDir.resolve("cached.jar").also { it.writeText("") }
+            val noOpDepStage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): ClasspathResolutionResult =
+                        ClasspathResolutionResult(emptyList())
+                }
+            val noOpBuildFileStage =
+                object : BuildFileParseStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): List<Path> = emptyList()
+                }
+            val builderWithFakeStage4 =
+                object : LstBuilder(
+                    logger = NoOpRunnerLogger,
+                    cacheDir = projectDir.resolve("cache"),
+                    toolConfig = toolConfig,
+                    projectBuildStage = failingBuildTool,
+                    depResolutionStage = noOpDepStage,
+                    buildFileParseStage = noOpBuildFileStage
+                ) {
+                    override fun createLocalRepositoryStage(
+                        projectDir: Path
+                    ): LocalRepositoryStage =
+                        object : LocalRepositoryStage(projectDir, NoOpRunnerLogger) {
+                            override fun findAvailableJars(
+                                declaredCoordinates: List<String>
+                            ): List<Path> = listOf(fakeJar)
+                        }
+                }
+
+            projectDir.resolve("Hello.java").writeText("class Hello {}")
+            val lstBuildResult =
+                builderWithFakeStage4.build(
+                    projectDir = projectDir,
+                    includeExtensionsCli = listOf(".java")
+                )
+
+            assertEquals(
+                UsedExecutionStage.LOCAL_REPOSITORY,
+                lstBuildResult.executionDiagnostics.stageUsed,
+                "Stage 4 with JARs → stageUsed should be LOCAL_REPOSITORY"
+            )
+            assertEquals(
+                1,
+                lstBuildResult.executionDiagnostics.resolvedJarCount,
+                "Stage 4 with 1 JAR → resolvedJarCount should be 1"
+            )
         }
     })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/MultiModuleJavaVersionTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/MultiModuleJavaVersionTest.kt
@@ -68,7 +68,7 @@ class MultiModuleJavaVersionTest :
          */
         fun buildAndGetVersionsPerFile(): Map<String, JavaVersion> {
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java"))
+                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
             return sources
                 .filter { it.sourcePath.toString().endsWith(".java") }
                 .associateBy(

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatterTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatterTest.kt
@@ -1,5 +1,6 @@
 package io.github.skhokhlov.rewriterunner.output
 
+import io.github.skhokhlov.rewriterunner.ExecutionDiagnostics
 import io.github.skhokhlov.rewriterunner.RunResult
 import io.kotest.core.spec.style.FunSpec
 import java.io.ByteArrayOutputStream
@@ -251,7 +252,8 @@ class ResultFormatterTest :
                             projectDir = reportDir,
                             rawDiffs = mapOf(
                                 Path.of("Foo.java") to "diff --git a/Foo.java b/Foo.java\n"
-                            )
+                            ),
+                            executionDiagnostics = ExecutionDiagnostics.PLUGIN
                         )
                     )
                 }
@@ -266,7 +268,8 @@ class ResultFormatterTest :
                             results = emptyList(),
                             changedFiles = emptyList(),
                             projectDir = reportDir,
-                            rawDiffs = mapOf(Path.of("Foo.java") to "diff")
+                            rawDiffs = mapOf(Path.of("Foo.java") to "diff"),
+                            executionDiagnostics = ExecutionDiagnostics.PLUGIN
                         )
                     )
                 }
@@ -282,7 +285,8 @@ class ResultFormatterTest :
                         projectDir = reportDir,
                         rawDiffs = mapOf(
                             Path.of("Foo.java") to "diff --git a/Foo.java b/Foo.java\n"
-                        )
+                        ),
+                        executionDiagnostics = ExecutionDiagnostics.PLUGIN
                     )
                 )
             }

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -66,6 +66,42 @@ Return type of `RewriteRunner.run()`.
 | `rawDiffs` | `Map<Path, String>` | Unified diffs from the plugin-first path. Empty when the in-process LST path runs. |
 | `hasChanges` | `Boolean` | `true` when the recipe produced at least one change, regardless of `dryRun` |
 | `changeCount` | `Int` | Number of changed source files |
+| `executionDiagnostics` | `ExecutionDiagnostics` | Which pipeline stage produced the run and how many JARs were on the classpath |
+
+## ExecutionDiagnostics
+
+Structured signal about which execution path produced the run. Useful for detecting blind runs (where all JVM type information is missing) and for metrics/telemetry.
+
+```kotlin
+data class ExecutionDiagnostics(
+    val stageUsed: UsedExecutionStage?,
+    val resolvedJarCount: Int,
+)
+```
+
+| Property | Description |
+|----------|-------------|
+| `stageUsed` | The stage that produced the classpath, or `null` when every LST stage produced an empty classpath (recipe ran semantically blind) |
+| `resolvedJarCount` | Number of `.jar` entries on the LST classpath (project class directories excluded). `0` when `stageUsed` is `PLUGIN` or `null` |
+
+### Detecting a blind run
+
+```kotlin
+val result = RewriteRunner.builder()...build().run()
+if (result.executionDiagnostics.stageUsed == null) {
+    error("Classpath resolution failed — recipe ran without type information")
+}
+```
+
+### UsedExecutionStage values
+
+| Value | Description |
+|-------|-------------|
+| `PLUGIN` | Stage 0 — official Gradle/Maven OpenRewrite plugin handled the recipe; classpath not observed |
+| `BUILD_TOOL` | Stage 1 — project's own build tool extracted the compile classpath |
+| `DEPENDENCY_RESOLUTION` | Stage 2 — `mvn dependency:tree` / `gradle dependencies` + Maven Resolver |
+| `DIRECT_PARSE` | Stage 3 — static build-file parse + POM traversal via Maven Resolver |
+| `LOCAL_REPOSITORY` | Stage 4 — local Maven/Gradle cache scan, no network |
 
 Each `org.openrewrite.Result` in `results` exposes:
 - `before` — the source file before the recipe (`null` for newly created files)


### PR DESCRIPTION
Add UsedExecutionStage enum and ExecutionDiagnostics data class to give library consumers a structured signal about which pipeline stage produced the recipe run and how many JARs were on the LST classpath.

RunResult gains a required executionDiagnostics field (breaking change). LstBuilder.build() now returns LstBuildResult(sourceFiles, executionDiagnostics) instead of List<SourceFile> (breaking change).

Stage 0 (plugin) → ExecutionDiagnostics.PLUGIN (resolvedJarCount = 0). Stages 1–4 carry UsedExecutionStage.BUILD_TOOL / DEPENDENCY_RESOLUTION / DIRECT_PARSE / LOCAL_REPOSITORY; null stageUsed signals a blind run.

LocalRepositoryStage is now open with an open findAvailableJars() to support test subclassing; LstBuilder exposes a protected open createLocalRepositoryStage() factory following the same pattern as existing stage overrides.

BREAKING CHANGE: RunResult constructor requires executionDiagnostics.
BREAKING CHANGE: LstBuilder.build() return type changed to LstBuildResult.