### PR TITLE
feat(cli)!: replace --include/--exclude-extensions with glob --exclude-paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ---
 
+## Breaking changes in vNEXT
+
+`--include-extensions` and `--exclude-extensions` have been removed; the `Builder.includeExtensions(...)`, `Builder.excludeExtensions(...)`, and the YAML `parse.includeExtensions` / `parse.excludeExtensions` keys are gone too. The new surface aligns with the upstream OpenRewrite Gradle/Maven plugins' native exclusion primitive:
+
+| Before | After |
+|--------|-------|
+| `--exclude-extensions .md,.json` | `--exclude-paths "**/*.md,**/*.json"` |
+| `--include-extensions .java` | (no replacement — exclusion is the only filter, matching upstream) |
+| `Builder.includeExtensions(...)` / `Builder.excludeExtensions(...)` | (removed; use `Builder.excludePaths(...)`) |
+| `parse.includeExtensions` / `parse.excludeExtensions` in YAML | (removed; use `parse.excludePaths`) |
+
+`--exclude-paths` is forwarded both to the Stage 0 plugin invocation (Maven: `-Drewrite.exclusions=…`; Gradle: `exclusion(...)` lines in the generated init script) and to the LST fallback pipeline, so the two paths apply identical filtering. When the exclusion list eliminates every JVM source file from scope, classpath resolution stages 1–4 are skipped entirely.
+
+---
+
 ## Quick Commands
 
 ```bash
@@ -46,8 +61,7 @@ java -jar cli/build/libs/cli-1.0-SNAPSHOT-all.jar --help
 | `--plugin-run-timeout` | | Stage 0 Gradle/Maven plugin timeout | `10m` |
 | `--resolver-connect-timeout` | | Maven Resolver TCP connection timeout | `30s` |
 | `--resolver-request-timeout` | | Maven Resolver socket/request timeout | `60s` |
-| `--include-extensions` | | Comma-separated file types to parse | — |
-| `--exclude-extensions` | | Comma-separated file types to skip | — |
+| `--exclude-paths` | | Comma-separated glob patterns of files to skip (e.g. `**/generated/**,**/*.md`); forwarded to Stage 0 plugin and LST fallback alike | — |
 | `--info` | | Enable INFO-level logging to stderr | `false` |
 | `--debug` | | Enable DEBUG-level logging (overrides `--info`) | `false` |
 | `--no-maven-central` | | Disable Maven Central; use only repos from config | `false` |
@@ -105,7 +119,7 @@ cli/src/
 - `ProjectBuildStage` and `DependencyResolutionStage` are `open` with `open` methods — subclass in tests instead of mocking
 - `ResultFormatter` has a secondary constructor accepting `PrintWriter`; `RunCommand` passes picocli's `@Spec` output writer
 - Stage 0 tries the official Gradle/Maven OpenRewrite plugins first and returns `RunResult.rawDiffs` on success. Use `--skip-plugin-run` / `Builder.skipPluginRun(true)` when testing or debugging the in-process LST pipeline directly.
-- Extension filtering: CLI flags take precedence over config file settings
+- Path exclusion: `--exclude-paths` (CLI) overrides `parse.excludePaths` (YAML) when non-empty. The resolved value is forwarded to Stage 0 and to the LST fallback so both apply identical filtering. When no JVM source survives the exclusion, classpath resolution stages 1–4 are skipped.
 - OpenRewrite requires all source files in memory simultaneously — for large projects use `-Xmx6g`
 - Dockerfile/Containerfile files are collected both by extension (`.dockerfile`, `.containerfile`) and by filename prefix (`Dockerfile*`, `Containerfile*`) — all go into the `.dockerfile` bucket for `DockerParser`
 - `pom.xml` files are routed to `MavenParser` (full resolution — parent POMs, property interpolation, BOM imports); all other `.xml` files use `XmlParser`. This split happens in the `.xml` routing block inside `LstBuilder.build()` by filtering on `file.name == "pom.xml"`. `MavenParser` adds `MavenResolutionResult` marker, enabling the full `rewrite-maven` recipe catalog. Resolution uses `~/.m2/settings.xml` and local repo; artifacts already cached require no network access.

--- a/README.md
+++ b/README.md
@@ -312,8 +312,7 @@ Usage: rewrite-runner [-h] [--dry-run] [--skip-plugin-run] [--info] [--debug]
                           [--artifact-resolver-request-timeout=<duration>]
                           [--output=<mode>] [--project-dir=<path>]
                           [--rewrite-config=<path>]
-                          [--exclude-extensions=<ext>[,<ext>...]]
-                          [--include-extensions=<ext>[,<ext>...]]
+                          [--exclude-paths=<glob>[,<glob>...]]
                           [--recipe-artifact=<coord>]...
 ```
 
@@ -333,8 +332,7 @@ Usage: rewrite-runner [-h] [--dry-run] [--skip-plugin-run] [--info] [--debug]
 | `--plugin-run-timeout`                | Timeout for plugin-first Gradle/Maven invocations. Accepts `ms`, `s`, `m`, `h`, `d`, or ISO-8601 values. | `10m` |
 | `--artifact-resolver-connect-timeout` | TCP connection timeout for Maven Resolver downloads. Accepts `ms`, `s`, `m`, `h`, `d`, or ISO-8601 values. | `30s` |
 | `--artifact-resolver-request-timeout` | Socket read/request timeout for Maven Resolver downloads. Accepts `ms`, `s`, `m`, `h`, `d`, or ISO-8601 values. | `60s` |
-| `--include-extensions`                | Comma-separated file extensions to parse (e.g. `.java,.kt`) | all supported |
-| `--exclude-extensions`                | Comma-separated file extensions to skip | — |
+| `--exclude-paths`                     | Comma-separated glob patterns of files to skip (e.g. `**/generated/**,**/*.md`). Forwarded to both the Stage 0 plugin (Maven: `-Drewrite.exclusions=…`; Gradle: `exclusion(...)` DSL) and to the LST fallback pipeline. | — |
 | `--no-maven-central`                  | Disable Maven Central; use only repositories from the config file | `false` |
 | `--info`                              | Enable INFO-level logging to stderr | `false` |
 | `--debug`                             | Enable DEBUG-level logging to stderr (overrides `--info`) | `false` |
@@ -461,11 +459,9 @@ resolverConnectTimeout: 30s       # Maven Resolver TCP connection timeout
 resolverRequestTimeout: 60s       # Maven Resolver socket/request timeout
 
 parse:
-  includeExtensions: [".java", ".kt", ".xml"]
-  excludeExtensions: [".properties"]
   excludePaths:
     - "**/generated/**"
-    - "**/build/**"
+    - "**/*.md"
 ```
 
 Environment variable placeholders (`${VAR_NAME}`) are expanded at runtime.
@@ -538,7 +534,7 @@ Unresolved types appear as `JavaType.Unknown` in the LST, but all structural, te
 | `.proto` | `ProtoParser` |
 | `.dockerfile`, `.containerfile`, `Dockerfile*`, `Containerfile*` | `DockerParser` (matched both by extension and by filename prefix) |
 
-The parsed file set is configurable via `--include-extensions`, `--exclude-extensions`, and the `parse` section of `rewriterunner.yml`.
+All supported extensions are parsed by default. Use `--exclude-paths` (CLI), `parse.excludePaths` (YAML), or `Builder.excludePaths(...)` (library) to skip specific paths via glob patterns. The same value is forwarded to the Stage 0 plugin invocation and to the LST fallback pipeline.
 
 ### Automatically excluded directories
 
@@ -546,7 +542,7 @@ The following directories are always skipped during the file-system walk, regard
 
 `.git`, `build`, `target`, `node_modules`, `.gradle`, `.idea`, `out`, `dist`
 
-Use `parse.excludePaths` (or `--exclude-extensions` / `excludePaths()` in the library API) to skip additional paths.
+Use `parse.excludePaths` in `rewriterunner.yml`, `--exclude-paths` on the CLI, or `Builder.excludePaths(...)` in the library to skip additional paths.
 
 ## Development
 

--- a/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
+++ b/cli/src/main/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommand.kt
@@ -99,18 +99,14 @@ class RunCommand : Callable<Int> {
     var debugLogging: Boolean = false
 
     @Option(
-        names = ["--include-extensions"],
-        description = ["Comma-separated list of file extensions to include (e.g. .java,.kt)."],
+        names = ["--exclude-paths"],
+        description = [
+            "Comma-separated glob patterns of files to skip (e.g. '**/generated/**,**/*.md').",
+            "Forwarded to the OpenRewrite Gradle/Maven plugin and to the LST fallback pipeline."
+        ],
         split = ","
     )
-    var includeExtensions: List<String> = emptyList()
-
-    @Option(
-        names = ["--exclude-extensions"],
-        description = ["Comma-separated list of file extensions to exclude."],
-        split = ","
-    )
-    var excludeExtensions: List<String> = emptyList()
+    var excludePaths: List<String> = emptyList()
 
     @Option(
         names = ["--no-maven-central"],
@@ -175,8 +171,7 @@ class RunCommand : Callable<Int> {
                 .recipeArtifacts(recipeArtifacts)
                 .dryRun(dryRun)
                 .skipPluginRun(skipPluginRun)
-                .includeExtensions(includeExtensions)
-                .excludeExtensions(excludeExtensions)
+                .excludePaths(excludePaths)
                 .logger(logger)
             rewriteConfig?.let { builder.rewriteConfig(it) }
             cacheDir?.let { builder.cacheDir(it) }

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
@@ -248,26 +248,33 @@ class RunCommandTest :
             )
         }
 
-        test("--include-extensions splits on comma") {
+        test("--exclude-paths splits on comma") {
             val cmd = RunCommand()
             CommandLine(cmd).parseArgs(
                 "--active-recipe",
                 "io.github.skhokhlov.rewriterunner.MyRecipe",
-                "--include-extensions",
-                ".java,.kt"
+                "--exclude-paths",
+                "**/*.md,src/test/**"
             )
-            assertEquals(listOf(".java", ".kt"), cmd.includeExtensions)
+            assertEquals(listOf("**/*.md", "src/test/**"), cmd.excludePaths)
         }
 
-        test("--exclude-extensions splits on comma") {
-            val cmd = RunCommand()
-            CommandLine(cmd).parseArgs(
+        test("--include-extensions is rejected (removed in breaking change)") {
+            val errBaos = ByteArrayOutputStream()
+            val code = cli().setErr(PrintWriter(errBaos)).execute(
                 "--active-recipe",
-                "io.github.skhokhlov.rewriterunner.MyRecipe",
-                "--exclude-extensions",
-                ".xml,.properties"
+                "io.github.skhokhlov.rewriterunner.MyRecipe"
             )
-            assertEquals(listOf(".xml", ".properties"), cmd.excludeExtensions)
+            assertNotEquals(0, code, "--include-extensions should no longer be recognised")
+        }
+
+        test("--exclude-extensions is rejected (removed in breaking change)") {
+            val errBaos = ByteArrayOutputStream()
+            val code = cli().setErr(PrintWriter(errBaos)).execute(
+                "--active-recipe",
+                "io.github.skhokhlov.rewriterunner.MyRecipe"
+            )
+            assertNotEquals(0, code, "--exclude-extensions should no longer be recognised")
         }
 
         test("--rewrite-config path is accepted") {
@@ -350,9 +357,7 @@ class RunCommandTest :
                         "--active-recipe",
                         "io.github.skhokhlov.rewriterunner.recipe.ThatDoesNotExist",
                         "--cache-dir",
-                        cacheDir.toString(),
-                        "--include-extensions",
-                        ".java"
+                        cacheDir.toString()
                     )
 
             assertNotEquals(0, code, "Nonexistent recipe should produce exit code 1")
@@ -409,8 +414,6 @@ class RunCommandTest :
                         "org.openrewrite.java.format.AutoFormat",
                         "--cache-dir",
                         cacheDir.toString(),
-                        "--include-extensions",
-                        ".java",
                         "--output",
                         "diff"
                     )
@@ -443,8 +446,6 @@ class RunCommandTest :
                 "org.openrewrite.java.format.AutoFormat",
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".java",
                 "--dry-run"
             )
 
@@ -471,8 +472,6 @@ class RunCommandTest :
                         "org.openrewrite.java.format.AutoFormat",
                         "--cache-dir",
                         cacheDir.toString(),
-                        "--include-extensions",
-                        ".java",
                         "--output",
                         "files",
                         "--dry-run"
@@ -500,8 +499,6 @@ class RunCommandTest :
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".java",
                     "--output",
                     "report",
                     "--dry-run"
@@ -537,9 +534,7 @@ class RunCommandTest :
                     "--active-recipe",
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".java"
+                    cacheDir.toString()
                 )
             }
             assertTrue(
@@ -572,9 +567,7 @@ class RunCommandTest :
                     "--rewrite-config",
                     rewriteYaml.toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".java"
+                    cacheDir.toString()
                 )
             }
             assertTrue(

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/DockerProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/DockerProjectIntegrationTest.kt
@@ -53,9 +53,7 @@ class DockerProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".dockerfile"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -82,8 +80,6 @@ class DockerProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".dockerfile",
                 "--dry-run"
             )
 
@@ -110,9 +106,7 @@ class DockerProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".dockerfile"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -136,9 +130,7 @@ class DockerProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".dockerfile"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -164,9 +156,7 @@ class DockerProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".dockerfile"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -194,8 +184,6 @@ class DockerProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".dockerfile",
                     "--dry-run"
                 )
 
@@ -229,8 +217,6 @@ class DockerProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".dockerfile",
                     "--output",
                     "files",
                     "--dry-run"

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/GroovyProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/GroovyProjectIntegrationTest.kt
@@ -57,9 +57,7 @@ class GroovyProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".groovy"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -112,8 +110,6 @@ class GroovyProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".groovy",
                 "--dry-run"
             )
 
@@ -148,9 +144,7 @@ class GroovyProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--skip-plugin-run",
-                    "--include-extensions",
-                    ".gradle"
+                    "--skip-plugin-run"
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -189,7 +183,7 @@ class GroovyProjectIntegrationTest :
             )
         }
 
-        test("only gradle files are modified when include-extensions is dot-gradle") {
+        test("excludePaths skips .groovy file while still processing .gradle") {
             val groovyFile = projectDir.resolve("Helper.groovy")
             val gradleFile = projectDir.resolve("build.gradle")
             groovyFile.writeText("class Helper { def x = 'PLACEHOLDER' }")
@@ -206,22 +200,22 @@ class GroovyProjectIntegrationTest :
                 "--cache-dir",
                 cacheDir.toString(),
                 "--skip-plugin-run",
-                "--include-extensions",
-                ".gradle"
+                "--exclude-paths",
+                "Helper.groovy"
             )
 
             assertEquals(
                 "class Helper { def x = 'PLACEHOLDER' }",
                 groovyFile.readText(),
-                ".groovy file should not be touched when only .gradle is included"
+                ".groovy file should be excluded by --exclude-paths"
             )
             assertTrue(
                 gradleFile.readText().contains("REPLACED"),
-                ".gradle file should be modified"
+                ".gradle file should still be modified"
             )
         }
 
-        test("both groovy and gradle files are processed when no include-extensions is set") {
+        test("both groovy and gradle files are processed when no path exclusion is set") {
             val groovyFile = projectDir.resolve("Helper.groovy")
             val gradleFile = projectDir.resolve("build.gradle")
             groovyFile.writeText("def x = 'PLACEHOLDER'")

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/HclProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/HclProjectIntegrationTest.kt
@@ -56,9 +56,7 @@ class HclProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".tf"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -87,9 +85,7 @@ class HclProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".hcl"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -113,9 +109,7 @@ class HclProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".tfvars"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -140,8 +134,6 @@ class HclProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".tf",
                 "--dry-run"
             )
 
@@ -170,8 +162,6 @@ class HclProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".tf",
                     "--dry-run"
                 )
 
@@ -209,8 +199,6 @@ class HclProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".hcl,.tf,.tfvars",
                     "--output",
                     "files",
                     "--dry-run"

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/JavaProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/JavaProjectIntegrationTest.kt
@@ -49,8 +49,6 @@ class JavaProjectIntegrationTest :
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".java",
                     "--dry-run"
                 )
 
@@ -76,8 +74,6 @@ class JavaProjectIntegrationTest :
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".java",
                     "--dry-run"
                 )
 
@@ -101,8 +97,6 @@ class JavaProjectIntegrationTest :
                 "org.openrewrite.java.format.AutoFormat",
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".java",
                 "--dry-run"
             )
 
@@ -126,9 +120,7 @@ class JavaProjectIntegrationTest :
                     "--active-recipe",
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".java"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -154,8 +146,6 @@ class JavaProjectIntegrationTest :
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".java",
                     "--output",
                     "files",
                     "--dry-run"
@@ -187,8 +177,6 @@ class JavaProjectIntegrationTest :
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".java",
                     "--output",
                     "report",
                     "--dry-run"
@@ -222,8 +210,6 @@ class JavaProjectIntegrationTest :
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".java",
                     "--output",
                     "files",
                     "--dry-run"
@@ -262,10 +248,12 @@ class JavaProjectIntegrationTest :
                 gradlew.setExecutable(true)
 
                 val result = runCli(
-                    "--project-dir", projectDir.toString(),
-                    "--active-recipe", "org.openrewrite.java.format.AutoFormat",
-                    "--cache-dir", cacheDir.toString(),
-                    "--include-extensions", ".java",
+                    "--project-dir",
+                    projectDir.toString(),
+                    "--active-recipe",
+                    "org.openrewrite.java.format.AutoFormat",
+                    "--cache-dir",
+                    cacheDir.toString(),
                     "--skip-plugin-run",
                     "--dry-run"
                 )
@@ -319,10 +307,12 @@ class JavaProjectIntegrationTest :
                 mvnw.setExecutable(true)
 
                 val result = runCli(
-                    "--project-dir", projectDir.toString(),
-                    "--active-recipe", "org.openrewrite.java.format.AutoFormat",
-                    "--cache-dir", cacheDir.toString(),
-                    "--include-extensions", ".java",
+                    "--project-dir",
+                    projectDir.toString(),
+                    "--active-recipe",
+                    "org.openrewrite.java.format.AutoFormat",
+                    "--cache-dir",
+                    cacheDir.toString(),
                     "--skip-plugin-run",
                     "--dry-run"
                 )
@@ -349,10 +339,12 @@ class JavaProjectIntegrationTest :
             gradlew.setExecutable(true)
 
             val result = runCli(
-                "--project-dir", projectDir.toString(),
-                "--active-recipe", "org.openrewrite.java.format.AutoFormat",
-                "--cache-dir", cacheDir.toString(),
-                "--include-extensions", ".java",
+                "--project-dir",
+                projectDir.toString(),
+                "--active-recipe",
+                "org.openrewrite.java.format.AutoFormat",
+                "--cache-dir",
+                cacheDir.toString(),
                 "--dry-run"
             )
 
@@ -380,10 +372,12 @@ class JavaProjectIntegrationTest :
             mvnw.setExecutable(true)
 
             val result = runCli(
-                "--project-dir", projectDir.toString(),
-                "--active-recipe", "org.openrewrite.java.format.AutoFormat",
-                "--cache-dir", cacheDir.toString(),
-                "--include-extensions", ".java",
+                "--project-dir",
+                projectDir.toString(),
+                "--active-recipe",
+                "org.openrewrite.java.format.AutoFormat",
+                "--cache-dir",
+                cacheDir.toString(),
                 "--dry-run"
             )
 
@@ -403,8 +397,6 @@ class JavaProjectIntegrationTest :
                     "org.openrewrite.java.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".java",
                     "--output",
                     "files",
                     "--dry-run"

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/JsonProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/JsonProjectIntegrationTest.kt
@@ -53,9 +53,7 @@ class JsonProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".json"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -79,8 +77,6 @@ class JsonProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".json",
                 "--dry-run"
             )
 
@@ -115,9 +111,7 @@ class JsonProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".json"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -143,8 +137,6 @@ class JsonProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".json",
                     "--dry-run"
                 )
 
@@ -169,8 +161,6 @@ class JsonProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".json",
                     "--output",
                     "files",
                     "--dry-run"

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/KotlinProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/KotlinProjectIntegrationTest.kt
@@ -46,8 +46,6 @@ class KotlinProjectIntegrationTest :
                     "org.openrewrite.kotlin.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".kt",
                     "--dry-run"
                 )
 
@@ -69,8 +67,6 @@ class KotlinProjectIntegrationTest :
                     "org.openrewrite.kotlin.format.AutoFormat",
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".kt",
                     "--dry-run"
                 )
 
@@ -104,9 +100,7 @@ class KotlinProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".kt"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -133,8 +127,6 @@ class KotlinProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".kt",
                 "--dry-run"
             )
 
@@ -168,9 +160,7 @@ class KotlinProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--skip-plugin-run",
-                    "--include-extensions",
-                    ".kts"
+                    "--skip-plugin-run"
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -220,8 +210,6 @@ class KotlinProjectIntegrationTest :
                 "--cache-dir",
                 cacheDir.toString(),
                 "--skip-plugin-run",
-                "--include-extensions",
-                ".kts",
                 "--dry-run"
             )
 
@@ -261,7 +249,7 @@ class KotlinProjectIntegrationTest :
             )
         }
 
-        test("only kts files are modified when include-extensions is dot-kts") {
+        test("excludePaths skips .kt files while still processing .kts") {
             val ktFile = projectDir.resolve("App.kt")
             val ktsFile = projectDir.resolve("build.gradle.kts")
             ktFile.writeText("val url = \"PLACEHOLDER\"")
@@ -278,50 +266,18 @@ class KotlinProjectIntegrationTest :
                 "--cache-dir",
                 cacheDir.toString(),
                 "--skip-plugin-run",
-                "--include-extensions",
-                ".kts"
+                "--exclude-paths",
+                "App.kt"
             )
 
             assertEquals(
                 "val url = \"PLACEHOLDER\"",
                 ktFile.readText(),
-                ".kt file should not be touched when only .kts is included"
+                ".kt file should be excluded by --exclude-paths"
             )
             assertTrue(
                 ktsFile.readText().contains("REPLACED"),
-                ".kts file should be modified"
-            )
-        }
-
-        // ─── Extension filtering ──────────────────────────────────────────────────
-
-        test("only kt files are processed when include-extensions is dot-kt") {
-            projectDir.resolve("App.kt").writeText("val url = \"PLACEHOLDER\"")
-            projectDir.resolve("App.java").writeText("class App { String url = \"PLACEHOLDER\"; }")
-            projectDir.writeFindAndReplaceRecipe(find = "PLACEHOLDER", replace = "REPLACED")
-
-            runCli(
-                "--project-dir",
-                projectDir.toString(),
-                "--active-recipe",
-                "com.example.integration.FindAndReplace",
-                "--rewrite-config",
-                projectDir.resolve("rewrite.yaml").toString(),
-                "--cache-dir",
-                cacheDir.toString(),
-                "--include-extensions",
-                ".kt"
-            )
-
-            assertNotEquals(
-                "val url = \"PLACEHOLDER\"",
-                projectDir.resolve("App.kt").readText(),
-                "Kotlin file should be modified"
-            )
-            assertEquals(
-                "class App { String url = \"PLACEHOLDER\"; }",
-                projectDir.resolve("App.java").readText(),
-                "Java file should not be touched"
+                ".kts file should still be modified"
             )
         }
     })

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/MavenProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/MavenProjectIntegrationTest.kt
@@ -55,8 +55,7 @@ class MavenProjectIntegrationTest :
                     "--active-recipe", "com.example.integration.FindAndReplace",
                     "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir", cacheDir.toString(),
-                    "--skip-plugin-run",
-                    "--include-extensions", ".xml"
+                    "--skip-plugin-run"
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -81,7 +80,6 @@ class MavenProjectIntegrationTest :
                 "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir", cacheDir.toString(),
                 "--skip-plugin-run",
-                "--include-extensions", ".xml",
                 "--dry-run"
             )
 
@@ -106,7 +104,6 @@ class MavenProjectIntegrationTest :
                     "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir", cacheDir.toString(),
                     "--skip-plugin-run",
-                    "--include-extensions", ".xml",
                     "--dry-run"
                 )
 
@@ -142,7 +139,6 @@ class MavenProjectIntegrationTest :
                     "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir", cacheDir.toString(),
                     "--skip-plugin-run",
-                    "--include-extensions", ".xml",
                     "--output", "files",
                     "--dry-run"
                 )
@@ -182,7 +178,6 @@ class MavenProjectIntegrationTest :
                     "--rewrite-config", projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir", cacheDir.toString(),
                     "--skip-plugin-run",
-                    "--include-extensions", ".xml",
                     "--output", "files",
                     "--dry-run"
                 )

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/MultiLanguageProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/MultiLanguageProjectIntegrationTest.kt
@@ -74,94 +74,6 @@ class MultiLanguageProjectIntegrationTest :
             )
         }
 
-        // ─── Extension filtering ──────────────────────────────────────────────────
-
-        test("include-extensions limits processing to specified file types only") {
-            createSpringBootProject()
-            projectDir.writeFindAndReplaceRecipe(find = "PLACEHOLDER", replace = "REPLACED")
-
-            runCli(
-                "--project-dir",
-                projectDir.toString(),
-                "--active-recipe",
-                "com.example.integration.FindAndReplace",
-                "--rewrite-config",
-                projectDir.resolve("rewrite.yaml").toString(),
-                "--cache-dir",
-                cacheDir.toString(),
-                "--skip-plugin-run",
-                "--include-extensions",
-                ".java"
-            )
-
-            // Only Java should be changed
-            assertTrue(
-                projectDir.resolve("src/main/java/com/example/App.java")
-                    .readText()
-                    .contains("REPLACED"),
-                "Java file should be modified"
-            )
-            assertEquals(
-                """class Service { fun hello() = "PLACEHOLDER" }""",
-                projectDir.resolve("src/main/kotlin/com/example/Service.kt").readText(),
-                "Kotlin file must not be modified when .kt is not in include-extensions"
-            )
-            assertTrue(
-                projectDir.resolve("src/main/resources/application.yaml")
-                    .readText()
-                    .contains("PLACEHOLDER"),
-                "YAML file must not be modified"
-            )
-        }
-
-        test("multiple include-extensions targets all specified types") {
-            createSpringBootProject()
-            projectDir.writeFindAndReplaceRecipe(find = "PLACEHOLDER", replace = "REPLACED")
-
-            runCli(
-                "--project-dir",
-                projectDir.toString(),
-                "--active-recipe",
-                "com.example.integration.FindAndReplace",
-                "--rewrite-config",
-                projectDir.resolve("rewrite.yaml").toString(),
-                "--cache-dir",
-                cacheDir.toString(),
-                "--skip-plugin-run",
-                "--include-extensions",
-                ".java,.kt,.yaml"
-            )
-
-            assertTrue(
-                projectDir.resolve("src/main/java/com/example/App.java")
-                    .readText()
-                    .contains("REPLACED"),
-                "Java file should be modified"
-            )
-            assertTrue(
-                projectDir.resolve("src/main/kotlin/com/example/Service.kt")
-                    .readText()
-                    .contains("REPLACED"),
-                "Kotlin file should be modified"
-            )
-            assertTrue(
-                projectDir.resolve("src/main/resources/application.yaml")
-                    .readText()
-                    .contains("REPLACED"),
-                "YAML file should be modified"
-            )
-            assertTrue(
-                projectDir.resolve("src/main/resources/schema.json")
-                    .readText()
-                    .contains("PLACEHOLDER"),
-                "JSON file must not be modified"
-            )
-            assertTrue(
-                projectDir.resolve("pom.xml").readText().contains("PLACEHOLDER"),
-                "XML file must not be modified"
-            )
-        }
-
         // ─── Output modes on multi-file project ───────────────────────────────────
 
         test("diff mode lists all changed files in unified diff format") {
@@ -179,8 +91,6 @@ class MultiLanguageProjectIntegrationTest :
                     "--cache-dir",
                     cacheDir.toString(),
                     "--skip-plugin-run",
-                    "--include-extensions",
-                    ".java,.yaml,.xml,.json,.properties",
                     "--output",
                     "diff",
                     "--dry-run"
@@ -207,8 +117,6 @@ class MultiLanguageProjectIntegrationTest :
                     "--cache-dir",
                     cacheDir.toString(),
                     "--skip-plugin-run",
-                    "--include-extensions",
-                    ".java,.yaml,.xml,.json,.properties",
                     "--output",
                     "files",
                     "--dry-run"
@@ -244,8 +152,6 @@ class MultiLanguageProjectIntegrationTest :
                     "--cache-dir",
                     cacheDir.toString(),
                     "--skip-plugin-run",
-                    "--include-extensions",
-                    ".java,.yaml,.xml,.json,.properties",
                     "--output",
                     "report",
                     "--dry-run"
@@ -288,8 +194,6 @@ class MultiLanguageProjectIntegrationTest :
                 "--cache-dir",
                 cacheDir.toString(),
                 "--skip-plugin-run",
-                "--include-extensions",
-                ".java,.kt,.yaml,.properties,.xml,.json",
                 "--dry-run"
             )
 
@@ -320,8 +224,6 @@ class MultiLanguageProjectIntegrationTest :
                     "--cache-dir",
                     cacheDir.toString(),
                     "--skip-plugin-run",
-                    "--include-extensions",
-                    ".java",
                     "--output",
                     "files",
                     "--dry-run"

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/PropertiesProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/PropertiesProjectIntegrationTest.kt
@@ -59,9 +59,7 @@ class PropertiesProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".properties"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -99,8 +97,6 @@ class PropertiesProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".properties",
                     "--dry-run"
                 )
 
@@ -137,8 +133,6 @@ class PropertiesProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".properties",
                 "--dry-run"
             )
 
@@ -165,9 +159,7 @@ class PropertiesProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".properties"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -203,8 +195,6 @@ class PropertiesProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".properties",
                     "--output",
                     "files",
                     "--dry-run"
@@ -244,9 +234,7 @@ class PropertiesProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".properties"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/ProtoProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/ProtoProjectIntegrationTest.kt
@@ -58,9 +58,7 @@ class ProtoProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".proto"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -88,8 +86,6 @@ class ProtoProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".proto",
                 "--dry-run"
             )
 
@@ -118,8 +114,6 @@ class ProtoProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".proto",
                     "--dry-run"
                 )
 
@@ -156,8 +150,6 @@ class ProtoProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".proto",
                     "--output",
                     "files",
                     "--dry-run"

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/TomlProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/TomlProjectIntegrationTest.kt
@@ -52,9 +52,7 @@ class TomlProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".toml"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -79,8 +77,6 @@ class TomlProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".toml",
                 "--dry-run"
             )
 
@@ -109,8 +105,6 @@ class TomlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".toml",
                     "--dry-run"
                 )
 
@@ -147,8 +141,6 @@ class TomlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".toml",
                     "--output",
                     "files",
                     "--dry-run"

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/XmlProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/XmlProjectIntegrationTest.kt
@@ -54,9 +54,7 @@ class XmlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--skip-plugin-run",
-                    "--include-extensions",
-                    ".xml"
+                    "--skip-plugin-run"
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -80,8 +78,6 @@ class XmlProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".xml",
                 "--dry-run"
             )
 
@@ -116,9 +112,7 @@ class XmlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--skip-plugin-run",
-                    "--include-extensions",
-                    ".xml"
+                    "--skip-plugin-run"
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -149,8 +143,6 @@ class XmlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".xml",
                     "--output",
                     "files",
                     "--dry-run"
@@ -181,8 +173,6 @@ class XmlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".xml",
                     "--dry-run"
                 )
 

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/YamlProjectIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/YamlProjectIntegrationTest.kt
@@ -53,9 +53,7 @@ class YamlProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".yaml"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -78,9 +76,7 @@ class YamlProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".yml"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -105,8 +101,6 @@ class YamlProjectIntegrationTest :
                 projectDir.resolve("rewrite.yaml").toString(),
                 "--cache-dir",
                 cacheDir.toString(),
-                "--include-extensions",
-                ".yaml",
                 "--dry-run"
             )
 
@@ -135,8 +129,6 @@ class YamlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".yaml",
                     "--dry-run"
                 )
 
@@ -178,9 +170,7 @@ class YamlProjectIntegrationTest :
                     "--rewrite-config",
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
-                    cacheDir.toString(),
-                    "--include-extensions",
-                    ".yaml"
+                    cacheDir.toString()
                 )
 
             assertEquals(0, result.exitCode, "stderr: ${result.stderr}")
@@ -208,8 +198,6 @@ class YamlProjectIntegrationTest :
                     projectDir.resolve("rewrite.yaml").toString(),
                     "--cache-dir",
                     cacheDir.toString(),
-                    "--include-extensions",
-                    ".yaml",
                     "--output",
                     "files",
                     "--dry-run"

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunner.kt
@@ -103,6 +103,12 @@ class RewriteRunner private constructor(private val config: Builder) {
                 "resolverRequestTimeout"
             )
 
+        // Single resolution point for path exclusions: CLI override beats YAML config when
+        // non-empty. The same value is forwarded to Stage 0 and to the LST builder so the
+        // two execution paths apply identical filtering.
+        val effectiveExcludePaths: List<String> =
+            config.excludePaths.ifEmpty { toolConfig.parse.excludePaths }
+
         // Stage 0: let the project's own build tool run the official OpenRewrite plugin first.
         if (!config.skipPluginRun) {
             logger.lifecycle("[0/7] Attempting plugin-first recipe execution")
@@ -122,7 +128,8 @@ class RewriteRunner private constructor(private val config: Builder) {
                     includeMavenCentral = config.includeMavenCentral
                         ?: toolConfig.includeMavenCentral,
                     artifactRepositories =
-                        toolConfig.resolvedArtifactRepositories() + config.artifactRepositories
+                        toolConfig.resolvedArtifactRepositories() + config.artifactRepositories,
+                    excludePaths = effectiveExcludePaths
                 )
             when (pluginResult) {
                 is PluginRunResult.Success -> {
@@ -254,19 +261,11 @@ class RewriteRunner private constructor(private val config: Builder) {
                     toolConfig = effectiveToolConfig,
                     aetherContext = projectAetherContext
                 )
-            val effectiveParseConfig =
-                if (config.excludePaths.isNotEmpty()) {
-                    toolConfig.parse.copy(excludePaths = config.excludePaths)
-                } else {
-                    toolConfig.parse
-                }
             val lstStart = System.currentTimeMillis()
             val lstBuildResult: LstBuildResult =
                 lstBuilder.build(
                     projectDir = config.projectDir,
-                    parseConfig = effectiveParseConfig,
-                    includeExtensionsCli = config.includeExtensions,
-                    excludeExtensionsCli = config.excludeExtensions
+                    excludePaths = effectiveExcludePaths
                 )
             val sourceFiles = lstBuildResult.sourceFiles
             logger.lifecycle(
@@ -361,10 +360,6 @@ class RewriteRunner private constructor(private val config: Builder) {
             private set
         internal var skipPluginRun: Boolean = false
             private set
-        internal var includeExtensions: List<String> = emptyList()
-            private set
-        internal var excludeExtensions: List<String> = emptyList()
-            private set
         internal var includeMavenCentral: Boolean? = null
             private set
         internal var artifactDownloadThreads: Int? = null
@@ -452,22 +447,6 @@ class RewriteRunner private constructor(private val config: Builder) {
         fun skipPluginRun(value: Boolean): Builder = apply { skipPluginRun = value }
 
         /**
-         * Restrict parsing to the given file extensions (e.g. `".java"`, `".kt"`).
-         * Overrides any `includeExtensions` setting from the tool config file.
-         */
-        fun includeExtensions(extensions: List<String>): Builder = apply {
-            includeExtensions = extensions
-        }
-
-        /**
-         * Skip parsing files with the given extensions.
-         * Overrides any `excludeExtensions` setting from the tool config file.
-         */
-        fun excludeExtensions(extensions: List<String>): Builder = apply {
-            excludeExtensions = extensions
-        }
-
-        /**
          * Set the number of parallel artifact download threads. Defaults to 5.
          * When not set, falls back to `downloadThreads` from the tool config.
          */
@@ -522,6 +501,11 @@ class RewriteRunner private constructor(private val config: Builder) {
          * Glob patterns (relative to the project root) for paths to skip during parsing.
          * When non-empty, overrides `parse.excludePaths` from the tool config file.
          * Supports the same glob syntax as [java.nio.file.FileSystem.getPathMatcher].
+         *
+         * The same value is forwarded both to Stage 0 (the official OpenRewrite Gradle/Maven
+         * plugin invocation — Maven receives `-Drewrite.exclusions=…` and Gradle receives
+         * `exclusion(...)` lines inside the generated init script's `rewrite { }` block) and
+         * to the LST fallback pipeline, so the two execution paths apply identical filtering.
          */
         fun excludePaths(paths: List<String>): Builder = apply { excludePaths = paths }
 

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfig.kt
@@ -35,21 +35,14 @@ data class RepositoryConfig(
 /**
  * File parsing configuration for the LST-building stage.
  *
- * Controls which file types are included or excluded from parsing, and which file paths
- * are skipped via glob patterns.
+ * Controls which file paths are skipped via glob patterns. Matches the exclusion-only
+ * semantics of the upstream OpenRewrite Gradle/Maven plugins so Stage 0 plugin runs
+ * and the LST fallback apply identical filtering.
  *
- * @property includeExtensions Explicit set of file extensions to parse (e.g. `[".java", ".kt"]`).
- *   When empty, all [io.github.skhokhlov.rewriterunner.lst.LstBuilder] default extensions are used.
- * @property excludeExtensions Extensions to exclude from the default set.
- * @property excludePaths Glob patterns (relative to project root) for paths to skip entirely
- *   (e.g. `["generated/", "vendor/"]`).
+ * @property excludePaths Glob patterns (relative to project root) for paths to skip entirely.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class ParseConfig(
-    val includeExtensions: List<String> = emptyList(),
-    val excludeExtensions: List<String> = emptyList(),
-    val excludePaths: List<String> = emptyList()
-)
+data class ParseConfig(val excludePaths: List<String> = emptyList())
 
 /**
  * Top-level tool configuration, typically loaded from `rewriterunner.yml`.

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
@@ -5,7 +5,6 @@ import io.github.skhokhlov.rewriterunner.ExecutionDiagnostics
 import io.github.skhokhlov.rewriterunner.ParseFailure
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.UsedExecutionStage
-import io.github.skhokhlov.rewriterunner.config.ParseConfig
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
 import io.github.skhokhlov.rewriterunner.lst.utils.ClasspathResolutionResult
 import io.github.skhokhlov.rewriterunner.lst.utils.FileCollector
@@ -54,6 +53,9 @@ data class LstBuildResult(
     val sourceFiles: List<SourceFile>,
     val executionDiagnostics: ExecutionDiagnostics
 )
+
+/** Extensions whose presence requires JVM classpath resolution (stages 1–4). */
+private val JVM_SOURCE_EXTENSIONS = setOf(".java", ".kt", ".kts", ".groovy", ".gradle")
 
 /**
  * Orchestrates the 4-stage LST building pipeline and multi-language file parsing.
@@ -129,25 +131,22 @@ open class LstBuilder(
     /**
      * Parse all source files in [projectDir] into OpenRewrite SourceFile trees.
      *
-     * Runs the 3-stage classpath resolution pipeline, then dispatches each collected file
-     * to the appropriate language parser based on its extension.
+     * Runs the 4-stage classpath resolution pipeline (skipped entirely when no JVM source
+     * files survive [excludePaths]), then dispatches each collected file to the appropriate
+     * language parser based on its extension.
      *
      * @param projectDir Root of the project to parse. Must be an existing directory.
-     * @param parseConfig Extension inclusion/exclusion and glob-exclusion settings from the
-     *   tool config file. CLI flags ([includeExtensionsCli], [excludeExtensionsCli]) take
-     *   precedence when non-empty.
-     * @param includeExtensionsCli File extensions to include, as specified via CLI or the
-     *   library [io.github.skhokhlov.rewriterunner.RewriteRunner.Builder]. Overrides [parseConfig] when non-empty.
-     * @param excludeExtensionsCli File extensions to skip. Overrides [parseConfig] when non-empty.
+     * @param excludePaths Glob patterns (relative to [projectDir]) of files to skip. Same
+     *   semantics as the upstream OpenRewrite Gradle/Maven plugin exclusions. Resolved by
+     *   [io.github.skhokhlov.rewriterunner.RewriteRunner] from CLI override over
+     *   [io.github.skhokhlov.rewriterunner.config.ParseConfig.excludePaths] before reaching here.
      * @param ctx OpenRewrite execution context. Defaults to an [org.openrewrite.InMemoryExecutionContext]
      *   that logs parse warnings without aborting.
      * @return An [LstBuildResult] containing the parsed source files and execution diagnostics.
      */
     fun build(
         projectDir: Path,
-        parseConfig: ParseConfig = toolConfig.parse,
-        includeExtensionsCli: List<String> = emptyList(),
-        excludeExtensionsCli: List<String> = emptyList(),
+        excludePaths: List<String> = toolConfig.parse.excludePaths,
         ctx: ExecutionContext = InMemoryExecutionContext {}
     ): LstBuildResult {
         val pendingErrors = mutableListOf<Throwable>()
@@ -161,8 +160,7 @@ open class LstBuilder(
 
             override fun getOnError(): Consumer<Throwable> = errorConsumer
         }
-        val effectiveExtensions =
-            fileCollector.resolveExtensions(parseConfig, includeExtensionsCli, excludeExtensionsCli)
+        val effectiveExtensions = FileCollector.DEFAULT_EXTENSIONS
         logger.info("Parsing extensions: $effectiveExtensions")
 
         // ── Per-build parse-failure accumulator ───────────────────────────────
@@ -170,8 +168,30 @@ open class LstBuilder(
         // Maven coordinate failures alongside per-file parse failures.
         val parseFailures = mutableListOf<ParseFailure>()
 
+        // ── Collect files by extension ────────────────────────────────────────
+        val filesByExt = fileCollector.collectFiles(
+            projectDir,
+            effectiveExtensions,
+            excludePaths
+        )
+        val totalFiles = filesByExt.values.sumOf { it.size }
+        logger.lifecycle(
+            "Found $totalFiles files to parse across ${filesByExt.keys.size} extension group(s)"
+        )
+
         // ── 4-stage classpath resolution ──────────────────────────────────────
-        val resolutionResult = resolveClasspath(projectDir, parseFailures)
+        // Skip the four classpath stages entirely when no JVM source survived
+        // [excludePaths] filtering — running mvn/gradle subprocesses is pointless when no
+        // parser would consume their output.
+        val hasJvmSources = filesByExt.keys.any { it in JVM_SOURCE_EXTENSIONS }
+        val resolutionResult = if (hasJvmSources) {
+            resolveClasspath(projectDir, parseFailures)
+        } else {
+            logger.info(
+                "No JVM source files in scope — skipping classpath resolution stages."
+            )
+            ClasspathResolutionResult(emptyList())
+        }
         val classpath = resolutionResult.classpath
 
         // ── Shared type cache — all JVM parsers share one instance ────────────
@@ -187,21 +207,8 @@ open class LstBuilder(
         val javaVersionCache = mutableMapOf<Path, Pair<String, String>?>()
         val kotlinVersionCache = mutableMapOf<Path, Pair<String, String>?>()
 
-        // ── Collect files by extension ────────────────────────────────────────
-        val filesByExt = fileCollector.collectFiles(
-            projectDir,
-            effectiveExtensions,
-            parseConfig.excludePaths
-        )
-        val totalFiles = filesByExt.values.sumOf { it.size }
-        logger.lifecycle(
-            "Found $totalFiles files to parse across ${filesByExt.keys.size} extension group(s)"
-        )
-
         // ── Warn unconditionally when all stages produced empty classpath ─────
-        val jvmExtensions = setOf(".java", ".kt", ".kts", ".groovy")
-        val hasJvmFiles = jvmExtensions.any { filesByExt[it]?.isNotEmpty() == true }
-        if (classpath.isEmpty() && hasJvmFiles) {
+        if (classpath.isEmpty() && hasJvmSources) {
             logger.warn(
                 "Classpath resolution failed across all 4 stages — " +
                     "type information will be missing. Recipe results may be incomplete."

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/FileCollector.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/FileCollector.kt
@@ -1,6 +1,5 @@
 package io.github.skhokhlov.rewriterunner.lst.utils
 
-import io.github.skhokhlov.rewriterunner.config.ParseConfig
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
@@ -91,33 +90,6 @@ internal class FileCollector(
         }
 
         return result
-    }
-
-    /**
-     * Resolves the effective set of extensions to parse, applying CLI-flag overrides on
-     * top of [parseConfig] and normalising each entry to a dot-prefixed lowercase string.
-     * CLI flags take precedence over config file settings.
-     */
-    fun resolveExtensions(
-        parseConfig: ParseConfig,
-        includeExtensionsCli: List<String>,
-        excludeExtensionsCli: List<String>
-    ): Set<String> {
-        val include = (
-            includeExtensionsCli.takeIf { it.isNotEmpty() }
-                ?: parseConfig.includeExtensions
-            )
-            .map { it.lowercase().let { e -> if (e.startsWith(".")) e else ".$e" } }
-
-        val exclude = (
-            excludeExtensionsCli.takeIf { it.isNotEmpty() }
-                ?: parseConfig.excludeExtensions
-            )
-            .map { it.lowercase().let { e -> if (e.startsWith(".")) e else ".$e" } }
-            .toSet()
-
-        val base = include.takeIf { it.isNotEmpty() }?.toSet() ?: defaultExtensions
-        return base - exclude
     }
 
     /**

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategy.kt
@@ -8,6 +8,14 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 
+/**
+ * Gradle-side [PluginBuildStrategy] implementation.
+ *
+ * Forwards `excludePaths` to the upstream `rewrite-gradle-plugin` by emitting
+ * `exclusion("…")` lines inside the generated init script's `rewrite { }` block — the
+ * plugin does not expose `-P`-style overrides for exclusions, so the DSL is the only
+ * supported injection point. Each glob is escaped via [groovyString] before substitution.
+ */
 internal open class GradlePluginStrategy(
     private val logger: RunnerLogger,
     private val timeout: Duration,
@@ -21,7 +29,8 @@ internal open class GradlePluginStrategy(
         rewriteConfigContent: String?,
         dryRun: Boolean,
         includeMavenCentral: Boolean,
-        artifactRepositories: List<RepositoryConfig>
+        artifactRepositories: List<RepositoryConfig>,
+        excludePaths: List<String>
     ): PluginRunResult {
         val effectiveRewriteConfig =
             createRewriteConfigFile(rewriteConfigContent)
@@ -32,7 +41,8 @@ internal open class GradlePluginStrategy(
                 recipeArtifacts = recipeArtifacts,
                 rewriteConfig = effectiveRewriteConfig,
                 includeMavenCentral = includeMavenCentral,
-                repositories = artifactRepositories
+                repositories = artifactRepositories,
+                excludePaths = excludePaths
             )
         return try {
             DirectPluginExecutor(projectDir, dryRun, ::execute).run(
@@ -57,7 +67,8 @@ internal open class GradlePluginStrategy(
         recipeArtifacts: List<String>,
         rewriteConfig: Path?,
         includeMavenCentral: Boolean,
-        repositories: List<RepositoryConfig>
+        repositories: List<RepositoryConfig>,
+        excludePaths: List<String> = emptyList()
     ): Path {
         val initScript = createPrivateTempFile("rewrite-runner-plugin-", ".gradle")
         val text =
@@ -99,6 +110,9 @@ internal open class GradlePluginStrategy(
                     appendLine(
                         "        configFile = file(\"${it.toAbsolutePath().toString().groovyString()}\")"
                     )
+                }
+                excludePaths.forEach {
+                    appendLine("        exclusion(\"${it.groovyString()}\")")
                 }
                 appendLine("    }")
                 if (recipeArtifacts.isNotEmpty()) {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
@@ -14,6 +14,13 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader
 private const val FALLBACK_POM_DISCOVERY_DEPTH = 6
 private val MAVEN_PATCH_PATH: Path = Path.of("target/site/rewrite/rewrite.patch")
 
+/**
+ * Maven-side [PluginBuildStrategy] implementation.
+ *
+ * Forwards `excludePaths` to the upstream `rewrite-maven-plugin` via the
+ * `-Drewrite.exclusions=<csv>` system property (the plugin's documented exclusion knob),
+ * joined into a comma-separated list of globs.
+ */
 internal open class MavenPluginStrategy(
     private val logger: RunnerLogger,
     private val timeout: Duration,
@@ -27,7 +34,8 @@ internal open class MavenPluginStrategy(
         rewriteConfigContent: String?,
         dryRun: Boolean,
         includeMavenCentral: Boolean,
-        artifactRepositories: List<RepositoryConfig>
+        artifactRepositories: List<RepositoryConfig>,
+        excludePaths: List<String>
     ): PluginRunResult {
         val effectiveRewriteConfig =
             createRewriteConfigFile(rewriteConfigContent)
@@ -40,14 +48,16 @@ internal open class MavenPluginStrategy(
                         goal = "dryRun",
                         activeRecipe = activeRecipe,
                         recipeArtifacts = recipeArtifacts,
-                        rewriteConfig = effectiveRewriteConfig
+                        rewriteConfig = effectiveRewriteConfig,
+                        excludePaths = excludePaths
                     ),
                     applyCommand = buildCommand(
                         projectDir = projectDir,
                         goal = "run",
                         activeRecipe = activeRecipe,
                         recipeArtifacts = recipeArtifacts,
-                        rewriteConfig = effectiveRewriteConfig
+                        rewriteConfig = effectiveRewriteConfig,
+                        excludePaths = excludePaths
                     ),
                     patchFiles = { findPatchFiles(projectDir) },
                     dryRunFailureMessage = { pluginFailureMessage("Maven rewrite:dryRun", it) },
@@ -66,7 +76,8 @@ internal open class MavenPluginStrategy(
         goal: String,
         activeRecipe: String,
         recipeArtifacts: List<String>,
-        rewriteConfig: Path?
+        rewriteConfig: Path?,
+        excludePaths: List<String> = emptyList()
     ): List<String> = buildList {
         add(resolveMavenCommand(projectDir))
         add("-U")
@@ -79,6 +90,9 @@ internal open class MavenPluginStrategy(
         add("-Drewrite.activeRecipes=$activeRecipe")
         if (recipeArtifacts.isNotEmpty()) {
             add("-Drewrite.recipeArtifactCoordinates=${recipeArtifacts.joinToString(",")}")
+        }
+        if (excludePaths.isNotEmpty()) {
+            add("-Drewrite.exclusions=${excludePaths.joinToString(",")}")
         }
         rewriteConfig?.let {
             add("-Drewrite.configLocation=${it.toAbsolutePath()}")

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginBuildStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginBuildStrategy.kt
@@ -4,6 +4,14 @@ import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
 import java.nio.file.Path
 
 internal interface PluginBuildStrategy {
+    /**
+     * Invoke the project's native OpenRewrite plugin (Maven or Gradle) with the given recipe
+     * configuration.
+     *
+     * @param excludePaths Glob patterns of files to exclude from parsing. Forwarded to the
+     *   upstream plugin in its native format (Maven: `-Drewrite.exclusions=…`; Gradle:
+     *   `exclusion(...)` DSL calls in the init script). Empty list means no exclusion.
+     */
     fun run(
         projectDir: Path,
         activeRecipe: String,
@@ -12,6 +20,7 @@ internal interface PluginBuildStrategy {
         rewriteConfigContent: String?,
         dryRun: Boolean,
         includeMavenCentral: Boolean,
-        artifactRepositories: List<RepositoryConfig>
+        artifactRepositories: List<RepositoryConfig>,
+        excludePaths: List<String> = emptyList()
     ): PluginRunResult
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunner.kt
@@ -21,6 +21,10 @@ internal class PluginRecipeRunner(
 ) {
     /**
      * Tries Gradle before Maven when both root build files are present.
+     *
+     * @param excludePaths Glob patterns of files to exclude from parsing. Passed verbatim to
+     *   whichever strategy ([gradleStrategy] / [mavenStrategy]) is dispatched; each strategy
+     *   renders them in its own native plugin format.
      */
     fun run(
         projectDir: Path,
@@ -30,7 +34,8 @@ internal class PluginRecipeRunner(
         rewriteConfigContent: String?,
         dryRun: Boolean,
         includeMavenCentral: Boolean,
-        artifactRepositories: List<RepositoryConfig>
+        artifactRepositories: List<RepositoryConfig>,
+        excludePaths: List<String> = emptyList()
     ): PluginRunResult {
         val hasGradle = hasBuildGradle(projectDir)
         val hasPom = projectDir.resolve("pom.xml").exists()
@@ -53,7 +58,8 @@ internal class PluginRecipeRunner(
                         rewriteConfigContent = rewriteConfigContent,
                         dryRun = dryRun,
                         includeMavenCentral = includeMavenCentral,
-                        artifactRepositories = artifactRepositories
+                        artifactRepositories = artifactRepositories,
+                        excludePaths = excludePaths
                     )
             ) {
                 is PluginRunResult.Failed -> failures.add(result)
@@ -73,7 +79,8 @@ internal class PluginRecipeRunner(
                         rewriteConfigContent = rewriteConfigContent,
                         dryRun = dryRun,
                         includeMavenCentral = includeMavenCentral,
-                        artifactRepositories = artifactRepositories
+                        artifactRepositories = artifactRepositories,
+                        excludePaths = excludePaths
                     )
             ) {
                 is PluginRunResult.Failed -> failures.add(result)

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerBuilderTest.kt
@@ -147,24 +147,14 @@ class RewriteRunnerBuilderTest :
             assertEquals(Duration.ofSeconds(20), builder.artifactResolverRequestTimeout)
         }
 
-        test("builder stores includeExtensions") {
-            val extensions = listOf(".java", ".kt")
+        test("builder stores excludePaths") {
+            val paths = listOf("**/generated/**", "**/*.md")
             val builder =
                 RewriteRunner.builder()
                     .projectDir(tempDir)
                     .activeRecipe("org.openrewrite.FindSourceFiles")
-                    .includeExtensions(extensions)
-            assertEquals(extensions, builder.includeExtensions)
-        }
-
-        test("builder stores excludeExtensions") {
-            val extensions = listOf(".xml", ".yml")
-            val builder =
-                RewriteRunner.builder()
-                    .projectDir(tempDir)
-                    .activeRecipe("org.openrewrite.FindSourceFiles")
-                    .excludeExtensions(extensions)
-            assertEquals(extensions, builder.excludeExtensions)
+                    .excludePaths(paths)
+            assertEquals(paths, builder.excludePaths)
         }
 
         // ── Default values ───────────────────────────────────────────────────────
@@ -207,14 +197,9 @@ class RewriteRunnerBuilderTest :
             assertTrue(builder.recipeArtifacts.isEmpty())
         }
 
-        test("includeExtensions defaults to empty") {
+        test("excludePaths defaults to empty") {
             val builder = RewriteRunner.builder()
-            assertTrue(builder.includeExtensions.isEmpty())
-        }
-
-        test("excludeExtensions defaults to empty") {
-            val builder = RewriteRunner.builder()
-            assertTrue(builder.excludeExtensions.isEmpty())
+            assertTrue(builder.excludePaths.isEmpty())
         }
 
         // ── Run-time behaviour ───────────────────────────────────────────────────

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfigTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/config/ToolConfigTest.kt
@@ -50,15 +50,26 @@ class ToolConfigTest :
             configFile.writeText(
                 """
                 parse:
-                  includeExtensions: [".java", ".kt"]
+                  excludePaths: ["**/generated/**", "**/*.md"]
+                """.trimIndent()
+            )
+
+            val config = ToolConfig.load(configFile, NoOpRunnerLogger)
+            assertEquals(listOf("**/generated/**", "**/*.md"), config.parse.excludePaths)
+        }
+
+        test("ignores unknown legacy parse fields without error") {
+            val configFile = tempDir.resolve("runner.yml")
+            configFile.writeText(
+                """
+                parse:
+                  includeExtensions: [".java"]
                   excludeExtensions: [".xml"]
                   excludePaths: ["**/generated/**"]
                 """.trimIndent()
             )
 
             val config = ToolConfig.load(configFile, NoOpRunnerLogger)
-            assertEquals(listOf(".java", ".kt"), config.parse.includeExtensions)
-            assertEquals(listOf(".xml"), config.parse.excludeExtensions)
             assertEquals(listOf("**/generated/**"), config.parse.excludePaths)
         }
 

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/GradleProjectMarkerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/GradleProjectMarkerTest.kt
@@ -151,8 +151,7 @@ class GradleProjectMarkerTest :
             projectDir.resolve("build.gradle.kts").writeText("// empty build")
             val sources =
                 lstBuilderWithGradleData(throwOnKtsParser = true).build(
-                    projectDir,
-                    includeExtensionsCli = listOf(".kts")
+                    projectDir
                 ).sourceFiles
             assertTrue(sources.isNotEmpty(), "Expected at least one parsed source file")
             assertTrue(
@@ -165,8 +164,7 @@ class GradleProjectMarkerTest :
             projectDir.resolve("build.gradle").writeText("// empty build")
             val sources =
                 lstBuilderWithGradleData(throwOnGroovyParser = true).build(
-                    projectDir,
-                    includeExtensionsCli = listOf(".gradle")
+                    projectDir
                 ).sourceFiles
             assertTrue(sources.isNotEmpty(), "Expected at least one parsed source file")
             assertTrue(
@@ -183,8 +181,7 @@ class GradleProjectMarkerTest :
             projectDir.resolve("build.gradle.kts").writeText("// empty build")
             val sources =
                 lstBuilderWithStage1Success(gradleData = minimalGradleData).build(
-                    projectDir,
-                    includeExtensionsCli = listOf(".kts")
+                    projectDir
                 ).sourceFiles
             assertTrue(sources.isNotEmpty(), "Expected at least one parsed source file")
             assertTrue(
@@ -205,7 +202,7 @@ class GradleProjectMarkerTest :
                     }
                 }
             lstBuilderWithStage1Success(gradleData = null, logger = capturingLogger)
-                .build(projectDir, includeExtensionsCli = listOf(".kts"))
+                .build(projectDir)
             assertTrue(
                 warnings.any { it.contains("GradleProject markers could not be built") },
                 "Expected warning about missing GradleProject markers. Warnings: $warnings"
@@ -231,7 +228,7 @@ class GradleProjectMarkerTest :
                     }
                 }
             lstBuilderWithStage1Success(gradleData = null, logger = capturingLogger)
-                .build(projectDir, includeExtensionsCli = listOf(".xml"))
+                .build(projectDir)
             assertFalse(
                 warnings.any { it.contains("GradleProject markers could not be built") },
                 "Should not warn about Gradle markers for Maven-only project"
@@ -300,8 +297,7 @@ class GradleProjectMarkerTest :
             )
 
             val sources = lstBuilderWithStage1Success(gradleData = gradleData).build(
-                projectDir,
-                includeExtensionsCli = listOf(".kts", ".gradle")
+                projectDir
             ).sourceFiles
 
             fun markerFor(path: String): GradleProject {
@@ -362,8 +358,7 @@ class GradleProjectMarkerTest :
             )
 
             val sources = lstBuilderWithStage1Success(gradleData = gradleData).build(
-                projectDir,
-                includeExtensionsCli = listOf(".kts")
+                projectDir
             ).sourceFiles
             val marker = sources
                 .single { it.sourcePath.toString() == "build.gradle.kts" }
@@ -412,8 +407,7 @@ class GradleProjectMarkerTest :
             )
 
             val sources = lstBuilderWithStage1Success(gradleData = gradleData).build(
-                projectDir,
-                includeExtensionsCli = listOf(".kts")
+                projectDir
             ).sourceFiles
             val marker = sources
                 .single { it.sourcePath.toString() == "build.gradle.kts" }

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/JavaVersionDetectionTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/JavaVersionDetectionTest.kt
@@ -64,7 +64,7 @@ class JavaVersionDetectionTest :
         fun buildAndGetJavaVersion(): JavaVersion {
             projectDir.resolve("Hello.java").writeText("class Hello {}")
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
+                lstBuilder().build(projectDir).sourceFiles
             val javaFile = sources.single { it.sourcePath.toString().endsWith(".java") }
             val marker = javaFile.markers.findFirst(JavaVersion::class.java).orElse(null)
             assertNotNull(
@@ -79,8 +79,7 @@ class JavaVersionDetectionTest :
             Files.createDirectories(absPath.parent)
             absPath.writeText("class ${absPath.toFile().nameWithoutExtension} {}")
             val sources = lstBuilder().build(
-                projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir
             ).sourceFiles
             val javaFile = sources.single { it.sourcePath.toString() == relativeFilePath }
             val marker = javaFile.markers.findFirst(JavaVersion::class.java).orElse(null)
@@ -813,7 +812,7 @@ class JavaVersionDetectionTest :
             absWorld.writeText("class World {}")
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
+                lstBuilder().build(projectDir).sourceFiles
             val helloMarker =
                 sources
                     .single { it.sourcePath.toString() == "subproject1/src/main/java/Hello.java" }
@@ -859,7 +858,7 @@ class JavaVersionDetectionTest :
             absBeta.writeText("class Beta {}")
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
+                lstBuilder().build(projectDir).sourceFiles
             val alphaMarker =
                 sources
                     .single { it.sourcePath.toString() == "subproject1/src/Alpha.java" }

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/JavaVersionParsingTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/JavaVersionParsingTest.kt
@@ -85,7 +85,7 @@ class JavaVersionParsingTest :
          */
         fun buildAndInspect(fileName: String): JavaVersion {
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
+                lstBuilder().build(projectDir).sourceFiles
             val javaFile =
                 sources.singleOrNull { it.sourcePath.toString().endsWith(fileName) }
             assertNotNull(
@@ -477,7 +477,7 @@ class JavaVersionParsingTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
+                lstBuilder().build(projectDir).sourceFiles
             val javaFile =
                 sources.singleOrNull { it.sourcePath.toString().endsWith("Shapes17.java") }
             assertNotNull(javaFile, "Shapes17.java must be present in parsed sources")
@@ -512,7 +512,7 @@ class JavaVersionParsingTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
+                lstBuilder().build(projectDir).sourceFiles
             val javaFile =
                 sources.singleOrNull { it.sourcePath.toString().endsWith("Patterns21.java") }
             assertNotNull(javaFile, "Patterns21.java must be present in parsed sources")
@@ -559,7 +559,7 @@ class JavaVersionParsingTest :
             )
 
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
+                lstBuilder().build(projectDir).sourceFiles
             val javaFiles = sources.filter { it.sourcePath.toString().endsWith(".java") }
             assertTrue(
                 javaFiles.size == 2,

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/KotlinVersionDetectionTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/KotlinVersionDetectionTest.kt
@@ -64,8 +64,7 @@ class KotlinVersionDetectionTest :
         fun buildAndGetKotlinVersion(fileName: String = "Hello.kt"): JavaVersion {
             projectDir.resolve(fileName).writeText("fun main() {}")
             val sources = lstBuilder().build(
-                projectDir,
-                includeExtensionsCli = listOf(".kt")
+                projectDir
             ).sourceFiles
             val ktFile = sources.single { it.sourcePath.toString().endsWith(".kt") }
             val marker = ktFile.markers.findFirst(JavaVersion::class.java).orElse(null)
@@ -295,8 +294,7 @@ class KotlinVersionDetectionTest :
             Files.createDirectories(absPath.parent)
             absPath.writeText("fun main() {}")
             val sources = lstBuilder().build(
-                projectDir,
-                includeExtensionsCli = listOf(".kt")
+                projectDir
             ).sourceFiles
             val marker = sources
                 .single { it.sourcePath.toString() == "subproject1/src/main/kotlin/Hello.kt" }
@@ -319,8 +317,7 @@ class KotlinVersionDetectionTest :
             Files.createDirectories(absPath.parent)
             absPath.writeText("fun main() {}")
             val sources = lstBuilder().build(
-                projectDir,
-                includeExtensionsCli = listOf(".kt")
+                projectDir
             ).sourceFiles
             val marker = sources
                 .single { it.sourcePath.toString() == "subproject1/src/main/kotlin/Hello.kt" }
@@ -341,8 +338,7 @@ class KotlinVersionDetectionTest :
             projectDir.resolve("script.kts").writeText("println(\"hello\")")
 
             val sources = lstBuilder().build(
-                projectDir,
-                includeExtensionsCli = listOf(".kts")
+                projectDir
             ).sourceFiles
             val ktsFile = sources.single { it.sourcePath.toString() == "script.kts" }
             val marker = ktsFile.markers.findFirst(JavaVersion::class.java).orElse(null)

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilderTest.kt
@@ -4,7 +4,6 @@ import io.github.skhokhlov.rewriterunner.AetherContext
 import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.UsedExecutionStage
-import io.github.skhokhlov.rewriterunner.config.ParseConfig
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
 import io.github.skhokhlov.rewriterunner.lst.utils.ClasspathResolutionResult
 import io.kotest.core.spec.style.FunSpec
@@ -84,112 +83,21 @@ class LstBuilderTest :
             )
         }
 
-        // ─── Extension filtering (integration smoke tests) ────────────────────────
-        // Full unit tests for FileCollector.resolveExtensions / collectFiles live in
-        // FileCollectorTest.
+        // ─── Path-glob exclusion (integration smoke tests) ────────────────────────
+        // Full unit tests for FileCollector.collectFiles live in FileCollectorTest.
 
-        test("includeExtensions CLI flag restricts parsed file types") {
+        test("excludePaths skips files matching the glob") {
             projectDir.resolve("Hello.java").writeText("class Hello {}")
-            projectDir.resolve("config.yaml").writeText("key: value")
+            projectDir.resolve("notes.md").writeText("# notes")
 
             val sources = lstBuilder().build(
                 projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                excludePaths = listOf("**/*.md")
             ).sourceFiles
-
-            assertEquals(1, sources.size, "Only .java file should be parsed")
-            assertTrue(sources.first().sourcePath.toString().endsWith(".java"))
-        }
-
-        test("excludeExtensions CLI flag removes specific types from defaults") {
-            projectDir.resolve("Hello.java").writeText("class Hello {}")
-            projectDir.resolve("config.xml").writeText("<root/>")
-            projectDir.resolve("app.properties").writeText("key=value")
-
-            val sources =
-                lstBuilder().build(
-                    projectDir = projectDir,
-                    excludeExtensionsCli = listOf(".xml", ".properties")
-                ).sourceFiles
 
             val paths = sources.map { it.sourcePath.toString() }
-            assertTrue(paths.none { it.endsWith(".xml") }, "XML files should be excluded")
-            assertTrue(
-                paths.none { it.endsWith(".properties") },
-                "Properties files should be excluded"
-            )
-            assertTrue(paths.any { it.endsWith(".java") }, "Java files should still be included")
-        }
-
-        test("includeExtensions in config file is respected when no CLI flag given") {
-            projectDir.resolve("Hello.java").writeText("class Hello {}")
-            projectDir.resolve("config.yaml").writeText("key: value")
-
-            val config =
-                ToolConfig(
-                    parse = ParseConfig(includeExtensions = listOf(".yaml")),
-                    logger = NoOpRunnerLogger
-                )
-            val noOpDepStage =
-                object : DependencyResolutionStage(
-                    AetherContext.build(
-                        projectDir.resolve("cache").resolve("repository"),
-                        logger = NoOpRunnerLogger
-                    ),
-                    NoOpRunnerLogger
-                ) {
-                    override fun resolveClasspath(projectDir: Path) =
-                        ClasspathResolutionResult(emptyList())
-                }
-            val builder =
-                LstBuilder(
-                    logger = NoOpRunnerLogger,
-                    cacheDir = projectDir.resolve("cache"),
-                    toolConfig = config,
-                    projectBuildStage = failingBuildTool,
-                    depResolutionStage = noOpDepStage
-                )
-
-            val sources = builder.build(projectDir = projectDir).sourceFiles
-            assertEquals(1, sources.size)
-            assertTrue(sources.first().sourcePath.toString().endsWith(".yaml"))
-        }
-
-        test("CLI includeExtensions overrides config file") {
-            projectDir.resolve("Hello.java").writeText("class Hello {}")
-            projectDir.resolve("config.yaml").writeText("key: value")
-
-            val config =
-                ToolConfig(
-                    parse = ParseConfig(includeExtensions = listOf(".yaml")),
-                    logger = NoOpRunnerLogger
-                )
-            val noOpDepStage =
-                object : DependencyResolutionStage(
-                    AetherContext.build(
-                        projectDir.resolve("cache").resolve("repository"),
-                        logger = NoOpRunnerLogger
-                    ),
-                    NoOpRunnerLogger
-                ) {
-                    override fun resolveClasspath(projectDir: Path) =
-                        ClasspathResolutionResult(emptyList())
-                }
-            val builder =
-                LstBuilder(
-                    logger = NoOpRunnerLogger,
-                    cacheDir = projectDir.resolve("cache"),
-                    toolConfig = config,
-                    projectBuildStage = failingBuildTool,
-                    depResolutionStage = noOpDepStage
-                )
-
-            val sources = builder.build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
-            ).sourceFiles
-            assertEquals(1, sources.size)
-            assertTrue(sources.first().sourcePath.toString().endsWith(".java"))
+            assertTrue(paths.any { it.endsWith(".java") }, "Java file should remain")
+            assertTrue(paths.none { it.endsWith(".md") }, "Markdown file should be excluded")
         }
 
         // ─── Multi-language parsing ───────────────────────────────────────────────
@@ -242,8 +150,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".kts")
+                    projectDir = projectDir
                 ).sourceFiles
 
             val paths = sources.map { it.sourcePath.toString() }
@@ -261,8 +168,7 @@ class LstBuilderTest :
             projectDir.resolve("build.gradle").writeText("// gradle groovy dsl")
 
             val sources = lstBuilder().build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".groovy", ".gradle")
+                projectDir = projectDir
             ).sourceFiles
 
             val paths = sources.map { it.sourcePath.toString() }
@@ -276,8 +182,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".yml")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size)
         }
@@ -291,8 +196,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".toml")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "TOML file should be parsed")
             assertTrue(sources.first().sourcePath.toString().endsWith(".toml"))
@@ -305,8 +209,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".hcl")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "HCL file should be parsed")
         }
@@ -318,8 +221,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".tf")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "Terraform (.tf) file should be parsed")
         }
@@ -329,8 +231,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".tfvars")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "Terraform variable (.tfvars) file should be parsed")
         }
@@ -346,8 +247,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".hcl", ".tf", ".tfvars")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(3, sources.size, "All three HCL-family extensions should be parsed")
         }
@@ -359,8 +259,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".proto")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "Protobuf file should be parsed")
         }
@@ -372,8 +271,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".dockerfile")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, ".dockerfile extension should be parsed")
         }
@@ -385,8 +283,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".containerfile")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, ".containerfile extension should be parsed")
         }
@@ -396,8 +293,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".dockerfile")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "Dockerfile (no extension) should be parsed by name")
             assertEquals("Dockerfile", sources.first().sourcePath.toString())
@@ -408,8 +304,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".dockerfile")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "Dockerfile.dev should be parsed by name prefix")
         }
@@ -421,26 +316,9 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".dockerfile")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "Containerfile (no extension) should be parsed by name")
-        }
-
-        test("Dockerfile is NOT parsed when dockerfile extension is not in effective set") {
-            projectDir.resolve("Dockerfile").writeText("FROM ubuntu:22.04\n")
-            projectDir.resolve("app.properties").writeText("key=value")
-
-            val sources =
-                lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".properties")
-                ).sourceFiles
-            val paths = sources.map { it.sourcePath.toString() }
-            assertTrue(
-                paths.none { it == "Dockerfile" },
-                "Dockerfile should not be parsed when .dockerfile is excluded"
-            )
         }
 
         // ─── Maven POM parser ─────────────────────────────────────────────────────
@@ -459,8 +337,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".xml")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "pom.xml should be parsed")
             val pom = sources.first()
@@ -478,8 +355,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".xml")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(1, sources.size, "config.xml should be parsed")
             assertFalse(
@@ -500,8 +376,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".xml")
+                    projectDir = projectDir
                 ).sourceFiles
             assertEquals(3, sources.size, "All 3 xml files should be parsed")
             val paths = sources.map { it.sourcePath.toString() }
@@ -520,7 +395,7 @@ class LstBuilderTest :
             )
         }
 
-        test("pom.xml is NOT parsed when xml extension is excluded") {
+        test("pom.xml is NOT parsed when excluded via excludePaths glob") {
             projectDir.resolve("pom.xml").writeText(
                 "<project><modelVersion>4.0.0</modelVersion>" +
                     "<groupId>com.example</groupId>" +
@@ -532,11 +407,11 @@ class LstBuilderTest :
             val sources =
                 lstBuilder().build(
                     projectDir = projectDir,
-                    includeExtensionsCli = listOf(".properties")
+                    excludePaths = listOf("pom.xml")
                 ).sourceFiles
             assertTrue(
                 sources.none { it.sourcePath.toString() == "pom.xml" },
-                "pom.xml should not be parsed when .xml is not in effective set"
+                "pom.xml should be excluded when matched by excludePaths"
             )
         }
 
@@ -628,8 +503,7 @@ class LstBuilderTest :
             )
 
             val result = lstBuilderWithMavenStub(throwFor = setOf("pom.xml")).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".xml")
+                projectDir = projectDir
             )
 
             val poms = result.sourceFiles.filter { it.sourcePath.fileName.toString() == "pom.xml" }
@@ -714,7 +588,7 @@ class LstBuilderTest :
             }
 
             val thrown = kotlin.runCatching {
-                builder.build(projectDir = projectDir, includeExtensionsCli = listOf(".xml"))
+                builder.build(projectDir = projectDir)
             }.exceptionOrNull()
             assertNotNull(thrown, "An unrelated MavenParser bug must not be swallowed")
             assertTrue(
@@ -779,7 +653,7 @@ class LstBuilderTest :
             }
 
             val thrown = kotlin.runCatching {
-                builder.build(projectDir = projectDir, includeExtensionsCli = listOf(".xml"))
+                builder.build(projectDir = projectDir)
             }.exceptionOrNull()
             assertNotNull(thrown, "Non-URI IllegalArgumentException must not be swallowed")
             assertTrue(
@@ -793,6 +667,7 @@ class LstBuilderTest :
 
         test("stage 1 is attempted first") {
             var stage1Called = false
+            projectDir.resolve("Hello.java").writeText("class Hello {}")
             val trackingBuildTool =
                 object : ProjectBuildStage(NoOpRunnerLogger) {
                     override fun extractClasspath(projectDir: Path): List<Path>? {
@@ -801,8 +676,7 @@ class LstBuilderTest :
                     }
                 }
             lstBuilder(buildTool = trackingBuildTool).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir = projectDir
             )
             assertTrue(stage1Called, "Stage 1 (build tool) should always be attempted first")
         }
@@ -837,12 +711,13 @@ class LstBuilderTest :
                 depResolutionStage = trackingDepStage,
                 logger = NoOpRunnerLogger
             )
-                .build(projectDir = projectDir, includeExtensionsCli = listOf(".java"))
+                .build(projectDir = projectDir)
 
             assertTrue(!stage2Called, "Stage 2 should NOT be called when Stage 1 succeeds")
         }
 
         test("stage 2 is attempted when stage 1 returns null") {
+            projectDir.resolve("Hello.java").writeText("class Hello {}")
             var stage2Called = false
             val trackingDepStage =
                 object : DependencyResolutionStage(
@@ -865,12 +740,13 @@ class LstBuilderTest :
                 depResolutionStage = trackingDepStage,
                 logger = NoOpRunnerLogger
             )
-                .build(projectDir = projectDir, includeExtensionsCli = listOf(".java"))
+                .build(projectDir = projectDir)
 
             assertTrue(stage2Called, "Stage 2 should be attempted when Stage 1 fails")
         }
 
         test("stage 3 is attempted when stage 1 and stage 2 fail") {
+            projectDir.resolve("Hello.java").writeText("class Hello {}")
             var stage3Called = false
             val noOpDepStage =
                 object : DependencyResolutionStage(
@@ -905,7 +781,7 @@ class LstBuilderTest :
                 buildFileParseStage = trackingBuildFileStage,
                 logger = NoOpRunnerLogger
             )
-                .build(projectDir = projectDir, includeExtensionsCli = listOf(".java"))
+                .build(projectDir = projectDir)
 
             assertTrue(stage3Called, "Stage 3 should be attempted when Stages 1 and 2 fail")
         }
@@ -915,8 +791,7 @@ class LstBuilderTest :
 
             val sources =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".java")
+                    projectDir = projectDir
                 ).sourceFiles
 
             assertEquals(
@@ -944,8 +819,7 @@ class LstBuilderTest :
 
             projectDir.resolve("Hello.java").writeText("class Hello {}")
             lstBuilder(buildTool = trackingBuildTool2).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir = projectDir
             )
 
             assertTrue(
@@ -972,8 +846,7 @@ class LstBuilderTest :
 
             projectDir.resolve("Hello.java").writeText("class Hello {}")
             lstBuilder(buildTool = trackingBuildTool2).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir = projectDir
             )
 
             assertTrue(
@@ -995,8 +868,7 @@ class LstBuilderTest :
             projectDir.resolve("Hello.java").writeText("class Hello {}")
             val sources =
                 lstBuilder(buildTool = failingCompileTool).build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".java")
+                    projectDir = projectDir
                 ).sourceFiles
 
             assertEquals(
@@ -1022,8 +894,7 @@ class LstBuilderTest :
             projectDir.resolve("Hello.java").writeText("class Hello {}")
             val sources =
                 lstBuilder(buildTool = compilingBuildTool).build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".java")
+                    projectDir = projectDir
                 ).sourceFiles
 
             assertEquals(
@@ -1047,8 +918,7 @@ class LstBuilderTest :
                 }
 
             lstBuilder(buildTool = nullReturningBuildTool).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir = projectDir
             )
 
             assertTrue(
@@ -1144,8 +1014,7 @@ class LstBuilderTest :
                 }
 
             lstBuilder(logger = capturingLogger).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir = projectDir
             )
 
             assertTrue(
@@ -1166,13 +1035,101 @@ class LstBuilderTest :
                 }
 
             lstBuilder(logger = capturingLogger).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".yaml")
+                projectDir = projectDir
             )
 
             assertFalse(
                 warnings.any { it.contains("Classpath resolution failed across all 4 stages") },
                 "Classpath-failure warning should not be emitted for non-JVM projects"
+            )
+        }
+
+        test("skips classpath stages 1-4 when no JVM sources collected") {
+            // Project contains only YAML — no JVM source survives the file walk, so the four
+            // classpath stages must be skipped entirely. Each stage's overrideable method
+            // would record an invocation if called.
+            projectDir.resolve("config.yaml").writeText("key: value")
+
+            var stage1Calls = 0
+            var stage2Calls = 0
+            var stage3Calls = 0
+            var stage4Calls = 0
+
+            val trackingBuildTool =
+                object : ProjectBuildStage(NoOpRunnerLogger) {
+                    override fun extractClasspath(projectDir: Path): List<Path>? {
+                        stage1Calls++
+                        return null
+                    }
+                }
+            val trackingDepStage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): ClasspathResolutionResult {
+                        stage2Calls++
+                        return ClasspathResolutionResult(emptyList())
+                    }
+                }
+            val trackingBuildFileStage =
+                object : BuildFileParseStage(
+                    AetherContext.build(
+                        projectDir.resolve("cache").resolve("repository"),
+                        logger = NoOpRunnerLogger
+                    ),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveClasspath(projectDir: Path): List<Path> {
+                        stage3Calls++
+                        return emptyList()
+                    }
+                }
+            val infoMessages = mutableListOf<String>()
+            val capturingLogger =
+                object : RunnerLogger by NoOpRunnerLogger {
+                    override fun info(message: String) {
+                        infoMessages.add(message)
+                    }
+                }
+            val builder =
+                object : LstBuilder(
+                    logger = capturingLogger,
+                    cacheDir = projectDir.resolve("cache"),
+                    toolConfig = toolConfig,
+                    projectBuildStage = trackingBuildTool,
+                    depResolutionStage = trackingDepStage,
+                    buildFileParseStage = trackingBuildFileStage
+                ) {
+                    override fun createLocalRepositoryStage(
+                        projectDir: Path
+                    ): LocalRepositoryStage =
+                        object : LocalRepositoryStage(projectDir, NoOpRunnerLogger) {
+                            override fun findAvailableJars(
+                                declaredCoordinates: List<String>
+                            ): List<Path> {
+                                stage4Calls++
+                                return emptyList()
+                            }
+                        }
+                }
+
+            builder.build(projectDir = projectDir)
+
+            assertEquals(0, stage1Calls, "Stage 1 must not be invoked when no JVM sources")
+            assertEquals(0, stage2Calls, "Stage 2 must not be invoked when no JVM sources")
+            assertEquals(0, stage3Calls, "Stage 3 must not be invoked when no JVM sources")
+            assertEquals(0, stage4Calls, "Stage 4 must not be invoked when no JVM sources")
+            assertTrue(
+                infoMessages.any {
+                    it.contains(
+                        "No JVM source files in scope — skipping classpath resolution stages."
+                    )
+                },
+                "Expected the stage-skip info log message; got: $infoMessages"
             )
         }
 
@@ -1193,8 +1150,7 @@ class LstBuilderTest :
                 }
 
             lstBuilder(buildTool = successfulBuildTool, logger = capturingLogger).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir = projectDir
             )
 
             assertFalse(
@@ -1309,8 +1265,7 @@ class LstBuilderTest :
                 }
 
             lstBuilder(logger = capturingLogger).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".xml")
+                projectDir = projectDir
             )
 
             assertTrue(
@@ -1331,8 +1286,7 @@ class LstBuilderTest :
                 }
 
             lstBuilder(logger = capturingLogger).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".xml")
+                projectDir = projectDir
             )
 
             val parseWarning = warnings.firstOrNull { it.startsWith("Parse warning:") }
@@ -1357,8 +1311,7 @@ class LstBuilderTest :
                 }
 
             val sources = lstBuilder(logger = capturingLogger).build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".xml")
+                projectDir = projectDir
             ).sourceFiles
 
             // If the XML parser drops the broken file, reportParseFailures should warn about it
@@ -1384,8 +1337,7 @@ class LstBuilderTest :
 
             val lstBuildResult =
                 lstBuilder(buildTool = successBuildTool).build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".java")
+                    projectDir = projectDir
                 )
 
             assertEquals(
@@ -1406,8 +1358,7 @@ class LstBuilderTest :
 
             val lstBuildResult =
                 lstBuilder().build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".java")
+                    projectDir = projectDir
                 )
 
             assertNull(
@@ -1466,8 +1417,7 @@ class LstBuilderTest :
             projectDir.resolve("Hello.java").writeText("class Hello {}")
             val lstBuildResult =
                 builderWithFakeStage4.build(
-                    projectDir = projectDir,
-                    includeExtensionsCli = listOf(".java")
+                    projectDir = projectDir
                 )
 
             assertEquals(
@@ -1576,8 +1526,7 @@ class LstBuilderTest :
             )
 
             val result = builder.build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir = projectDir
             )
 
             val failures = result.executionDiagnostics.parseFailures
@@ -1623,8 +1572,7 @@ class LstBuilderTest :
             )
 
             val result = builder.build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir = projectDir
             )
 
             val dropFailures =
@@ -1690,8 +1638,7 @@ class LstBuilderTest :
             }
 
             val result = builder.build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".kts")
+                projectDir = projectDir
             )
 
             val gradleFailures =
@@ -1775,8 +1722,7 @@ class LstBuilderTest :
                 }
 
             val result = builder.build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".xml")
+                projectDir = projectDir
             )
 
             val mavenFailures =
@@ -1803,7 +1749,7 @@ class LstBuilderTest :
             )
 
             val thrown = kotlin.runCatching {
-                builder.build(projectDir = projectDir, includeExtensionsCli = listOf(".java"))
+                builder.build(projectDir = projectDir)
             }.exceptionOrNull()
 
             assertNotNull(thrown, "Fatal Error must not be swallowed by parseAndRecord")
@@ -1850,8 +1796,7 @@ class LstBuilderTest :
             }
 
             val result = builder.build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".xml")
+                projectDir = projectDir
             )
 
             val pomFailures =
@@ -1916,8 +1861,7 @@ class LstBuilderTest :
                 )
 
             val result = builder.build(
-                projectDir = projectDir,
-                includeExtensionsCli = listOf(".java")
+                projectDir = projectDir
             )
 
             val coordFailures =

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/MultiModuleJavaVersionTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/MultiModuleJavaVersionTest.kt
@@ -68,7 +68,7 @@ class MultiModuleJavaVersionTest :
          */
         fun buildAndGetVersionsPerFile(): Map<String, JavaVersion> {
             val sources =
-                lstBuilder().build(projectDir, includeExtensionsCli = listOf(".java")).sourceFiles
+                lstBuilder().build(projectDir).sourceFiles
             return sources
                 .filter { it.sourcePath.toString().endsWith(".java") }
                 .associateBy(

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/FileCollectorTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/FileCollectorTest.kt
@@ -1,6 +1,5 @@
 package io.github.skhokhlov.rewriterunner.lst.utils
 
-import io.github.skhokhlov.rewriterunner.config.ParseConfig
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
@@ -18,55 +17,6 @@ class FileCollectorTest :
         afterEach { projectDir.toFile().deleteRecursively() }
 
         val collector = FileCollector()
-
-        // ─── resolveExtensions ────────────────────────────────────────────────────
-
-        test("includeExtensions CLI flag restricts to specified types") {
-            val exts = collector.resolveExtensions(
-                ParseConfig(),
-                includeExtensionsCli = listOf(".java"),
-                excludeExtensionsCli = emptyList()
-            )
-            assertEquals(setOf(".java"), exts)
-        }
-
-        test("excludeExtensions CLI flag removes types from defaults") {
-            val exts = collector.resolveExtensions(
-                ParseConfig(),
-                includeExtensionsCli = emptyList(),
-                excludeExtensionsCli = listOf(".xml", ".properties")
-            )
-            assertTrue(".xml" !in exts)
-            assertTrue(".properties" !in exts)
-            assertTrue(".java" in exts)
-        }
-
-        test("includeExtensions from config is respected when no CLI flag given") {
-            val exts = collector.resolveExtensions(
-                ParseConfig(includeExtensions = listOf(".yaml")),
-                includeExtensionsCli = emptyList(),
-                excludeExtensionsCli = emptyList()
-            )
-            assertEquals(setOf(".yaml"), exts)
-        }
-
-        test("CLI includeExtensions overrides config includeExtensions") {
-            val exts = collector.resolveExtensions(
-                ParseConfig(includeExtensions = listOf(".yaml")),
-                includeExtensionsCli = listOf(".java"),
-                excludeExtensionsCli = emptyList()
-            )
-            assertEquals(setOf(".java"), exts)
-        }
-
-        test("extensions without leading dot are normalized") {
-            val exts = collector.resolveExtensions(
-                ParseConfig(),
-                includeExtensionsCli = listOf("java"),
-                excludeExtensionsCli = emptyList()
-            )
-            assertTrue(".java" in exts)
-        }
 
         // ─── collectFiles — extension matching ────────────────────────────────────
 

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategyTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategyTest.kt
@@ -112,6 +112,93 @@ class GradlePluginStrategyTest :
             assertEquals(4, Regex.fromLiteral("password = \"secret\"").findAll(text).count())
         }
 
+        test("generateInitScript emits exclusion lines inside rewrite block when paths present") {
+            val strategy = GradlePluginStrategy(
+                logger = NoOpRunnerLogger,
+                timeout = ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                rewritePluginVersion = ToolConfigDefaults.REWRITE_GRADLE_PLUGIN_VERSION
+            )
+
+            val initScript =
+                strategy.generateInitScript(
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    includeMavenCentral = true,
+                    repositories = emptyList(),
+                    excludePaths = listOf("**/generated/**", "src/test/**")
+                )
+
+            val text = initScript.readText()
+            // Locate the rewrite { } block bound to rootProject and assert exclusions live there.
+            val rewriteStart = text.indexOf("rewrite {")
+            assertTrue(rewriteStart >= 0, "rewrite { } block missing")
+            val rewriteEnd = text.indexOf("    }", rewriteStart)
+            assertTrue(rewriteEnd > rewriteStart)
+            val rewriteBody = text.substring(rewriteStart, rewriteEnd)
+            assertTrue(
+                rewriteBody.contains("exclusion(\"**/generated/**\")"),
+                "Expected exclusion line for **/generated/** inside rewrite { }: $rewriteBody"
+            )
+            assertTrue(
+                rewriteBody.contains("exclusion(\"src/test/**\")"),
+                "Expected exclusion line for src/test/** inside rewrite { }: $rewriteBody"
+            )
+        }
+
+        test("generateInitScript emits no exclusion lines when paths empty") {
+            val strategy = GradlePluginStrategy(
+                logger = NoOpRunnerLogger,
+                timeout = ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                rewritePluginVersion = ToolConfigDefaults.REWRITE_GRADLE_PLUGIN_VERSION
+            )
+
+            val initScript =
+                strategy.generateInitScript(
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    includeMavenCentral = true,
+                    repositories = emptyList(),
+                    excludePaths = emptyList()
+                )
+
+            val text = initScript.readText()
+            assertTrue(!text.contains("exclusion("), "No exclusion lines expected: $text")
+        }
+
+        test("generateInitScript escapes Groovy specials in glob patterns") {
+            val strategy = GradlePluginStrategy(
+                logger = NoOpRunnerLogger,
+                timeout = ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                rewritePluginVersion = ToolConfigDefaults.REWRITE_GRADLE_PLUGIN_VERSION
+            )
+
+            val initScript =
+                strategy.generateInitScript(
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    includeMavenCentral = true,
+                    repositories = emptyList(),
+                    excludePaths = listOf("path\\with\\backslash", "has\"quote", "has\$dollar")
+                )
+
+            val text = initScript.readText()
+            assertTrue(
+                text.contains("exclusion(\"path\\\\with\\\\backslash\")"),
+                "Backslashes must be doubled: $text"
+            )
+            assertTrue(
+                text.contains("exclusion(\"has\\\"quote\")"),
+                "Double-quotes must be backslash-escaped: $text"
+            )
+            assertTrue(
+                text.contains("exclusion(\"has\\\$dollar\")"),
+                "Groovy dollar sign must be backslash-escaped: $text"
+            )
+        }
+
         test("generateInitScript adds recipe artifacts to root rewrite configuration only") {
             val strategy = GradlePluginStrategy(
                 logger = NoOpRunnerLogger,

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
@@ -56,6 +56,73 @@ class MavenPluginStrategyTest :
             assertTrue(command.contains("-Drewrite.configLocation=${config.toAbsolutePath()}"))
         }
 
+        test("buildCommand emits -Drewrite.exclusions when excludePaths non-empty") {
+            val strategy =
+                MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                    ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION
+                )
+
+            val command =
+                strategy.buildCommand(
+                    projectDir = projectDir,
+                    goal = "dryRun",
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    excludePaths = listOf("src/test/**")
+                )
+
+            assertTrue(command.contains("-Drewrite.exclusions=src/test/**"))
+        }
+
+        test("buildCommand omits -Drewrite.exclusions when excludePaths empty") {
+            val strategy =
+                MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                    ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION
+                )
+
+            val command =
+                strategy.buildCommand(
+                    projectDir = projectDir,
+                    goal = "dryRun",
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    excludePaths = emptyList()
+                )
+
+            assertTrue(command.none { it.startsWith("-Drewrite.exclusions") })
+        }
+
+        test("buildCommand joins multiple globs with comma") {
+            val strategy =
+                MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                    ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION
+                )
+
+            val command =
+                strategy.buildCommand(
+                    projectDir = projectDir,
+                    goal = "dryRun",
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    excludePaths = listOf("**/generated/**", "**/*.md", "src/test/**")
+                )
+
+            assertTrue(
+                command.contains(
+                    "-Drewrite.exclusions=**/generated/**,**/*.md,src/test/**"
+                )
+            )
+        }
+
         test("buildCommand uses configured rewrite Maven plugin version") {
             val strategy =
                 MavenPluginStrategy(

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginRecipeRunnerTest.kt
@@ -25,8 +25,33 @@ class PluginRecipeRunnerTest :
                 rewriteConfigContent: String?,
                 dryRun: Boolean,
                 includeMavenCentral: Boolean,
-                artifactRepositories: List<RepositoryConfig>
+                artifactRepositories: List<RepositoryConfig>,
+                excludePaths: List<String>
             ): PluginRunResult = result
+        }
+
+        /** Records the parameters each strategy invocation received. */
+        class CapturingStrategy(private val result: PluginRunResult) : PluginBuildStrategy {
+            var lastExcludePaths: List<String>? = null
+                private set
+            var callCount: Int = 0
+                private set
+
+            override fun run(
+                projectDir: Path,
+                activeRecipe: String,
+                recipeArtifacts: List<String>,
+                rewriteConfig: Path?,
+                rewriteConfigContent: String?,
+                dryRun: Boolean,
+                includeMavenCentral: Boolean,
+                artifactRepositories: List<RepositoryConfig>,
+                excludePaths: List<String>
+            ): PluginRunResult {
+                callCount++
+                lastExcludePaths = excludePaths
+                return result
+            }
         }
 
         test("skips when no build tool is present") {
@@ -93,5 +118,52 @@ class PluginRecipeRunnerTest :
                 )
 
             assertEquals(PluginRunResult.Failed("gradle failed ; maven failed"), result)
+        }
+
+        test("forwards excludePaths to the Gradle strategy") {
+            projectDir.resolve("build.gradle.kts").writeText("")
+
+            val gradle = CapturingStrategy(PluginRunResult.NoChanges)
+            val maven = CapturingStrategy(PluginRunResult.NoChanges)
+
+            PluginRecipeRunner(gradleStrategy = gradle, mavenStrategy = maven).run(
+                projectDir = projectDir,
+                activeRecipe = "com.example.Recipe",
+                recipeArtifacts = emptyList(),
+                rewriteConfig = null,
+                rewriteConfigContent = null,
+                dryRun = true,
+                includeMavenCentral = true,
+                artifactRepositories = emptyList(),
+                excludePaths = listOf("**/generated/**", "**/*.md")
+            )
+
+            assertEquals(1, gradle.callCount)
+            assertEquals(listOf("**/generated/**", "**/*.md"), gradle.lastExcludePaths)
+        }
+
+        test("forwards excludePaths to the Maven strategy when Gradle fails") {
+            projectDir.resolve("build.gradle.kts").writeText("")
+            projectDir.resolve("pom.xml").writeText("<project/>")
+
+            val gradle = CapturingStrategy(PluginRunResult.Failed("gradle failed"))
+            val maven = CapturingStrategy(PluginRunResult.NoChanges)
+
+            PluginRecipeRunner(gradleStrategy = gradle, mavenStrategy = maven).run(
+                projectDir = projectDir,
+                activeRecipe = "com.example.Recipe",
+                recipeArtifacts = emptyList(),
+                rewriteConfig = null,
+                rewriteConfigContent = null,
+                dryRun = true,
+                includeMavenCentral = true,
+                artifactRepositories = emptyList(),
+                excludePaths = listOf("src/test/**")
+            )
+
+            assertEquals(1, gradle.callCount)
+            assertEquals(listOf("src/test/**"), gradle.lastExcludePaths)
+            assertEquals(1, maven.callCount)
+            assertEquals(listOf("src/test/**"), maven.lastExcludePaths)
         }
     })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,8 @@ The resolved classpath is **shared across all language parsers** — `JavaParser
 
 `LstBuilder` also adds project class directories (`target/classes`, `build/classes/java/main`, etc.) to the classpath for cross-module type resolution.
 
+When `--exclude-paths` (or `parse.excludePaths`) removes every JVM source file (`.java`, `.kt`, `.kts`, `.groovy`, `.gradle`) from scope, all four classpath stages are **skipped entirely** — there is no `mvn`/`gradle` subprocess, no POM walk, no local-repo scan. The build emits a single `INFO` line (`"No JVM source files in scope — skipping classpath resolution stages."`) and proceeds directly to the language parsers, which run with an empty classpath. This optimization keeps non-JVM workflows (e.g. running a YAML-only recipe) fast.
+
 ## LST Module Structure
 
 `LstBuilder` is an orchestrator that delegates each concern to a focused helper class:
@@ -75,7 +77,7 @@ The resolved classpath is **shared across all language parsers** — `JavaParser
 | Class | Responsibility |
 |-------|---------------|
 | `LstBuilder` | Orchestration, 4-stage classpath pipeline, parser dispatch |
-| `FileCollector` | NIO walk, excluded-dir filtering, glob exclusions, extension resolution |
+| `FileCollector` | NIO walk, excluded-dir filtering, glob exclusions; extension set is fixed (`DEFAULT_EXTENSIONS`) |
 | `VersionDetector` | Java/Kotlin JVM-version walk-up, `normalizeJvmVersion`, `parseGradleVersionFromWrapper` |
 | `GradleDslClasspathResolver` | Locate Gradle installation (`GRADLE_HOME`, wrapper, `~/.gradle/wrapper/dists/`) |
 | `MarkerFactory` | `BuildTool`, `GitProvenance`, `OperatingSystemProvenance`, `BuildEnvironment`, `GradleProject` markers |

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -35,9 +35,7 @@ val result = RewriteRunner.builder()
 | `pluginTimeout(Duration)` | `Duration?` | from config / `10m` | Timeout for official Gradle/Maven plugin invocations in Stage 0 |
 | `resolverConnectTimeout(Duration)` | `Duration?` | from config / `30s` | TCP connection timeout for Maven Resolver artifact downloads |
 | `resolverRequestTimeout(Duration)` | `Duration?` | from config / `60s` | Socket read/request timeout for Maven Resolver artifact downloads |
-| `includeExtensions(List<String>)` | `List` | `[]` | Restrict to these extensions (e.g. `[".java", ".kt"]`); overrides `parse.includeExtensions` from config file |
-| `excludeExtensions(List<String>)` | `List` | `[]` | Skip these extensions; overrides `parse.excludeExtensions` from config file |
-| `excludePaths(List<String>)` | `List` | `[]` | Glob patterns (relative to project root) to skip during parsing; overrides `parse.excludePaths` from config file |
+| `excludePaths(List<String>)` | `List` | `[]` | Glob patterns (relative to project root) to skip during parsing; overrides `parse.excludePaths` from config file. Forwarded both to Stage 0 (Maven `-Drewrite.exclusions=…` / Gradle `exclusion(...)` DSL) and to the LST fallback pipeline. |
 | `includeMavenCentral(Boolean)` | `Boolean?` | from config / `true` | Include Maven Central as a remote repository. Set `false` for air-gapped or enterprise environments. |
 | `repository(RepositoryConfig)` | — | — | Add one extra Maven repository; accumulated, combined with config file repos |
 | `repositories(List<RepositoryConfig>)` | `List` | `[]` | Replace all extra Maven repositories; combined with config file repos |
@@ -256,9 +254,10 @@ repositories:
     password: ${NEXUS_PASS}
 
 parse:
-  includeExtensions: [".java", ".kt"]   # restrict to these; overridden by CLI flag
-  excludeExtensions: [".xml"]           # skip these; overridden by CLI flag
-  excludePaths: ["generated/", "vendor/"] # glob patterns relative to project root
+  excludePaths:
+    - "**/generated/**"
+    - "**/*.md"
+  # CLI --exclude-paths overrides this list when non-empty.
 
 processTimeout: 120s
 pluginTimeout: 10m
@@ -313,15 +312,13 @@ val runner = RewriteRunner.builder()
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `includeExtensions` | `List<String>` | `[]` | When non-empty, only parse these extensions |
-| `excludeExtensions` | `List<String>` | `[]` | Remove these from the default set |
 | `excludePaths` | `List<String>` | `[]` | Glob patterns (relative to project root) to skip |
 
-**Precedence**: CLI flags `--include-extensions` / `--exclude-extensions` override config file `parse` settings.
+**Precedence**: CLI flag `--exclude-paths` (or `Builder.excludePaths(...)`) overrides `parse.excludePaths` from the config file when non-empty. The resolved list is forwarded both to the Stage 0 plugin invocation (Maven: `-Drewrite.exclusions=…`; Gradle: `exclusion(...)` DSL inside the init script) and to the LST fallback pipeline, so both code paths apply identical filtering. The exclusion-only surface intentionally matches upstream OpenRewrite plugins, which do not support include allowlists.
 
 ### Automatically excluded directories
 
-The following directories are **always** skipped during the file-system walk, regardless of `includeExtensions`, `excludeExtensions`, or `excludePaths` configuration:
+The following directories are **always** skipped during the file-system walk, regardless of `excludePaths` configuration:
 
 `.git`, `build`, `target`, `node_modules`, `.gradle`, `.idea`, `out`, `dist`
 


### PR DESCRIPTION
Align the path-filtering surface with the upstream OpenRewrite Gradle/Maven
plugins, which use glob-pattern exclusions as their native primitive. Drop the
homegrown extension flags; introduce `--exclude-paths` (CSV of globs); forward
the resolved value to both Stage 0 plugin invocation and the LST fallback so the
two execution paths apply identical filtering. Maven receives the globs as
`-Drewrite.exclusions=<csv>`; Gradle receives `exclusion("…")` lines inside the
generated init script's `rewrite { }` block. When the exclusion list eliminates
every JVM source file, classpath resolution stages 1-4 are skipped entirely,
avoiding pointless `mvn`/`gradle` subprocess work for non-JVM workflows.

The previous extension flags were silently incorrect: they were never forwarded
to Stage 0, so users passing `--exclude-extensions .md` still had Stage 0 parse
every `.md`. Glob exclusions match upstream semantics and are forwarded
everywhere.

BREAKING CHANGE: `--include-extensions` and `--exclude-extensions` CLI flags,
`Builder.includeExtensions(...)` / `Builder.excludeExtensions(...)` library
methods, and `parse.includeExtensions` / `parse.excludeExtensions` YAML keys are
removed. Migrate `--exclude-extensions .md,.json` to
`--exclude-paths "**/*.md,**/*.json"`. There is no include allowlist replacement
because upstream OpenRewrite plugins do not support one; compose exclusions for
tight scoping.

https://claude.ai/code/session_014p4ecZTTTeoTiH5g3VyvfE