### PR TITLE
fix(lst): fall back to XmlParser when MavenParser throws on illegal URIs

### DIFF
--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionDiagnostics.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionDiagnostics.kt
@@ -20,6 +20,18 @@ enum class UsedExecutionStage {
 }
 
 /**
+ * A non-fatal parse failure recorded during LST building. Surfaced via
+ * [ExecutionDiagnostics.parseFailures] so callers can see which files were degraded
+ * (e.g. a `pom.xml` parsed by `XmlParser` instead of `MavenParser` because the
+ * Maven dependency graph could not be resolved).
+ *
+ * @property path Project-relative source path.
+ * @property reason Short, human-readable cause (usually the exception message).
+ * @property parser The parser that gave up on this file (e.g. `"MavenParser"`).
+ */
+data class ParseFailure(val path: String, val reason: String, val parser: String)
+
+/**
  * Diagnostic info about which execution path produced the run and how its classpath
  * was assembled.
  *
@@ -28,8 +40,15 @@ enum class UsedExecutionStage {
  * @property resolvedJarCount Number of `.jar` entries on the LST classpath (project
  *   class directories excluded). `0` when [stageUsed] is [UsedExecutionStage.PLUGIN]
  *   (the plugin handled resolution internally) or `null`.
+ * @property parseFailures Files that the canonical parser could not handle and that
+ *   were either dropped or downgraded to a more lenient parser. Empty when every
+ *   file parsed successfully.
  */
-data class ExecutionDiagnostics(val stageUsed: UsedExecutionStage?, val resolvedJarCount: Int) {
+data class ExecutionDiagnostics(
+    val stageUsed: UsedExecutionStage?,
+    val resolvedJarCount: Int,
+    val parseFailures: List<ParseFailure> = emptyList()
+) {
     companion object {
         val PLUGIN = ExecutionDiagnostics(UsedExecutionStage.PLUGIN, 0)
         val EMPTY = ExecutionDiagnostics(null, 0)

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
@@ -2,6 +2,7 @@ package io.github.skhokhlov.rewriterunner.lst
 
 import io.github.skhokhlov.rewriterunner.AetherContext
 import io.github.skhokhlov.rewriterunner.ExecutionDiagnostics
+import io.github.skhokhlov.rewriterunner.ParseFailure
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.UsedExecutionStage
 import io.github.skhokhlov.rewriterunner.config.ParseConfig
@@ -210,6 +211,7 @@ open class LstBuilder(
 
         // ── Parse each language ───────────────────────────────────────────────
         val allSources = mutableListOf<SourceFile>()
+        val parseFailures = mutableListOf<ParseFailure>()
 
         filesByExt[".java"]?.let { files ->
             logger.info("Parsing ${files.size} Java file(s)")
@@ -418,9 +420,12 @@ open class LstBuilder(
 
             if (pomFiles.isNotEmpty()) {
                 logger.info("Parsing ${pomFiles.size} Maven POM file(s) with MavenParser")
-                val parsed = MavenParser.builder().build()
-                    .parse(pomFiles, projectDir, parseCtx)
-                    .toList()
+                val parsed = parsePomFilesWithFallback(
+                    pomFiles,
+                    projectDir,
+                    parseCtx,
+                    parseFailures
+                )
                 reportParseFailures(pomFiles, parsed, pendingErrors, projectDir)
                 pendingErrors.clear()
                 parsed.forEach { allSources.add(it) }
@@ -507,10 +512,75 @@ open class LstBuilder(
         val resolvedJarCount = classpath.count { it.toString().endsWith(".jar") }
         val diagnostics = ExecutionDiagnostics(
             stageUsed = resolutionResult.stageUsed,
-            resolvedJarCount = resolvedJarCount
+            resolvedJarCount = resolvedJarCount,
+            parseFailures = parseFailures.toList()
         )
         return LstBuildResult(withMarkers, diagnostics)
     }
+
+    /**
+     * Parse `pom.xml` files with [MavenParser], falling back to [XmlParser] when
+     * [MavenParser] throws an `IllegalArgumentException` whose cause is a
+     * [java.net.URISyntaxException] (the failure mode `MavenPomDownloader` produces
+     * via `URI.create(...)` when a coordinate or repository URL contains an illegal
+     * URI character).
+     *
+     * Strategy:
+     * 1. Try the batch with [MavenParser] — all poms together so parent/module
+     *    relationships resolve normally.
+     * 2. On URI failure, retry each pom individually so a single bad pom does not
+     *    poison its siblings.
+     * 3. Any pom that still trips [MavenParser] is reparsed with [XmlParser] so the
+     *    file still shows up in the LST (without `MavenResolutionResult` markers) and
+     *    recorded in [failures].
+     *
+     * Exceptions without a [java.net.URISyntaxException] in their cause chain are
+     * rethrown — the fallback is intentionally narrow so unrelated MavenParser
+     * regressions surface rather than being silently downgraded to XmlParser.
+     */
+    private fun parsePomFilesWithFallback(
+        pomFiles: List<Path>,
+        projectDir: Path,
+        parseCtx: ExecutionContext,
+        failures: MutableList<ParseFailure>
+    ): List<SourceFile> = try {
+        buildMavenParser().parse(pomFiles, projectDir, parseCtx).toList()
+    } catch (e: Throwable) {
+        if (!isUriFailure(e)) throw e
+        logger.warn(
+            "MavenParser failed on the pom batch (${e.message}); " +
+                "retrying each pom.xml individually"
+        )
+        pomFiles.flatMap { pom ->
+            try {
+                buildMavenParser().parse(listOf(pom), projectDir, parseCtx).toList()
+            } catch (single: Throwable) {
+                if (!isUriFailure(single)) throw single
+                val rel = projectDir.relativize(pom).normalize().toString()
+                logger.warn(
+                    "Failed to parse $rel with MavenParser (${single.message}); " +
+                        "falling back to XmlParser"
+                )
+                failures += ParseFailure(
+                    path = rel,
+                    reason = single.message ?: single.javaClass.simpleName,
+                    parser = "MavenParser"
+                )
+                XmlParser().parse(listOf(pom), projectDir, parseCtx).toList()
+            }
+        }
+    }
+
+    /**
+     * True when [t] or any cause in its chain is a [java.net.URISyntaxException].
+     *
+     * `MavenPomDownloader` calls `URI.create(...)`, which wraps `URISyntaxException`
+     * inside `IllegalArgumentException`. Matching on the `URISyntaxException` cause
+     * (rather than any `IllegalArgumentException`) keeps the fallback narrow so
+     * unrelated MavenParser bugs surface instead of being silently downgraded.
+     */
+    private fun isUriFailure(t: Throwable): Boolean =
+        generateSequence(t) { it.cause }.any { it is java.net.URISyntaxException }
 
     // ─── Overrideable parser factories (for testing fallback paths) ──────────
 
@@ -545,6 +615,9 @@ open class LstBuilder(
     /** Creates the [LocalRepositoryStage] used for Stage 4. Overrideable in tests. */
     protected open fun createLocalRepositoryStage(projectDir: Path): LocalRepositoryStage =
         LocalRepositoryStage(projectDir, logger)
+
+    /** Creates the [MavenParser] used for `pom.xml` files. Overrideable in tests. */
+    protected open fun buildMavenParser(): MavenParser = MavenParser.builder().build()
 
     // ─── Classpath resolution (4 stages) ─────────────────────────────────────
 

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
@@ -17,6 +17,10 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.openrewrite.ExecutionContext
+import org.openrewrite.Parser
+import org.openrewrite.SourceFile
+import org.openrewrite.maven.MavenParser
 import org.openrewrite.maven.tree.MavenResolutionResult
 
 /**
@@ -529,6 +533,255 @@ class LstBuilderTest :
             assertTrue(
                 sources.none { it.sourcePath.toString() == "pom.xml" },
                 "pom.xml should not be parsed when .xml is not in effective set"
+            )
+        }
+
+        // ─── MavenParser URI failure fallback ────────────────────────────────────
+
+        /**
+         * Builds an [LstBuilder] whose [LstBuilder.buildMavenParser] returns a
+         * [MavenParser] that throws [IllegalArgumentException] (with a
+         * [java.net.URISyntaxException] cause) for any pom whose relative path matches
+         * [throwFor]. Mirrors the [MavenPomDownloader] failure mode where
+         * `URI.create(...)` rejects an illegal artifact path.
+         */
+        fun lstBuilderWithMavenStub(throwFor: Set<String>): LstBuilder {
+            val noOpDepStage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): ClasspathResolutionResult =
+                        ClasspathResolutionResult(emptyList())
+                }
+            val noOpBuildFileStage =
+                object : BuildFileParseStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): List<Path> = emptyList()
+                }
+            return object : LstBuilder(
+                logger = NoOpRunnerLogger,
+                cacheDir = projectDir.resolve("cache"),
+                toolConfig = toolConfig,
+                projectBuildStage = failingBuildTool,
+                depResolutionStage = noOpDepStage,
+                buildFileParseStage = noOpBuildFileStage
+            ) {
+                override fun buildMavenParser(): MavenParser =
+                    object : MavenParser(emptyList(), emptyMap(), false) {
+                        override fun parseInputs(
+                            sources: Iterable<Parser.Input>,
+                            relativeTo: Path?,
+                            ctx: ExecutionContext
+                        ): java.util.stream.Stream<SourceFile> {
+                            val cwd = relativeTo ?: projectDir
+                            sources.forEach { input ->
+                                val rel = cwd.relativize(input.path).normalize().toString()
+                                if (rel in throwFor) {
+                                    throw IllegalArgumentException(
+                                        "Illegal character in path at index 7: $rel",
+                                        java.net.URISyntaxException("bad", "Illegal character")
+                                    )
+                                }
+                            }
+                            return super.parseInputs(sources, relativeTo, ctx)
+                        }
+                    }
+            }
+        }
+
+        test("pom.xml with URI-failure does not abort the build") {
+            // Good pom in a subdirectory so per-file fallback can still resolve it.
+            val module = projectDir.resolve("module").also { it.createDirectories() }
+            module.resolve("pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>good</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """.trimIndent()
+            )
+            // Bad pom — content itself is valid XML; the stub MavenParser throws on it.
+            projectDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>bad</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """.trimIndent()
+            )
+
+            val result = lstBuilderWithMavenStub(throwFor = setOf("pom.xml")).build(
+                projectDir = projectDir,
+                includeExtensionsCli = listOf(".xml")
+            )
+
+            val poms = result.sourceFiles.filter { it.sourcePath.fileName.toString() == "pom.xml" }
+            assertEquals(2, poms.size, "Both pom.xml files should be in the LST")
+
+            val badPom = poms.first { it.sourcePath.toString() == "pom.xml" }
+            assertFalse(
+                badPom.markers.findFirst(MavenResolutionResult::class.java).isPresent,
+                "Bad pom should be downgraded to XmlParser (no MavenResolutionResult marker)"
+            )
+
+            val goodPom = poms.first {
+                it.sourcePath.toString().endsWith("module/pom.xml") ||
+                    it.sourcePath.toString().endsWith("module${java.io.File.separator}pom.xml")
+            }
+            assertTrue(
+                goodPom.markers.findFirst(MavenResolutionResult::class.java).isPresent,
+                "Good pom should still be parsed by MavenParser"
+            )
+
+            assertEquals(
+                1,
+                result.executionDiagnostics.parseFailures.size,
+                "Exactly one parse failure should be recorded"
+            )
+            val failure = result.executionDiagnostics.parseFailures.first()
+            assertEquals("pom.xml", failure.path)
+            assertEquals("MavenParser", failure.parser)
+            assertTrue(failure.reason.contains("Illegal character"))
+        }
+
+        test("non-URI MavenParser exceptions still bubble up") {
+            projectDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """.trimIndent()
+            )
+
+            val noOpDepStage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): ClasspathResolutionResult =
+                        ClasspathResolutionResult(emptyList())
+                }
+            val noOpBuildFileStage =
+                object : BuildFileParseStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): List<Path> = emptyList()
+                }
+            val builder = object : LstBuilder(
+                logger = NoOpRunnerLogger,
+                cacheDir = projectDir.resolve("cache"),
+                toolConfig = toolConfig,
+                projectBuildStage = failingBuildTool,
+                depResolutionStage = noOpDepStage,
+                buildFileParseStage = noOpBuildFileStage
+            ) {
+                override fun buildMavenParser(): MavenParser =
+                    object : MavenParser(emptyList(), emptyMap(), false) {
+                        override fun parseInputs(
+                            sources: Iterable<Parser.Input>,
+                            relativeTo: Path?,
+                            ctx: ExecutionContext
+                        ): java.util.stream.Stream<SourceFile> =
+                            throw IllegalStateException("unrelated bug")
+                    }
+            }
+
+            val thrown = kotlin.runCatching {
+                builder.build(projectDir = projectDir, includeExtensionsCli = listOf(".xml"))
+            }.exceptionOrNull()
+            assertNotNull(thrown, "An unrelated MavenParser bug must not be swallowed")
+            assertTrue(
+                thrown is IllegalStateException && thrown.message == "unrelated bug",
+                "Expected the original IllegalStateException to bubble up, got: $thrown"
+            )
+        }
+
+        test("IllegalArgumentException without URISyntaxException cause bubbles up") {
+            // Regression guard: an IllegalArgumentException whose cause chain does NOT
+            // include a URISyntaxException must not trigger the XmlParser fallback.
+            // Otherwise unrelated MavenParser bugs would be silently downgraded.
+            projectDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """.trimIndent()
+            )
+
+            val noOpDepStage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): ClasspathResolutionResult =
+                        ClasspathResolutionResult(emptyList())
+                }
+            val noOpBuildFileStage =
+                object : BuildFileParseStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): List<Path> = emptyList()
+                }
+            val builder = object : LstBuilder(
+                logger = NoOpRunnerLogger,
+                cacheDir = projectDir.resolve("cache"),
+                toolConfig = toolConfig,
+                projectBuildStage = failingBuildTool,
+                depResolutionStage = noOpDepStage,
+                buildFileParseStage = noOpBuildFileStage
+            ) {
+                override fun buildMavenParser(): MavenParser =
+                    object : MavenParser(emptyList(), emptyMap(), false) {
+                        override fun parseInputs(
+                            sources: Iterable<Parser.Input>,
+                            relativeTo: Path?,
+                            ctx: ExecutionContext
+                        ): java.util.stream.Stream<SourceFile> =
+                            throw IllegalArgumentException("non-URI validation failure")
+                    }
+            }
+
+            val thrown = kotlin.runCatching {
+                builder.build(projectDir = projectDir, includeExtensionsCli = listOf(".xml"))
+            }.exceptionOrNull()
+            assertNotNull(thrown, "Non-URI IllegalArgumentException must not be swallowed")
+            assertTrue(
+                thrown is IllegalArgumentException &&
+                    thrown.message == "non-URI validation failure",
+                "Expected the original IllegalArgumentException to bubble up, got: $thrown"
             )
         }
 


### PR DESCRIPTION
MavenPomDownloader builds artifact URLs via URI.create(...) deep inside MavenParser. When a pom contains a coordinate or repository URL with an illegal URI character, URI.create raises IllegalArgumentException, which escapes MavenParser.parse() and aborts the entire LST build.

Wrap the pom.xml batch call in LstBuilder with a narrow try/catch (IllegalArgumentException / URISyntaxException only) and, on failure, retry each pom individually; poms that still trip MavenParser are reparsed with XmlParser so they remain in the LST (without Maven markers) and recorded as a new ParseFailure entry on ExecutionDiagnostics. Non-URI exceptions still bubble up so unrelated MavenParser bugs are not masked.