### PR TITLE
feat(lst): collect parse failures across all parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,16 @@ result.results.forEach { r ->
 
 // changedFiles: paths written to disk (empty in dry-run mode)
 result.changedFiles.forEach { path -> println("Written: $path") }
+
+// Per-file parse failures (no need to scrape logs)
+result.executionDiagnostics.parseFailures.forEach { failure ->
+    println("${failure.parser} could not handle ${failure.path}: ${failure.reason}")
+}
 ```
+
+The build never aborts when a single file fails to parse — every per-file failure is
+collected into `executionDiagnostics.parseFailures` so callers can surface or ignore
+them. See [`docs/library-api.md`](docs/library-api.md#parse-failures) for the full shape.
 
 ### Formatted output (ResultFormatter)
 
@@ -353,9 +362,21 @@ Usage: rewrite-runner [-h] [--dry-run] [--skip-plugin-run] [--info] [--debug]
       "isNewFile": false,
       "isDeletedFile": false
     }
+  ],
+  "parseFailures": [
+    {
+      "path": "src/main/java/Broken.java",
+      "reason": "unterminated comment",
+      "parser": "JavaParser"
+    }
   ]
 }
 ```
+
+`parseFailures` is empty when every file parsed cleanly. Each entry names the canonical
+parser (`JavaParser`, `MavenParser`, `XmlParser`, …) that gave up on the file along with
+a short reason. A file can appear more than once if multiple parsers tried and failed on
+it (the Maven POM → XML fallback path is the typical case).
 
 ## Recipe Artifacts
 

--- a/README.md
+++ b/README.md
@@ -175,9 +175,14 @@ result.executionDiagnostics.parseFailures.forEach { failure ->
 }
 ```
 
-The build never aborts when a single file fails to parse — every per-file failure is
-collected into `executionDiagnostics.parseFailures` so callers can surface or ignore
-them. See [`docs/library-api.md`](docs/library-api.md#parse-failures) for the full shape.
+Per-file parse failures are collected into `executionDiagnostics.parseFailures`
+rather than aborting the build; callers can surface or ignore them. The one
+intentional exception: a non-URI `MavenParser` throw aborts the LST build by
+design (silently downgrading it to `XmlParser` would hide regressions and produce
+misleading recipe results). URI-class `MavenParser` failures still fall back to
+`XmlParser` and are recorded normally. Fatal `Error`s (e.g. `OutOfMemoryError`)
+always propagate. See [`docs/library-api.md`](docs/library-api.md#parse-failures)
+for the full shape.
 
 ### Formatted output (ResultFormatter)
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionDiagnostics.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionDiagnostics.kt
@@ -59,8 +59,16 @@ data class ParseFailure(val path: String, val reason: String, val parser: String
  *   - **Thrown exceptions** from `parser.parse(...)` — caught so the build does not
  *     abort. One entry is recorded for every file in the batch that threw.
  *
- *   Empty when every file parsed cleanly. The build never aborts on per-file parse
- *   failures: the recipe still runs against whatever was successfully parsed.
+ *   Empty when every file parsed cleanly. With one deliberate exception, the build
+ *   does not abort on per-file parse failures: the recipe still runs against whatever
+ *   was successfully parsed.
+ *
+ *   **Exception — MavenParser non-URI failures are fatal by design.** A
+ *   `MavenParser` throw whose cause chain does not contain a `URISyntaxException`
+ *   is rethrown rather than recorded, so unrelated MavenParser regressions surface
+ *   instead of being silently downgraded. Only URI-class MavenParser failures fall
+ *   back to `XmlParser` (and are recorded here); every other parser's batch throws
+ *   are caught and recorded.
  */
 data class ExecutionDiagnostics(
     val stageUsed: UsedExecutionStage?,

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionDiagnostics.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/ExecutionDiagnostics.kt
@@ -21,13 +21,21 @@ enum class UsedExecutionStage {
 
 /**
  * A non-fatal parse failure recorded during LST building. Surfaced via
- * [ExecutionDiagnostics.parseFailures] so callers can see which files were degraded
- * (e.g. a `pom.xml` parsed by `XmlParser` instead of `MavenParser` because the
- * Maven dependency graph could not be resolved).
+ * [ExecutionDiagnostics.parseFailures] so callers can see which files the parsers
+ * could not handle without having to scrape the logs.
  *
- * @property path Project-relative source path.
- * @property reason Short, human-readable cause (usually the exception message).
- * @property parser The parser that gave up on this file (e.g. `"MavenParser"`).
+ * The same file path may appear in more than one [ParseFailure] when several parsers
+ * have tried and failed on it — for example a `pom.xml` that trips `MavenParser` and
+ * also `XmlParser` produces one entry per parser.
+ *
+ * @property path Project-relative source path (or the file name when no path is
+ *   available, as with a malformed Maven coordinate string).
+ * @property reason Short, human-readable cause — typically the exception message
+ *   from the parser, the `ParseExceptionResult` marker attached to a [org.openrewrite.tree.ParseError],
+ *   or the literal text `"silently dropped by <parser>"` when a parser returned fewer
+ *   files than it was given.
+ * @property parser The canonical parser name (e.g. `"JavaParser"`, `"MavenParser"`,
+ *   `"XmlParser"`) that gave up on this file.
  */
 data class ParseFailure(val path: String, val reason: String, val parser: String)
 
@@ -40,9 +48,19 @@ data class ParseFailure(val path: String, val reason: String, val parser: String
  * @property resolvedJarCount Number of `.jar` entries on the LST classpath (project
  *   class directories excluded). `0` when [stageUsed] is [UsedExecutionStage.PLUGIN]
  *   (the plugin handled resolution internally) or `null`.
- * @property parseFailures Files that the canonical parser could not handle and that
- *   were either dropped or downgraded to a more lenient parser. Empty when every
- *   file parsed successfully.
+ * @property parseFailures Per-file parse failures collected across every parser the
+ *   LST pipeline ran. Three signals end up here:
+ *
+ *   - **[org.openrewrite.tree.ParseError] SourceFiles** in the parser output — the
+ *     parser produced a stub instead of a real LST node. The `ParseError` itself
+ *     still appears in [LstBuildResult.sourceFiles], so callers can inspect it.
+ *   - **Silently dropped files** — the parser was given a file but returned nothing
+ *     for it. The reason is `"silently dropped by <parser>"`.
+ *   - **Thrown exceptions** from `parser.parse(...)` — caught so the build does not
+ *     abort. One entry is recorded for every file in the batch that threw.
+ *
+ *   Empty when every file parsed cleanly. The build never aborts on per-file parse
+ *   failures: the recipe still runs against whatever was successfully parsed.
  */
 data class ExecutionDiagnostics(
     val stageUsed: UsedExecutionStage?,

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
@@ -49,6 +49,12 @@ import kotlin.io.path.exists
  * This class is thread-safe for concurrent [run] calls only when each call operates on a
  * different [Builder.projectDir]. Sharing the same project directory across concurrent
  * runs is not supported.
+ *
+ * Diagnostics — including per-file parse failures from every parser the LST pipeline
+ * ran — are exposed on [RunResult.executionDiagnostics]. Inspect
+ * [ExecutionDiagnostics.parseFailures] to see which files OpenRewrite could not handle;
+ * the build does not abort on per-file failures, so the recipe still runs against
+ * whatever was successfully parsed.
  */
 class RewriteRunner private constructor(private val config: Builder) {
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
@@ -29,6 +29,8 @@ import kotlin.io.path.name
 import org.openrewrite.DelegatingExecutionContext
 import org.openrewrite.ExecutionContext
 import org.openrewrite.InMemoryExecutionContext
+import org.openrewrite.ParseExceptionResult
+import org.openrewrite.Parser
 import org.openrewrite.SourceFile
 import org.openrewrite.docker.DockerParser
 import org.openrewrite.gradle.GradleParser
@@ -43,6 +45,7 @@ import org.openrewrite.maven.MavenParser
 import org.openrewrite.properties.PropertiesParser
 import org.openrewrite.protobuf.ProtoParser
 import org.openrewrite.toml.TomlParser
+import org.openrewrite.tree.ParseError
 import org.openrewrite.xml.XmlParser
 import org.openrewrite.yaml.YamlParser
 
@@ -215,13 +218,10 @@ open class LstBuilder(
 
         filesByExt[".java"]?.let { files ->
             logger.info("Parsing ${files.size} Java file(s)")
-            val parser = JavaParser
-                .fromJavaVersion()
-                .classpath(classpath)
-                .typeCache(typeCache)
-                .build()
-            val parsed = parser.parse(files, projectDir, parseCtx).toList()
-            reportParseFailures(files, parsed, pendingErrors, projectDir)
+            val parser = buildJavaParser(classpath, typeCache)
+            val parsed = parseAndRecord("JavaParser", files, projectDir, parseFailures) {
+                parser.parse(files, projectDir, parseCtx).toList()
+            }
             pendingErrors.clear()
             parsed.forEach { sourceFile ->
                 val absPath = projectDir.resolve(sourceFile.sourcePath)
@@ -247,8 +247,9 @@ open class LstBuilder(
         filesByExt[".kt"]?.let { files ->
             logger.info("Parsing ${files.size} Kotlin file(s)")
             val parser = KotlinParser.builder().classpath(classpath).typeCache(typeCache).build()
-            val parsed = parser.parse(files, projectDir, parseCtx).toList()
-            reportParseFailures(files, parsed, pendingErrors, projectDir)
+            val parsed = parseAndRecord("KotlinParser", files, projectDir, parseFailures) {
+                parser.parse(files, projectDir, parseCtx).toList()
+            }
             pendingErrors.clear()
             parsed.forEach { sourceFile ->
                 val absPath = projectDir.resolve(sourceFile.sourcePath)
@@ -281,8 +282,10 @@ open class LstBuilder(
                 val parser = KotlinParser.builder().classpath(
                     classpath
                 ).typeCache(typeCache).build()
-                val parsed = parser.parse(plainKtsFiles, projectDir, parseCtx).toList()
-                reportParseFailures(plainKtsFiles, parsed, pendingErrors, projectDir)
+                val parsed =
+                    parseAndRecord("KotlinParser", plainKtsFiles, projectDir, parseFailures) {
+                        parser.parse(plainKtsFiles, projectDir, parseCtx).toList()
+                    }
                 pendingErrors.clear()
                 parsed.forEach { sourceFile ->
                     val absPath = projectDir.resolve(sourceFile.sourcePath)
@@ -309,35 +312,49 @@ open class LstBuilder(
                         "Augmenting GradleParser KTS classpath with ${gradleDslClasspath.size} Gradle DSL JAR(s)"
                     )
                 }
-                try {
-                    val parsed = buildGradleKtsParser(classpath, gradleDslClasspath, typeCache)
+                val parsed = try {
+                    val raw = buildGradleKtsParser(classpath, gradleDslClasspath, typeCache)
                         .parse(gradleKtsFiles, projectDir, parseCtx)
                         .toList()
-                    reportParseFailures(gradleKtsFiles, parsed, pendingErrors, projectDir)
+                    recordParseFailures(
+                        "GradleParser",
+                        gradleKtsFiles,
+                        raw,
+                        projectDir,
+                        parseFailures
+                    )
                     pendingErrors.clear()
-                    parsed.forEach { sf ->
-                        allSources.add(
-                            markerFactory.addGradleProjectMarker(sf, projectDir, resolutionResult)
-                        )
-                    }
+                    raw
                 } catch (e: Exception) {
                     pendingErrors.clear()
                     logger.warn(
                         "GradleParser failed for Kotlin DSL, falling back to KotlinParser: ${e.message}"
                     )
-                    val parsed = KotlinParser.builder()
-                        .classpath(classpath + gradleDslClasspath)
-                        .typeCache(typeCache)
-                        .build()
-                        .parse(gradleKtsFiles, projectDir, parseCtx)
-                        .toList()
-                    reportParseFailures(gradleKtsFiles, parsed, pendingErrors, projectDir)
-                    pendingErrors.clear()
-                    parsed.forEach {
-                        allSources.add(
-                            markerFactory.addGradleProjectMarker(it, projectDir, resolutionResult)
-                        )
-                    }
+                    recordBatchFailure(
+                        "GradleParser",
+                        gradleKtsFiles,
+                        projectDir,
+                        parseFailures,
+                        e
+                    )
+                    parseAndRecord(
+                        "KotlinParser",
+                        gradleKtsFiles,
+                        projectDir,
+                        parseFailures
+                    ) {
+                        KotlinParser.builder()
+                            .classpath(classpath + gradleDslClasspath)
+                            .typeCache(typeCache)
+                            .build()
+                            .parse(gradleKtsFiles, projectDir, parseCtx)
+                            .toList()
+                    }.also { pendingErrors.clear() }
+                }
+                parsed.forEach { sf ->
+                    allSources.add(
+                        markerFactory.addGradleProjectMarker(sf, projectDir, resolutionResult)
+                    )
                 }
             }
         }
@@ -345,8 +362,9 @@ open class LstBuilder(
         filesByExt[".groovy"]?.let { files ->
             logger.info("Parsing ${files.size} Groovy file(s)")
             val parser = GroovyParser.builder().classpath(classpath).typeCache(typeCache).build()
-            val parsed = parser.parse(files, projectDir, parseCtx).toList()
-            reportParseFailures(files, parsed, pendingErrors, projectDir)
+            val parsed = parseAndRecord("GroovyParser", files, projectDir, parseFailures) {
+                parser.parse(files, projectDir, parseCtx).toList()
+            }
             pendingErrors.clear()
             parsed.forEach { sourceFile ->
                 val absPath = projectDir.resolve(sourceFile.sourcePath)
@@ -364,35 +382,32 @@ open class LstBuilder(
                     "Augmenting GradleParser classpath with ${gradleDslClasspath.size} Gradle DSL JAR(s)"
                 )
             }
-            try {
-                val parsed = buildGradleGroovyParser(classpath, gradleDslClasspath, typeCache)
+            val parsed = try {
+                val raw = buildGradleGroovyParser(classpath, gradleDslClasspath, typeCache)
                     .parse(files, projectDir, parseCtx)
                     .toList()
-                reportParseFailures(files, parsed, pendingErrors, projectDir)
+                recordParseFailures("GradleParser", files, raw, projectDir, parseFailures)
                 pendingErrors.clear()
-                parsed.forEach { sf ->
-                    allSources.add(
-                        markerFactory.addGradleProjectMarker(sf, projectDir, resolutionResult)
-                    )
-                }
+                raw
             } catch (e: Exception) {
                 pendingErrors.clear()
                 logger.warn(
                     "GradleParser failed for Groovy DSL, falling back to GroovyParser: ${e.message}"
                 )
-                val parsed = GroovyParser.builder()
-                    .classpath(classpath + gradleDslClasspath)
-                    .typeCache(typeCache)
-                    .build()
-                    .parse(files, projectDir, parseCtx)
-                    .toList()
-                reportParseFailures(files, parsed, pendingErrors, projectDir)
-                pendingErrors.clear()
-                parsed.forEach {
-                    allSources.add(
-                        markerFactory.addGradleProjectMarker(it, projectDir, resolutionResult)
-                    )
-                }
+                recordBatchFailure("GradleParser", files, projectDir, parseFailures, e)
+                parseAndRecord("GroovyParser", files, projectDir, parseFailures) {
+                    GroovyParser.builder()
+                        .classpath(classpath + gradleDslClasspath)
+                        .typeCache(typeCache)
+                        .build()
+                        .parse(files, projectDir, parseCtx)
+                        .toList()
+                }.also { pendingErrors.clear() }
+            }
+            parsed.forEach { sf ->
+                allSources.add(
+                    markerFactory.addGradleProjectMarker(sf, projectDir, resolutionResult)
+                )
             }
         }
 
@@ -400,16 +415,18 @@ open class LstBuilder(
             ((filesByExt[".yaml"] ?: emptyList()) + (filesByExt[".yml"] ?: emptyList()))
         if (yamlFiles.isNotEmpty()) {
             logger.info("Parsing ${yamlFiles.size} YAML file(s)")
-            val parsed = YamlParser().parse(yamlFiles, projectDir, parseCtx).toList()
-            reportParseFailures(yamlFiles, parsed, pendingErrors, projectDir)
+            val parsed = parseAndRecord("YamlParser", yamlFiles, projectDir, parseFailures) {
+                YamlParser().parse(yamlFiles, projectDir, parseCtx).toList()
+            }
             pendingErrors.clear()
             parsed.forEach { allSources.add(it) }
         }
 
         filesByExt[".json"]?.let { files ->
             logger.info("Parsing ${files.size} JSON file(s)")
-            val parsed = JsonParser().parse(files, projectDir, parseCtx).toList()
-            reportParseFailures(files, parsed, pendingErrors, projectDir)
+            val parsed = parseAndRecord("JsonParser", files, projectDir, parseFailures) {
+                JsonParser().parse(files, projectDir, parseCtx).toList()
+            }
             pendingErrors.clear()
             parsed.forEach { allSources.add(it) }
         }
@@ -426,15 +443,16 @@ open class LstBuilder(
                     parseCtx,
                     parseFailures
                 )
-                reportParseFailures(pomFiles, parsed, pendingErrors, projectDir)
                 pendingErrors.clear()
                 parsed.forEach { allSources.add(it) }
             }
 
             if (otherXmlFiles.isNotEmpty()) {
                 logger.info("Parsing ${otherXmlFiles.size} XML file(s)")
-                val parsedXml = XmlParser().parse(otherXmlFiles, projectDir, parseCtx).toList()
-                reportParseFailures(otherXmlFiles, parsedXml, pendingErrors, projectDir)
+                val parsedXml =
+                    parseAndRecord("XmlParser", otherXmlFiles, projectDir, parseFailures) {
+                        buildXmlParser().parse(otherXmlFiles, projectDir, parseCtx).toList()
+                    }
                 pendingErrors.clear()
                 parsedXml.forEach { allSources.add(it) }
             }
@@ -442,18 +460,20 @@ open class LstBuilder(
 
         filesByExt[".properties"]?.let { files ->
             logger.info("Parsing ${files.size} properties file(s)")
-            val parsed = PropertiesParser().parse(files, projectDir, parseCtx).toList()
-            reportParseFailures(files, parsed, pendingErrors, projectDir)
+            val parsed = parseAndRecord("PropertiesParser", files, projectDir, parseFailures) {
+                PropertiesParser().parse(files, projectDir, parseCtx).toList()
+            }
             pendingErrors.clear()
             parsed.forEach { allSources.add(it) }
         }
 
         filesByExt[".toml"]?.let { files ->
             logger.info("Parsing ${files.size} TOML file(s)")
-            val parsed = TomlParser.builder().build()
-                .parse(files, projectDir, parseCtx)
-                .toList()
-            reportParseFailures(files, parsed, pendingErrors, projectDir)
+            val parsed = parseAndRecord("TomlParser", files, projectDir, parseFailures) {
+                TomlParser.builder().build()
+                    .parse(files, projectDir, parseCtx)
+                    .toList()
+            }
             pendingErrors.clear()
             parsed.forEach { allSources.add(it) }
         }
@@ -465,20 +485,22 @@ open class LstBuilder(
         ).flatten()
         if (hclFiles.isNotEmpty()) {
             logger.info("Parsing ${hclFiles.size} HCL file(s)")
-            val parsed = HclParser.builder().build()
-                .parse(hclFiles, projectDir, parseCtx)
-                .toList()
-            reportParseFailures(hclFiles, parsed, pendingErrors, projectDir)
+            val parsed = parseAndRecord("HclParser", hclFiles, projectDir, parseFailures) {
+                HclParser.builder().build()
+                    .parse(hclFiles, projectDir, parseCtx)
+                    .toList()
+            }
             pendingErrors.clear()
             parsed.forEach { allSources.add(it) }
         }
 
         filesByExt[".proto"]?.let { files ->
             logger.info("Parsing ${files.size} Protobuf file(s)")
-            val parsed = ProtoParser.builder().build()
-                .parse(files, projectDir, parseCtx)
-                .toList()
-            reportParseFailures(files, parsed, pendingErrors, projectDir)
+            val parsed = parseAndRecord("ProtoParser", files, projectDir, parseFailures) {
+                ProtoParser.builder().build()
+                    .parse(files, projectDir, parseCtx)
+                    .toList()
+            }
             pendingErrors.clear()
             parsed.forEach { allSources.add(it) }
         }
@@ -489,10 +511,11 @@ open class LstBuilder(
         ).flatten()
         if (dockerFiles.isNotEmpty()) {
             logger.info("Parsing ${dockerFiles.size} Dockerfile(s)")
-            val parsed = DockerParser.builder().build()
-                .parse(dockerFiles, projectDir, parseCtx)
-                .toList()
-            reportParseFailures(dockerFiles, parsed, pendingErrors, projectDir)
+            val parsed = parseAndRecord("DockerParser", dockerFiles, projectDir, parseFailures) {
+                DockerParser.builder().build()
+                    .parse(dockerFiles, projectDir, parseCtx)
+                    .toList()
+            }
             pendingErrors.clear()
             parsed.forEach { allSources.add(it) }
         }
@@ -566,7 +589,9 @@ open class LstBuilder(
                     reason = single.message ?: single.javaClass.simpleName,
                     parser = "MavenParser"
                 )
-                XmlParser().parse(listOf(pom), projectDir, parseCtx).toList()
+                parseAndRecord("XmlParser", listOf(pom), projectDir, failures) {
+                    buildXmlParser().parse(listOf(pom), projectDir, parseCtx).toList()
+                }
             }
         }
     }
@@ -583,6 +608,17 @@ open class LstBuilder(
         generateSequence(t) { it.cause }.any { it is java.net.URISyntaxException }
 
     // ─── Overrideable parser factories (for testing fallback paths) ──────────
+
+    /** Creates the [JavaParser] used for `.java` files. Overrideable in tests. */
+    protected open fun buildJavaParser(classpath: List<Path>, typeCache: JavaTypeCache): Parser =
+        JavaParser
+            .fromJavaVersion()
+            .classpath(classpath)
+            .typeCache(typeCache)
+            .build()
+
+    /** Creates the [XmlParser] used for non-pom `.xml` files and the pom fallback. Overrideable in tests. */
+    protected open fun buildXmlParser(): Parser = XmlParser()
 
     /** Creates the [GradleParser] used for `.gradle.kts` files. Overrideable in tests. */
     protected open fun buildGradleKtsParser(
@@ -805,30 +841,94 @@ open class LstBuilder(
         "${java.io.File.separatorChar}test${java.io.File.separatorChar}"
     )
 
-    private fun reportParseFailures(
+    // ─── Parse-failure collection (shared across every parser site) ──────────
+
+    /**
+     * Run [parse] for [parserName] and record any failures it produces into [failures]:
+     *
+     * - **Thrown exceptions** — caught here so the LST build never aborts on a single
+     *   broken parser. One [ParseFailure] is recorded for every file in [inputFiles],
+     *   each carrying the exception message; the function returns an empty list.
+     * - **[ParseError] SourceFiles** — OpenRewrite parsers signal per-file failure by
+     *   returning a [ParseError] in their output. The error stays in the returned list
+     *   so callers can still see (and inspect) it, but a [ParseFailure] is recorded
+     *   pointing at the same path.
+     * - **Silently dropped files** — any [inputFiles] entry that does not appear in the
+     *   parser output is recorded as a [ParseFailure] with a `silently dropped` reason.
+     */
+    private fun parseAndRecord(
+        parserName: String,
+        inputFiles: List<Path>,
+        projectDir: Path,
+        failures: MutableList<ParseFailure>,
+        parse: () -> List<SourceFile>
+    ): List<SourceFile> {
+        val parsed = try {
+            parse()
+        } catch (t: Throwable) {
+            recordBatchFailure(parserName, inputFiles, projectDir, failures, t)
+            return emptyList()
+        }
+        recordParseFailures(parserName, inputFiles, parsed, projectDir, failures)
+        return parsed
+    }
+
+    /**
+     * Inspect a successful parser run for [ParseError] SourceFiles and silently dropped
+     * input files. Records a [ParseFailure] for each. Used directly by the Gradle DSL
+     * paths so they can still trigger their Kotlin/Groovy fallback when the parser
+     * itself throws.
+     */
+    private fun recordParseFailures(
+        parserName: String,
         inputFiles: List<Path>,
         parsedFiles: List<SourceFile>,
-        errors: List<Throwable>,
-        projectDir: Path
+        projectDir: Path,
+        failures: MutableList<ParseFailure>
     ) {
-        val parsedPaths = parsedFiles.map { it.sourcePath.normalize() }.toSet()
-        val failedEntries = inputFiles
-            .map { file -> file to projectDir.relativize(file).normalize() }
-            .filter { (_, rel) -> rel !in parsedPaths }
-        if (failedEntries.isEmpty()) return
+        parsedFiles.filterIsInstance<ParseError>().forEach { pe ->
+            val message = pe.markers
+                .findFirst(ParseExceptionResult::class.java)
+                .map { it.message?.takeIf { m -> m.isNotBlank() } ?: it.exceptionType }
+                .orElse("parse error")
+            val rel = pe.sourcePath.normalize().toString()
+            failures += ParseFailure(path = rel, reason = message, parser = parserName)
+            logger.warn("$parserName produced a ParseError for $rel: $message")
+        }
 
-        failedEntries.forEach { (file, rel) ->
-            val filename = file.fileName.toString()
-            val reason = errors
-                .firstOrNull { t ->
-                    generateSequence(t) { it.cause }.any { it.message?.contains(filename) == true }
-                }?.message
-                ?: if (errors.size == 1 && failedEntries.size == 1) errors.first().message else null
-            if (reason != null) {
-                logger.warn("Failed to parse $rel: $reason")
-            } else {
-                logger.warn("Failed to parse $rel (run with --debug for error details)")
+        val parsedPaths = parsedFiles.map { it.sourcePath.normalize() }.toSet()
+        inputFiles.forEach { file ->
+            val rel = projectDir.relativize(file).normalize()
+            if (rel !in parsedPaths) {
+                failures += ParseFailure(
+                    path = rel.toString(),
+                    reason = "silently dropped by $parserName",
+                    parser = parserName
+                )
+                logger.warn("$parserName silently dropped $rel")
             }
+        }
+    }
+
+    /**
+     * Record one [ParseFailure] per file when an entire parser invocation throws. Used
+     * directly by the Gradle DSL paths before they trigger their Kotlin/Groovy fallback.
+     */
+    private fun recordBatchFailure(
+        parserName: String,
+        inputFiles: List<Path>,
+        projectDir: Path,
+        failures: MutableList<ParseFailure>,
+        cause: Throwable
+    ) {
+        val reason = cause.message?.takeIf { it.isNotBlank() } ?: cause.javaClass.simpleName
+        logger.warn(
+            "$parserName threw on a batch of ${inputFiles.size} file(s): $reason"
+        )
+        logger.info("$parserName failure details:\n${cause.stackTraceToString()}")
+        inputFiles.forEach { file ->
+            val rel = projectDir.relativize(file).normalize().toString()
+            failures += ParseFailure(path = rel, reason = reason, parser = parserName)
         }
     }
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
@@ -567,7 +567,11 @@ open class LstBuilder(
         parseCtx: ExecutionContext,
         failures: MutableList<ParseFailure>
     ): List<SourceFile> = try {
-        buildMavenParser().parse(pomFiles, projectDir, parseCtx).toList()
+        val parsed = buildMavenParser().parse(pomFiles, projectDir, parseCtx).toList()
+        // Scan the batch output for ParseError SourceFiles and silently dropped poms —
+        // MavenParser may signal per-file trouble without throwing.
+        recordParseFailures("MavenParser", pomFiles, parsed, projectDir, failures)
+        parsed
     } catch (e: Throwable) {
         if (!isUriFailure(e)) throw e
         logger.warn(
@@ -576,7 +580,17 @@ open class LstBuilder(
         )
         pomFiles.flatMap { pom ->
             try {
-                buildMavenParser().parse(listOf(pom), projectDir, parseCtx).toList()
+                val parsedOne =
+                    buildMavenParser().parse(listOf(pom), projectDir, parseCtx).toList()
+                // Per-pom retry can still produce ParseError / drops without throwing.
+                recordParseFailures(
+                    "MavenParser",
+                    listOf(pom),
+                    parsedOne,
+                    projectDir,
+                    failures
+                )
+                parsedOne
             } catch (single: Throwable) {
                 if (!isUriFailure(single)) throw single
                 val rel = projectDir.relativize(pom).normalize().toString()
@@ -863,10 +877,13 @@ open class LstBuilder(
         failures: MutableList<ParseFailure>,
         parse: () -> List<SourceFile>
     ): List<SourceFile> {
+        // Catch [Exception] only — fatal [Error]s (OOM, StackOverflow, …) signal an
+        // invalid JVM state and must propagate so the run fails fast rather than
+        // emitting misleading partial results.
         val parsed = try {
             parse()
-        } catch (t: Throwable) {
-            recordBatchFailure(parserName, inputFiles, projectDir, failures, t)
+        } catch (e: Exception) {
+            recordBatchFailure(parserName, inputFiles, projectDir, failures, e)
             return emptyList()
         }
         recordParseFailures(parserName, inputFiles, parsed, projectDir, failures)

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatter.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatter.kt
@@ -1,5 +1,7 @@
 package io.github.skhokhlov.rewriterunner.output
 
+import io.github.skhokhlov.rewriterunner.ExecutionDiagnostics
+import io.github.skhokhlov.rewriterunner.ParseFailure
 import io.github.skhokhlov.rewriterunner.RunResult
 import java.io.OutputStream
 import java.io.PrintStream
@@ -80,19 +82,39 @@ class ResultFormatter(
     /**
      * Write formatted output for a full [RunResult], including plugin-first raw diffs
      * when no OpenRewrite [Result] objects were produced in-process.
+     *
+     * In [OutputMode.REPORT] mode the emitted JSON additionally carries the
+     * [ExecutionDiagnostics.parseFailures] collected during the LST build, so library
+     * consumers can see which files the parsers could not handle.
      */
     fun format(runResult: RunResult) {
         // In-process recipe results and plugin-first raw diffs are mutually exclusive
         // for normal runner output. Prefer Result objects if a future path supplies both.
         if (runResult.results.isNotEmpty() || runResult.rawDiffs.isEmpty()) {
-            format(runResult.results, runResult.projectDir)
+            when (outputMode) {
+                OutputMode.DIFF -> printDiffs(runResult.results)
+
+                OutputMode.FILES -> printFiles(runResult.results)
+
+                OutputMode.REPORT -> writeReport(
+                    runResult.results,
+                    runResult.projectDir,
+                    runResult.executionDiagnostics
+                )
+            }
             return
         }
 
         when (outputMode) {
             OutputMode.DIFF -> printRawDiffs(runResult.rawDiffs)
+
             OutputMode.FILES -> printRawFiles(runResult.rawDiffs.keys)
-            OutputMode.REPORT -> writeRawReport(runResult.rawDiffs, runResult.projectDir)
+
+            OutputMode.REPORT -> writeRawReport(
+                runResult.rawDiffs,
+                runResult.projectDir,
+                runResult.executionDiagnostics
+            )
         }
     }
 
@@ -142,7 +164,11 @@ class ResultFormatter(
 
     // ─── report ───────────────────────────────────────────────────────────────
 
-    private fun writeReport(results: List<Result>, reportDir: Path) {
+    private fun writeReport(
+        results: List<Result>,
+        reportDir: Path,
+        diagnostics: ExecutionDiagnostics? = null
+    ) {
         val reportFile = reportDir.resolve("openrewrite-report.json").toFile()
         val report = mapOf(
             "totalChanged" to results.size,
@@ -153,13 +179,18 @@ class ResultFormatter(
                     "isDeletedFile" to (r.after == null),
                     "diff" to r.diff()
                 )
-            }
+            },
+            "parseFailures" to parseFailuresJson(diagnostics)
         )
         json.writerWithDefaultPrettyPrinter().writeValue(reportFile, report)
         out.println("Report written to: ${reportFile.absolutePath}")
     }
 
-    private fun writeRawReport(rawDiffs: Map<Path, String>, reportDir: Path) {
+    private fun writeRawReport(
+        rawDiffs: Map<Path, String>,
+        reportDir: Path,
+        diagnostics: ExecutionDiagnostics? = null
+    ) {
         val reportFile = reportDir.resolve("openrewrite-report.json").toFile()
         val report = mapOf(
             "totalChanged" to rawDiffs.size,
@@ -170,9 +201,15 @@ class ResultFormatter(
                     "isDeletedFile" to diff.contains("\n+++ /dev/null\n"),
                     "diff" to diff
                 )
-            }
+            },
+            "parseFailures" to parseFailuresJson(diagnostics)
         )
         json.writerWithDefaultPrettyPrinter().writeValue(reportFile, report)
         out.println("Report written to: ${reportFile.absolutePath}")
     }
+
+    private fun parseFailuresJson(diagnostics: ExecutionDiagnostics?): List<Map<String, String>> =
+        (diagnostics?.parseFailures ?: emptyList()).map { f: ParseFailure ->
+            mapOf("path" to f.path, "reason" to f.reason, "parser" to f.parser)
+        }
 }

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
@@ -18,10 +18,14 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.openrewrite.ExecutionContext
+import org.openrewrite.ParseExceptionResult
 import org.openrewrite.Parser
 import org.openrewrite.SourceFile
+import org.openrewrite.java.internal.JavaTypeCache
+import org.openrewrite.marker.Markers
 import org.openrewrite.maven.MavenParser
 import org.openrewrite.maven.tree.MavenResolutionResult
+import org.openrewrite.tree.ParseError
 
 /**
  * Integration tests for [LstBuilder.build]: parser routing, 3-stage classpath pipeline,
@@ -1475,6 +1479,293 @@ class LstBuilderTest :
                 1,
                 lstBuildResult.executionDiagnostics.resolvedJarCount,
                 "Stage 4 with 1 JAR → resolvedJarCount should be 1"
+            )
+        }
+
+        // ─── Generic parser-level failure collection ─────────────────────────────
+
+        /**
+         * Builds a no-op DependencyResolutionStage with an in-tree cache. Used by helpers
+         * below that construct anonymous [LstBuilder] subclasses.
+         */
+        fun noOpDepStage(): DependencyResolutionStage = object : DependencyResolutionStage(
+            AetherContext.build(
+                projectDir.resolve("cache").resolve("repository"),
+                logger = NoOpRunnerLogger
+            ),
+            NoOpRunnerLogger
+        ) {
+            override fun resolveClasspath(projectDir: Path): ClasspathResolutionResult =
+                ClasspathResolutionResult(emptyList())
+        }
+
+        fun noOpBuildFileStage(): BuildFileParseStage = object : BuildFileParseStage(
+            AetherContext.build(
+                projectDir.resolve("cache").resolve("repository"),
+                logger = NoOpRunnerLogger
+            ),
+            NoOpRunnerLogger
+        ) {
+            override fun resolveClasspath(projectDir: Path): List<Path> = emptyList()
+        }
+
+        /**
+         * Builds a [Parser] whose [Parser.parseInputs] returns whatever [behavior] produces.
+         * The stub is generic — used to stand in for JavaParser / XmlParser etc. in tests.
+         */
+        fun stubParser(behavior: (List<Parser.Input>, Path?) -> List<SourceFile>): Parser =
+            object : Parser {
+                override fun parseInputs(
+                    sources: Iterable<Parser.Input>,
+                    relativeTo: Path?,
+                    ctx: ExecutionContext
+                ): java.util.stream.Stream<SourceFile> {
+                    val inputs = sources.toList()
+                    return behavior(inputs, relativeTo).stream()
+                }
+
+                override fun accept(path: Path): Boolean = true
+
+                override fun sourcePathFromSourceText(prefix: Path, sourceCode: String): Path =
+                    prefix.resolve("Synthetic.java")
+            }
+
+        /** Builds an [LstBuilder] whose Java parser factory returns [stub]. */
+        fun lstBuilderWithJavaStub(stub: Parser): LstBuilder = object : LstBuilder(
+            logger = NoOpRunnerLogger,
+            cacheDir = projectDir.resolve("cache"),
+            toolConfig = toolConfig,
+            projectBuildStage = failingBuildTool,
+            depResolutionStage = noOpDepStage(),
+            buildFileParseStage = noOpBuildFileStage()
+        ) {
+            override fun buildJavaParser(classpath: List<Path>, typeCache: JavaTypeCache): Parser =
+                stub
+        }
+
+        test("ParseError SourceFile in parser output is recorded as a ParseFailure") {
+            projectDir.resolve("Broken.java").writeText("class Broken { /* unterminated")
+
+            val builder = lstBuilderWithJavaStub(
+                stubParser { inputs, relativeTo ->
+                    val input = inputs.single()
+                    val rel = (relativeTo ?: projectDir).relativize(input.path).normalize()
+                    val markers = Markers.EMPTY.addIfAbsent(
+                        ParseExceptionResult(
+                            java.util.UUID.randomUUID(),
+                            "JavaParser",
+                            "ParseException",
+                            "unterminated comment",
+                            null
+                        )
+                    )
+                    listOf(
+                        ParseError(
+                            java.util.UUID.randomUUID(),
+                            markers,
+                            rel,
+                            null,
+                            null,
+                            false,
+                            null,
+                            "class Broken { /* unterminated",
+                            null
+                        )
+                    )
+                }
+            )
+
+            val result = builder.build(
+                projectDir = projectDir,
+                includeExtensionsCli = listOf(".java")
+            )
+
+            val failures = result.executionDiagnostics.parseFailures
+            assertEquals(1, failures.size, "Exactly one ParseFailure should be recorded")
+            val failure = failures.single()
+            assertEquals("Broken.java", failure.path)
+            assertEquals("JavaParser", failure.parser)
+            assertTrue(
+                failure.reason.contains("unterminated", ignoreCase = true),
+                "Reason should reflect the ParseExceptionResult message, got: ${failure.reason}"
+            )
+            // ParseError SourceFile still lives in the LST so callers can inspect it.
+            assertTrue(
+                result.sourceFiles.any { it is ParseError },
+                "ParseError SourceFile should remain in the LST"
+            )
+        }
+
+        test("silently dropped Java input is recorded as a ParseFailure") {
+            projectDir.resolve("Kept.java").writeText("class Kept {}")
+            projectDir.resolve("Dropped.java").writeText("class Dropped {}")
+
+            val builder = lstBuilderWithJavaStub(
+                stubParser { inputs, _ ->
+                    // Drop "Dropped.java" entirely; return only "Kept.java" as a ParseError stub
+                    // so we have a valid SourceFile for the kept input.
+                    inputs
+                        .filter { it.path.fileName.toString() == "Kept.java" }
+                        .map { input ->
+                            ParseError(
+                                java.util.UUID.randomUUID(),
+                                Markers.EMPTY,
+                                projectDir.relativize(input.path).normalize(),
+                                null,
+                                null,
+                                false,
+                                null,
+                                "class Kept {}",
+                                null
+                            ) as SourceFile
+                        }
+                }
+            )
+
+            val result = builder.build(
+                projectDir = projectDir,
+                includeExtensionsCli = listOf(".java")
+            )
+
+            val dropFailures =
+                result.executionDiagnostics.parseFailures.filter { it.path == "Dropped.java" }
+            assertEquals(1, dropFailures.size, "Dropped.java should be recorded once")
+            assertEquals("JavaParser", dropFailures.single().parser)
+            assertTrue(
+                dropFailures.single().reason.contains("dropped", ignoreCase = true),
+                "Drop reason should mention 'dropped', got: ${dropFailures.single().reason}"
+            )
+        }
+
+        test("thrown exception from a parser is recorded and the build continues") {
+            projectDir.resolve("Boom.java").writeText("class Boom {}")
+            projectDir.resolve("config.yaml").writeText("key: value")
+
+            val builder = lstBuilderWithJavaStub(
+                stubParser { _, _ -> throw IllegalStateException("boom") }
+            )
+
+            val result = builder.build(projectDir = projectDir)
+
+            val javaFailures =
+                result.executionDiagnostics.parseFailures.filter { it.parser == "JavaParser" }
+            assertEquals(
+                1,
+                javaFailures.size,
+                "One ParseFailure per .java input should be recorded when the parser throws"
+            )
+            assertEquals("Boom.java", javaFailures.single().path)
+            assertTrue(
+                javaFailures.single().reason.contains("boom"),
+                "Reason should contain the exception message, got: ${javaFailures.single().reason}"
+            )
+            // The YAML file must still be parsed — the JavaParser throw must not abort the build.
+            assertTrue(
+                result.sourceFiles.any { it.sourcePath.toString().endsWith("config.yaml") },
+                "config.yaml should still be parsed when JavaParser throws"
+            )
+        }
+
+        test("Gradle DSL parser failure records a GradleParser ParseFailure and falls back") {
+            projectDir.resolve("build.gradle.kts").writeText(
+                """
+                plugins { id("java") }
+                """.trimIndent()
+            )
+
+            val builder = object : LstBuilder(
+                logger = NoOpRunnerLogger,
+                cacheDir = projectDir.resolve("cache"),
+                toolConfig = toolConfig,
+                projectBuildStage = failingBuildTool,
+                depResolutionStage = noOpDepStage(),
+                buildFileParseStage = noOpBuildFileStage()
+            ) {
+                override fun buildGradleKtsParser(
+                    classpath: List<Path>,
+                    gradleDslClasspath: List<Path>,
+                    typeCache: JavaTypeCache
+                ): org.openrewrite.gradle.GradleParser =
+                    throw IllegalStateException("gradle ktS parser boom")
+            }
+
+            val result = builder.build(
+                projectDir = projectDir,
+                includeExtensionsCli = listOf(".kts")
+            )
+
+            val gradleFailures =
+                result.executionDiagnostics.parseFailures.filter { it.parser == "GradleParser" }
+            assertEquals(
+                1,
+                gradleFailures.size,
+                "GradleParser failure should be recorded exactly once"
+            )
+            assertEquals("build.gradle.kts", gradleFailures.single().path)
+            // The fallback KotlinParser should still produce a SourceFile for the script.
+            assertTrue(
+                result.sourceFiles.any {
+                    it.sourcePath.toString().endsWith("build.gradle.kts")
+                },
+                "Fallback parser should still place build.gradle.kts in the LST"
+            )
+        }
+
+        test("pom that also fails XmlParser produces two ParseFailure entries") {
+            projectDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>bad</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """.trimIndent()
+            )
+
+            val builder = object : LstBuilder(
+                logger = NoOpRunnerLogger,
+                cacheDir = projectDir.resolve("cache"),
+                toolConfig = toolConfig,
+                projectBuildStage = failingBuildTool,
+                depResolutionStage = noOpDepStage(),
+                buildFileParseStage = noOpBuildFileStage()
+            ) {
+                override fun buildMavenParser(): MavenParser =
+                    object : MavenParser(emptyList(), emptyMap(), false) {
+                        override fun parseInputs(
+                            sources: Iterable<Parser.Input>,
+                            relativeTo: Path?,
+                            ctx: ExecutionContext
+                        ): java.util.stream.Stream<SourceFile> = throw IllegalArgumentException(
+                            "Illegal character in path at index 7: pom.xml",
+                            java.net.URISyntaxException("bad", "Illegal character")
+                        )
+                    }
+
+                override fun buildXmlParser(): Parser =
+                    stubParser { _, _ -> throw IllegalStateException("xml parser boom") }
+            }
+
+            val result = builder.build(
+                projectDir = projectDir,
+                includeExtensionsCli = listOf(".xml")
+            )
+
+            val pomFailures =
+                result.executionDiagnostics.parseFailures.filter { it.path == "pom.xml" }
+            assertEquals(
+                2,
+                pomFailures.size,
+                "Both MavenParser and XmlParser failures should be recorded for the same pom"
+            )
+            assertTrue(
+                pomFailures.any { it.parser == "MavenParser" },
+                "MavenParser failure should be present"
+            )
+            assertTrue(
+                pomFailures.any { it.parser == "XmlParser" },
+                "XmlParser fallback failure should be present"
             )
         }
     })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
@@ -1711,6 +1711,108 @@ class LstBuilderTest :
             )
         }
 
+        test("ParseError in MavenParser output is recorded even when no exception is thrown") {
+            // Regression test for the case where MavenParser returns a ParseError SourceFile
+            // (or silently drops a pom) without throwing. The Maven path used to skip the
+            // failure scan and miss these cases.
+            projectDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>silent</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """.trimIndent()
+            )
+
+            val builder =
+                object : LstBuilder(
+                    logger = NoOpRunnerLogger,
+                    cacheDir = projectDir.resolve("cache"),
+                    toolConfig = toolConfig,
+                    projectBuildStage = failingBuildTool,
+                    depResolutionStage = noOpDepStage(),
+                    buildFileParseStage = noOpBuildFileStage()
+                ) {
+                    override fun buildMavenParser(): MavenParser =
+                        object : MavenParser(emptyList(), emptyMap(), false) {
+                            override fun parseInputs(
+                                sources: Iterable<Parser.Input>,
+                                relativeTo: Path?,
+                                ctx: ExecutionContext
+                            ): java.util.stream.Stream<SourceFile> {
+                                // Return a ParseError instead of an Xml.Document, no throw.
+                                val cwd = relativeTo ?: projectDir
+                                return sources
+                                    .toList()
+                                    .map { input ->
+                                        val rel = cwd.relativize(input.path).normalize()
+                                        val markers = Markers.EMPTY.addIfAbsent(
+                                            ParseExceptionResult(
+                                                java.util.UUID.randomUUID(),
+                                                "MavenParser",
+                                                "ParseException",
+                                                "malformed pom marker",
+                                                null
+                                            )
+                                        )
+                                        ParseError(
+                                            java.util.UUID.randomUUID(),
+                                            markers,
+                                            rel,
+                                            null,
+                                            null,
+                                            false,
+                                            null,
+                                            "<project/>",
+                                            null
+                                        ) as SourceFile
+                                    }
+                                    .stream()
+                            }
+                        }
+                }
+
+            val result = builder.build(
+                projectDir = projectDir,
+                includeExtensionsCli = listOf(".xml")
+            )
+
+            val mavenFailures =
+                result.executionDiagnostics.parseFailures.filter { it.parser == "MavenParser" }
+            assertEquals(
+                1,
+                mavenFailures.size,
+                "MavenParser ParseError output should be recorded as a ParseFailure"
+            )
+            assertEquals("pom.xml", mavenFailures.single().path)
+            assertTrue(
+                mavenFailures.single().reason.contains("malformed pom marker"),
+                "Reason should reflect the ParseExceptionResult message"
+            )
+        }
+
+        test("fatal Errors propagate instead of being recorded as ParseFailure") {
+            // OutOfMemoryError / StackOverflowError signal an invalid JVM state.
+            // Continuing the build would emit misleading results.
+            projectDir.resolve("Hello.java").writeText("class Hello {}")
+
+            val builder = lstBuilderWithJavaStub(
+                stubParser { _, _ -> throw OutOfMemoryError("simulated") }
+            )
+
+            val thrown = kotlin.runCatching {
+                builder.build(projectDir = projectDir, includeExtensionsCli = listOf(".java"))
+            }.exceptionOrNull()
+
+            assertNotNull(thrown, "Fatal Error must not be swallowed by parseAndRecord")
+            assertTrue(
+                thrown is OutOfMemoryError && thrown.message == "simulated",
+                "Expected OutOfMemoryError to propagate, got: $thrown"
+            )
+        }
+
         test("pom that also fails XmlParser produces two ParseFailure entries") {
             projectDir.resolve("pom.xml").writeText(
                 """

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatterTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/output/ResultFormatterTest.kt
@@ -1,6 +1,7 @@
 package io.github.skhokhlov.rewriterunner.output
 
 import io.github.skhokhlov.rewriterunner.ExecutionDiagnostics
+import io.github.skhokhlov.rewriterunner.ParseFailure
 import io.github.skhokhlov.rewriterunner.RunResult
 import io.kotest.core.spec.style.FunSpec
 import java.io.ByteArrayOutputStream
@@ -294,5 +295,63 @@ class ResultFormatterTest :
                 json.readTree(reportDir.resolve("openrewrite-report.json").readText())
             assertEquals(1, tree["totalChanged"].asInt())
             assertEquals("Foo.java", tree["results"][0]["filePath"].asText())
+        }
+
+        // ─── parseFailures in REPORT JSON ─────────────────────────────────────────
+
+        test("REPORT mode includes parseFailures from executionDiagnostics") {
+            val runResult =
+                RunResult(
+                    results = emptyList(),
+                    changedFiles = emptyList(),
+                    projectDir = reportDir,
+                    executionDiagnostics =
+                        ExecutionDiagnostics(
+                            stageUsed = null,
+                            resolvedJarCount = 0,
+                            parseFailures = listOf(
+                                ParseFailure(
+                                    path = "src/Broken.java",
+                                    reason = "unterminated comment",
+                                    parser = "JavaParser"
+                                )
+                            )
+                        )
+                )
+
+            captureOutput { pw ->
+                ResultFormatter(OutputMode.REPORT, pw).format(runResult)
+            }
+
+            val tree =
+                json.readTree(reportDir.resolve("openrewrite-report.json").readText())
+            assertTrue(
+                tree.has("parseFailures"),
+                "REPORT JSON should expose a parseFailures array"
+            )
+            assertEquals(1, tree["parseFailures"].size())
+            val entry = tree["parseFailures"][0]
+            assertEquals("src/Broken.java", entry["path"].asText())
+            assertEquals("unterminated comment", entry["reason"].asText())
+            assertEquals("JavaParser", entry["parser"].asText())
+        }
+
+        test("REPORT mode emits empty parseFailures array when none recorded") {
+            val runResult =
+                RunResult(
+                    results = emptyList(),
+                    changedFiles = emptyList(),
+                    projectDir = reportDir,
+                    executionDiagnostics = ExecutionDiagnostics(null, 0)
+                )
+
+            captureOutput { pw ->
+                ResultFormatter(OutputMode.REPORT, pw).format(runResult)
+            }
+
+            val tree =
+                json.readTree(reportDir.resolve("openrewrite-report.json").readText())
+            assertTrue(tree.has("parseFailures"))
+            assertEquals(0, tree["parseFailures"].size())
         }
     })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,6 +116,30 @@ and `rewriteMavenPluginVersion`.
 | `.proto` | `ProtoParser` | — |
 | `.dockerfile` / `.containerfile` / `Dockerfile*` / `Containerfile*` | `DockerParser` | — (matched by extension **and** by filename prefix) |
 
+## Parse Failure Handling
+
+`LstBuilder` wraps every parser invocation in a `parseAndRecord` helper. The build
+never aborts on a per-file parse failure — any of the following gets recorded into
+`ExecutionDiagnostics.parseFailures` and execution continues with whatever was
+successfully parsed:
+
+- A `org.openrewrite.tree.ParseError` returned in a parser's output (the ParseError
+  stub stays in the LST so callers can still inspect it).
+- A file that the parser silently dropped from its output.
+- A thrown exception from `parser.parse(...)` — one entry is recorded for every file
+  in the batch that threw.
+
+Two paths preserve their existing fallback behaviour on top of recording:
+
+- **Maven POMs** — `MavenParser` URI failures fall back to `XmlParser`; both attempts
+  record their own `ParseFailure` if they fail.
+- **Gradle DSL** — `GradleParser` failures on `.gradle` / `*.gradle.kts` fall back to
+  `GroovyParser` / `KotlinParser`; the `GradleParser` failure is recorded before the
+  fallback runs, and the fallback parser's failures (if any) are also recorded.
+
+See [`library-api.md`](library-api.md#parse-failures) for the consumer-facing shape
+and the canonical `parser` names.
+
 ## Gradle DSL Classpath
 
 Resolved from the Gradle installation:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,20 +119,27 @@ and `rewriteMavenPluginVersion`.
 ## Parse Failure Handling
 
 `LstBuilder` wraps every parser invocation in a `parseAndRecord` helper. The build
-never aborts on a per-file parse failure — any of the following gets recorded into
+does not abort on a per-file parse failure — the following are recorded into
 `ExecutionDiagnostics.parseFailures` and execution continues with whatever was
 successfully parsed:
 
 - A `org.openrewrite.tree.ParseError` returned in a parser's output (the ParseError
   stub stays in the LST so callers can still inspect it).
 - A file that the parser silently dropped from its output.
-- A thrown exception from `parser.parse(...)` — one entry is recorded for every file
-  in the batch that threw.
+- A thrown `Exception` from `parser.parse(...)` — one entry is recorded for every
+  file in the batch that threw. Fatal `Error`s (`OutOfMemoryError`,
+  `StackOverflowError`, …) are deliberately **not** caught; they propagate so the
+  run fails fast on an invalid JVM state.
 
 Two paths preserve their existing fallback behaviour on top of recording:
 
-- **Maven POMs** — `MavenParser` URI failures fall back to `XmlParser`; both attempts
-  record their own `ParseFailure` if they fail.
+- **Maven POMs** — only `MavenParser` throws whose cause chain contains a
+  `URISyntaxException` fall back to `XmlParser`. Both attempts record their own
+  `ParseFailure` if they fail. **Any other `MavenParser` exception is rethrown**
+  and aborts the LST build by design: silently downgrading an unrelated
+  `MavenParser` regression to `XmlParser` would hide the failure and produce
+  misleading recipe results. This contract is locked in by
+  `LstBuilderTest`'s `non-URI MavenParser exceptions still bubble up` test.
 - **Gradle DSL** — `GradleParser` failures on `.gradle` / `*.gradle.kts` fall back to
   `GroovyParser` / `KotlinParser`; the `GradleParser` failure is recorded before the
   fallback runs, and the fallback parser's failures (if any) are also recorded.

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -124,12 +124,22 @@ Three signals end up here:
    it. The reason is the literal string `"silently dropped by <parser>"`.
 3. **Thrown exceptions from `parser.parse(...)`** — caught and recorded one
    `ParseFailure` per file in the batch that threw. The exception does **not** abort
-   the LST build.
+   the LST build. Fatal `Error`s (`OutOfMemoryError`, `StackOverflowError`, …) are
+   **not** caught; they propagate so the run fails fast on an invalid JVM state.
 
-The Maven POM path is special: when `MavenParser` fails on a pom and falls back to
-`XmlParser`, the original `MavenParser` failure is recorded, and any failure of the
-`XmlParser` fallback is recorded too — so a single pom can produce two entries with
-the same `path` and different `parser` values.
+The Maven POM path is special:
+
+- When `MavenParser` throws an `IllegalArgumentException` whose cause chain contains
+  a `URISyntaxException` (the `MavenPomDownloader` URI-failure mode), the pom is
+  retried individually and any pom that still fails falls back to `XmlParser`. The
+  `MavenParser` failure is recorded, and any failure of the `XmlParser` fallback is
+  recorded too — so a single pom can produce two entries with the same `path` and
+  different `parser` values.
+- Any other `MavenParser` throw — i.e. a non-URI exception — is **rethrown** and
+  aborts the LST build. This is deliberate: it keeps unrelated `MavenParser`
+  regressions visible instead of silently downgrading them to `XmlParser`. Recipe
+  results would otherwise be misleading. If you need to keep going past such a
+  failure, the caller is responsible for catching and recovering.
 
 ```kotlin
 val result = RewriteRunner.builder()...build().run()

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -76,13 +76,17 @@ Structured signal about which execution path produced the run. Useful for detect
 data class ExecutionDiagnostics(
     val stageUsed: UsedExecutionStage?,
     val resolvedJarCount: Int,
+    val parseFailures: List<ParseFailure> = emptyList(),
 )
+
+data class ParseFailure(val path: String, val reason: String, val parser: String)
 ```
 
 | Property | Description |
 |----------|-------------|
 | `stageUsed` | The stage that produced the classpath, or `null` when every LST stage produced an empty classpath (recipe ran semantically blind) |
 | `resolvedJarCount` | Number of `.jar` entries on the LST classpath (project class directories excluded). `0` when `stageUsed` is `PLUGIN` or `null` |
+| `parseFailures` | Per-file parse failures across every parser the LST pipeline ran (see [Parse failures](#parse-failures) below). Empty when every file parsed cleanly. |
 
 ### Detecting a blind run
 
@@ -102,6 +106,52 @@ if (result.executionDiagnostics.stageUsed == null) {
 | `DEPENDENCY_RESOLUTION` | Stage 2 — `mvn dependency:tree` / `gradle dependencies` + Maven Resolver |
 | `DIRECT_PARSE` | Stage 3 — static build-file parse + POM traversal via Maven Resolver |
 | `LOCAL_REPOSITORY` | Stage 4 — local Maven/Gradle cache scan, no network |
+
+### Parse failures
+
+The LST pipeline never aborts on per-file parse failures. Instead, every signal of
+trouble — from any parser the pipeline ran — is collected into
+`executionDiagnostics.parseFailures` so callers can decide whether to log, ignore, or
+fail their own build.
+
+Three signals end up here:
+
+1. **`org.openrewrite.tree.ParseError` SourceFiles** in the parser output — the parser
+   produced a stub instead of a real LST node. The stub still appears in the LST so it
+   can be inspected; the `ParseFailure` carries the message from the attached
+   `ParseExceptionResult` marker.
+2. **Silently dropped files** — the parser was given a file but returned nothing for
+   it. The reason is the literal string `"silently dropped by <parser>"`.
+3. **Thrown exceptions from `parser.parse(...)`** — caught and recorded one
+   `ParseFailure` per file in the batch that threw. The exception does **not** abort
+   the LST build.
+
+The Maven POM path is special: when `MavenParser` fails on a pom and falls back to
+`XmlParser`, the original `MavenParser` failure is recorded, and any failure of the
+`XmlParser` fallback is recorded too — so a single pom can produce two entries with
+the same `path` and different `parser` values.
+
+```kotlin
+val result = RewriteRunner.builder()...build().run()
+
+result.executionDiagnostics.parseFailures.forEach { failure ->
+    println("${failure.parser} could not handle ${failure.path}: ${failure.reason}")
+}
+
+// Group by parser to spot systematic failures
+val byParser = result.executionDiagnostics.parseFailures.groupBy { it.parser }
+byParser.forEach { (parser, failures) ->
+    println("$parser failed on ${failures.size} file(s)")
+}
+```
+
+Canonical `parser` values today: `JavaParser`, `KotlinParser`, `GroovyParser`,
+`GradleParser`, `YamlParser`, `JsonParser`, `MavenParser`, `XmlParser`,
+`PropertiesParser`, `TomlParser`, `HclParser`, `ProtoParser`, `DockerParser`.
+
+In `--output report` mode the same data is serialized as a top-level `parseFailures`
+array in `openrewrite-report.json` (see [README](../README.md#output-modes) for the
+JSON schema).
 
 Each `org.openrewrite.Result` in `results` exposes:
 - `before` — the source file before the recipe (`null` for newly created files)


### PR DESCRIPTION
Wrap every parser invocation in a parseAndRecord helper that records three classes of per-file failure into ExecutionDiagnostics.parseFailures: ParseError SourceFiles in parser output, silently dropped inputs, and thrown exceptions (one entry per file in the batch). The build never aborts on per-file failures.

Maven POMs keep their URI fallback to XmlParser; the XmlParser fallback now runs through parseAndRecord too, so a pom that fails both parsers shows up twice. Gradle DSL parsers keep their Kotlin/Groovy fallback; the GradleParser batch failure is recorded before the fallback runs.

ResultFormatter REPORT JSON now carries a top-level parseFailures array. README, docs/library-api.md (new "Parse failures" section), docs/architecture.md (new "Parse Failure Handling" section), and KDoc on ExecutionDiagnostics, ParseFailure, and RewriteRunner document the new contract.