### PR TITLE
fix(plugin): direct Maven plugin patch output to a known temp dir

### DIFF
--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
@@ -97,10 +97,11 @@ internal open class MavenPluginStrategy(
                 "$rewritePluginVersion:$goal"
         )
         add("-Drewrite.activeRecipes=$activeRecipe")
-        add(
-            "-Drewrite.reportOutputDirectory=" +
-                reportOutputDirectory.toAbsolutePath().toString()
-        )
+        // The rewrite-maven-plugin's documented user property for reportOutputDirectory is
+        // unprefixed (see https://openrewrite.github.io/rewrite-maven-plugin/dryRun-mojo.html);
+        // -Drewrite.reportOutputDirectory is silently ignored. runPerSubmodule, by contrast, is
+        // exposed as `rewrite.runPerSubmodule`.
+        add("-DreportOutputDirectory=${reportOutputDirectory.toAbsolutePath()}")
         add("-Drewrite.runPerSubmodule=false")
         if (recipeArtifacts.isNotEmpty()) {
             add("-Drewrite.recipeArtifactCoordinates=${recipeArtifacts.joinToString(",")}")

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
@@ -13,10 +13,12 @@ import kotlin.io.path.exists
  * Maven-side [PluginBuildStrategy] implementation.
  *
  * Pins the plugin's patch output to a private temp directory via
- * `-Drewrite.reportOutputDirectory=<dir>`, sidestepping per-version default-path drift
- * (older docs say `target/site/rewrite/`, current plugin defaults to `target/rewrite/`).
- * Also pins `-Drewrite.runPerSubmodule=false` so user pom configuration cannot redirect
- * the plugin into per-submodule mode that would race/overwrite the shared output file.
+ * `-DreportOutputDirectory=<dir>` (note: the rewrite-maven-plugin's documented user property
+ * is unprefixed — `-Drewrite.reportOutputDirectory=` is silently ignored). This sidesteps
+ * per-version default-path drift (older docs say `target/site/rewrite/`, current plugin
+ * defaults to `target/rewrite/`). Also pins `-Drewrite.runPerSubmodule=false` so user pom
+ * configuration cannot redirect the plugin into per-submodule mode that would
+ * race/overwrite the shared output file.
  *
  * Forwards `excludePaths` to the upstream `rewrite-maven-plugin` via the
  * `-Drewrite.exclusions=<csv>` system property, joined into a comma-separated list of globs.

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategy.kt
@@ -8,18 +8,18 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 import kotlin.io.path.exists
-import kotlin.streams.toList
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader
-
-private const val FALLBACK_POM_DISCOVERY_DEPTH = 6
-private val MAVEN_PATCH_PATH: Path = Path.of("target/site/rewrite/rewrite.patch")
 
 /**
  * Maven-side [PluginBuildStrategy] implementation.
  *
+ * Pins the plugin's patch output to a private temp directory via
+ * `-Drewrite.reportOutputDirectory=<dir>`, sidestepping per-version default-path drift
+ * (older docs say `target/site/rewrite/`, current plugin defaults to `target/rewrite/`).
+ * Also pins `-Drewrite.runPerSubmodule=false` so user pom configuration cannot redirect
+ * the plugin into per-submodule mode that would race/overwrite the shared output file.
+ *
  * Forwards `excludePaths` to the upstream `rewrite-maven-plugin` via the
- * `-Drewrite.exclusions=<csv>` system property (the plugin's documented exclusion knob),
- * joined into a comma-separated list of globs.
+ * `-Drewrite.exclusions=<csv>` system property, joined into a comma-separated list of globs.
  */
 internal open class MavenPluginStrategy(
     private val logger: RunnerLogger,
@@ -40,6 +40,7 @@ internal open class MavenPluginStrategy(
         val effectiveRewriteConfig =
             createRewriteConfigFile(rewriteConfigContent)
                 ?: rewriteConfig
+        val reportDir = createPrivateTempDirectory("rewrite-runner-report-")
         return try {
             DirectPluginExecutor(projectDir, dryRun, ::execute).run(
                 DirectPluginInvocation(
@@ -49,6 +50,7 @@ internal open class MavenPluginStrategy(
                         activeRecipe = activeRecipe,
                         recipeArtifacts = recipeArtifacts,
                         rewriteConfig = effectiveRewriteConfig,
+                        reportOutputDirectory = reportDir,
                         excludePaths = excludePaths
                     ),
                     applyCommand = buildCommand(
@@ -57,14 +59,20 @@ internal open class MavenPluginStrategy(
                         activeRecipe = activeRecipe,
                         recipeArtifacts = recipeArtifacts,
                         rewriteConfig = effectiveRewriteConfig,
+                        reportOutputDirectory = reportDir,
                         excludePaths = excludePaths
                     ),
-                    patchFiles = { findPatchFiles(projectDir) },
+                    patchFiles = { findPatchFiles(projectDir, reportDir) },
                     dryRunFailureMessage = { pluginFailureMessage("Maven rewrite:dryRun", it) },
                     applyFailureMessage = { pluginFailureMessage("Maven rewrite:run", it) }
                 )
             )
         } finally {
+            try {
+                deleteRecursively(reportDir)
+            } catch (e: Exception) {
+                logger.warn("Maven plugin: failed to clean up report dir $reportDir: ${e.message}")
+            }
             if (rewriteConfigContent != null && effectiveRewriteConfig != null) {
                 Files.deleteIfExists(effectiveRewriteConfig)
             }
@@ -77,6 +85,7 @@ internal open class MavenPluginStrategy(
         activeRecipe: String,
         recipeArtifacts: List<String>,
         rewriteConfig: Path?,
+        reportOutputDirectory: Path,
         excludePaths: List<String> = emptyList()
     ): List<String> = buildList {
         add(resolveMavenCommand(projectDir))
@@ -88,6 +97,11 @@ internal open class MavenPluginStrategy(
                 "$rewritePluginVersion:$goal"
         )
         add("-Drewrite.activeRecipes=$activeRecipe")
+        add(
+            "-Drewrite.reportOutputDirectory=" +
+                reportOutputDirectory.toAbsolutePath().toString()
+        )
+        add("-Drewrite.runPerSubmodule=false")
         if (recipeArtifacts.isNotEmpty()) {
             add("-Drewrite.recipeArtifactCoordinates=${recipeArtifacts.joinToString(",")}")
         }
@@ -107,77 +121,9 @@ internal open class MavenPluginStrategy(
         logger = logger
     )
 
-    private fun findPatchFiles(projectDir: Path): List<DirectPluginPatchFile> =
-        discoverMavenRoots(projectDir).mapNotNull { moduleDir ->
-            val patchFile = moduleDir.resolve(MAVEN_PATCH_PATH)
-            if (!patchFile.exists()) return@mapNotNull null
-
-            DirectPluginPatchFile(
-                file = patchFile,
-                baseDir = moduleDir
-            )
-        }.sortedBy { it.file }
-
-    private fun discoverMavenRoots(projectDir: Path): List<Path> {
-        val projectRoot = projectDir.toAbsolutePath().normalize()
-        return if (projectRoot.resolve("pom.xml").exists()) {
-            val roots = linkedSetOf<Path>()
-            collectDeclaredMavenRoots(
-                projectRoot = projectRoot,
-                moduleDir = projectRoot,
-                found = roots
-            )
-            roots.toList()
-        } else {
-            discoverFallbackPomRoots(projectRoot)
-        }
-    }
-
-    private fun collectDeclaredMavenRoots(
-        projectRoot: Path,
-        moduleDir: Path,
-        found: MutableSet<Path>
-    ) {
-        val normalizedModule = moduleDir.toAbsolutePath().normalize()
-        if (!normalizedModule.startsWith(projectRoot)) return
-        if (!normalizedModule.resolve("pom.xml").exists()) return
-        if (!found.add(normalizedModule)) return
-
-        for (module in readDeclaredModules(normalizedModule)) {
-            if (module.isBlank()) continue
-            collectDeclaredMavenRoots(
-                projectRoot = projectRoot,
-                moduleDir = normalizedModule.resolve(module),
-                found = found
-            )
-        }
-    }
-
-    private fun readDeclaredModules(moduleDir: Path): List<String> = try {
-        Files.newInputStream(moduleDir.resolve("pom.xml")).use { input ->
-            MavenXpp3Reader().read(input).modules
-        }
-    } catch (e: Exception) {
-        logger.warn("Maven plugin: failed to parse modules in ${moduleDir.fileName}: ${e.message}")
-        emptyList()
-    }
-
-    private fun discoverFallbackPomRoots(projectRoot: Path): List<Path> = try {
-        Files.find(
-            projectRoot,
-            FALLBACK_POM_DISCOVERY_DEPTH,
-            { path, attributes ->
-                attributes.isRegularFile &&
-                    path.fileName.toString() == "pom.xml"
-            }
-        ).use { paths ->
-            paths.toList()
-                .map { it.parent.toAbsolutePath().normalize() }
-                .distinct()
-                .sorted()
-        }
-    } catch (e: Exception) {
-        logger.warn("Maven plugin: failed to walk for pom.xml files: ${e.message}")
-        emptyList()
+    private fun findPatchFiles(projectDir: Path, reportDir: Path): List<DirectPluginPatchFile> {
+        val patch = reportDir.resolve("rewrite.patch")
+        if (!patch.exists()) return emptyList()
+        return listOf(DirectPluginPatchFile(file = patch, baseDir = projectDir))
     }
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginTempFiles.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/PluginTempFiles.kt
@@ -12,6 +12,18 @@ internal fun createPrivateTempFile(prefix: String, suffix: String): Path =
         it.toFile().deleteOnExit()
     }
 
+internal fun createPrivateTempDirectory(prefix: String): Path =
+    Files.createTempDirectory(prefix, *privateTempDirectoryAttributes()).also {
+        it.toFile().deleteOnExit()
+    }
+
+internal fun deleteRecursively(path: Path) {
+    if (!Files.exists(path)) return
+    Files.walk(path).use { stream ->
+        stream.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+    }
+}
+
 internal fun createRewriteConfigFile(content: String?): Path? {
     if (content == null) return null
     val configFile = createPrivateTempFile("rewrite-runner-config-", ".yml")
@@ -32,6 +44,21 @@ private fun privateTempFileAttributes(): Array<FileAttribute<*>> =
                 setOf(
                     PosixFilePermission.OWNER_READ,
                     PosixFilePermission.OWNER_WRITE
+                )
+            )
+        )
+    } else {
+        emptyArray()
+    }
+
+private fun privateTempDirectoryAttributes(): Array<FileAttribute<*>> =
+    if ("posix" in FileSystems.getDefault().supportedFileAttributeViews()) {
+        arrayOf<FileAttribute<*>>(
+            PosixFilePermissions.asFileAttribute(
+                setOf(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE
                 )
             )
         )

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
@@ -12,7 +12,11 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-private const val REPORT_OUTPUT_FLAG = "-Drewrite.reportOutputDirectory="
+// These must match the documented user-property names on the rewrite-maven-plugin mojos
+// (https://openrewrite.github.io/rewrite-maven-plugin/dryRun-mojo.html). They are pinned as
+// literal strings here — *not* shared with production code — so a typo in the production
+// flag fails this test rather than silently being ignored by Maven and skipping rewrite:run.
+private const val REPORT_OUTPUT_FLAG = "-DreportOutputDirectory="
 private const val RUN_PER_SUBMODULE_FLAG = "-Drewrite.runPerSubmodule=false"
 
 private fun extractReportDir(command: List<String>): Path? =

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/MavenPluginStrategyTest.kt
@@ -5,11 +5,20 @@ import io.github.skhokhlov.rewriterunner.config.ToolConfigDefaults
 import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
 import kotlin.io.path.writeText
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+
+private const val REPORT_OUTPUT_FLAG = "-Drewrite.reportOutputDirectory="
+private const val RUN_PER_SUBMODULE_FLAG = "-Drewrite.runPerSubmodule=false"
+
+private fun extractReportDir(command: List<String>): Path? =
+    command.firstOrNull { it.startsWith(REPORT_OUTPUT_FLAG) }
+        ?.removePrefix(REPORT_OUTPUT_FLAG)
+        ?.let(Path::of)
 
 class MavenPluginStrategyTest :
     FunSpec({
@@ -24,6 +33,7 @@ class MavenPluginStrategyTest :
 
         test("buildCommand includes active recipe, artifacts, and config location") {
             val config = Files.createTempFile("rewrite", ".yml")
+            val reportDir = Files.createTempDirectory("report-")
             val strategy =
                 MavenPluginStrategy(
                     NoOpRunnerLogger,
@@ -37,7 +47,8 @@ class MavenPluginStrategyTest :
                     goal = "dryRun",
                     activeRecipe = "com.example.Recipe",
                     recipeArtifacts = listOf("com.example:recipes:1.0.0", "com.example:more:2.0.0"),
-                    rewriteConfig = config
+                    rewriteConfig = config,
+                    reportOutputDirectory = reportDir
                 )
 
             assertEquals("mvn", command.first())
@@ -57,6 +68,7 @@ class MavenPluginStrategyTest :
         }
 
         test("buildCommand emits -Drewrite.exclusions when excludePaths non-empty") {
+            val reportDir = Files.createTempDirectory("report-")
             val strategy =
                 MavenPluginStrategy(
                     NoOpRunnerLogger,
@@ -71,6 +83,7 @@ class MavenPluginStrategyTest :
                     activeRecipe = "com.example.Recipe",
                     recipeArtifacts = emptyList(),
                     rewriteConfig = null,
+                    reportOutputDirectory = reportDir,
                     excludePaths = listOf("src/test/**")
                 )
 
@@ -78,6 +91,7 @@ class MavenPluginStrategyTest :
         }
 
         test("buildCommand omits -Drewrite.exclusions when excludePaths empty") {
+            val reportDir = Files.createTempDirectory("report-")
             val strategy =
                 MavenPluginStrategy(
                     NoOpRunnerLogger,
@@ -92,6 +106,7 @@ class MavenPluginStrategyTest :
                     activeRecipe = "com.example.Recipe",
                     recipeArtifacts = emptyList(),
                     rewriteConfig = null,
+                    reportOutputDirectory = reportDir,
                     excludePaths = emptyList()
                 )
 
@@ -99,6 +114,7 @@ class MavenPluginStrategyTest :
         }
 
         test("buildCommand joins multiple globs with comma") {
+            val reportDir = Files.createTempDirectory("report-")
             val strategy =
                 MavenPluginStrategy(
                     NoOpRunnerLogger,
@@ -113,6 +129,7 @@ class MavenPluginStrategyTest :
                     activeRecipe = "com.example.Recipe",
                     recipeArtifacts = emptyList(),
                     rewriteConfig = null,
+                    reportOutputDirectory = reportDir,
                     excludePaths = listOf("**/generated/**", "**/*.md", "src/test/**")
                 )
 
@@ -124,6 +141,7 @@ class MavenPluginStrategyTest :
         }
 
         test("buildCommand uses configured rewrite Maven plugin version") {
+            val reportDir = Files.createTempDirectory("report-")
             val strategy =
                 MavenPluginStrategy(
                     logger = NoOpRunnerLogger,
@@ -137,7 +155,8 @@ class MavenPluginStrategyTest :
                     goal = "dryRun",
                     activeRecipe = "com.example.Recipe",
                     recipeArtifacts = emptyList(),
-                    rewriteConfig = null
+                    rewriteConfig = null,
+                    reportOutputDirectory = reportDir
                 )
 
             assertTrue(
@@ -145,6 +164,57 @@ class MavenPluginStrategyTest :
                     "org.openrewrite.maven:rewrite-maven-plugin:" +
                         ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION + ":dryRun"
                 )
+            )
+        }
+
+        test("buildCommand pins reportOutputDirectory to an absolute path") {
+            val reportDir = Files.createTempDirectory("report-")
+            val strategy =
+                MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                    ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION
+                )
+
+            val command =
+                strategy.buildCommand(
+                    projectDir = projectDir,
+                    goal = "dryRun",
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    reportOutputDirectory = reportDir
+                )
+
+            val flag = command.firstOrNull { it.startsWith(REPORT_OUTPUT_FLAG) }
+            assertNotNull(flag, "expected $REPORT_OUTPUT_FLAG in $command")
+            val path = Path.of(flag.removePrefix(REPORT_OUTPUT_FLAG))
+            assertTrue(path.isAbsolute, "expected absolute path, got $path")
+            assertEquals(reportDir.toAbsolutePath(), path)
+        }
+
+        test("buildCommand pins runPerSubmodule=false to defend against user overrides") {
+            val reportDir = Files.createTempDirectory("report-")
+            val strategy =
+                MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                    ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION
+                )
+
+            val command =
+                strategy.buildCommand(
+                    projectDir = projectDir,
+                    goal = "dryRun",
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    reportOutputDirectory = reportDir
+                )
+
+            assertTrue(
+                command.contains(RUN_PER_SUBMODULE_FLAG),
+                "expected $RUN_PER_SUBMODULE_FLAG in $command"
             )
         }
 
@@ -173,7 +243,7 @@ class MavenPluginStrategyTest :
             assertIs<PluginRunResult.Failed>(result)
         }
 
-        test("run returns success without apply in dry-run mode") {
+        test("run picks up patch written to the configured reportOutputDirectory") {
             val commands = mutableListOf<List<String>>()
             val strategy =
                 object : MavenPluginStrategy(
@@ -183,8 +253,8 @@ class MavenPluginStrategyTest :
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? {
                         commands.add(command)
-                        projectDir.resolve("target/site/rewrite").createDirectories()
-                        projectDir.resolve("target/site/rewrite/rewrite.patch").writeText(
+                        val reportDir = extractReportDir(command)!!
+                        reportDir.resolve("rewrite.patch").writeText(
                             """
                             diff --git a/pom.xml b/pom.xml
                             --- a/pom.xml
@@ -216,7 +286,9 @@ class MavenPluginStrategyTest :
             assertEquals(setOf(Path.of("pom.xml")), result.diffs.keys)
         }
 
-        test("run detects patch files emitted by Maven submodules") {
+        test("run aggregates diffs across submodules from a single patch file") {
+            // Multi-module: parent declares modules, but the plugin (with runPerSubmodule=false)
+            // emits one aggregated patch at the configured reportOutputDirectory.
             projectDir.resolve("pom.xml").writeText(
                 """
                 <project>
@@ -227,23 +299,12 @@ class MavenPluginStrategyTest :
                   <packaging>pom</packaging>
                   <modules>
                     <module>module-a</module>
+                    <module>module-b</module>
                   </modules>
                 </project>
                 """.trimIndent()
             )
-            projectDir.resolve("module-a").createDirectories()
-            projectDir.resolve("module-a/pom.xml").writeText(
-                """
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example</groupId>
-                  <artifactId>module-a</artifactId>
-                  <version>1.0.0</version>
-                </project>
-                """.trimIndent()
-            )
 
-            val commands = mutableListOf<List<String>>()
             val strategy =
                 object : MavenPluginStrategy(
                     NoOpRunnerLogger,
@@ -251,21 +312,22 @@ class MavenPluginStrategyTest :
                     ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? {
-                        commands.add(command)
                         if (command.any { it.endsWith(":dryRun") }) {
-                            projectDir.resolve("module-a/target/site/rewrite").createDirectories()
-                            val patchFile =
-                                projectDir.resolve(
-                                    "module-a/target/site/rewrite/rewrite.patch"
-                                )
-                            patchFile.writeText(
+                            val reportDir = extractReportDir(command)!!
+                            reportDir.resolve("rewrite.patch").writeText(
                                 """
-                                diff --git a/src/main/java/A.java b/src/main/java/A.java
-                                --- a/src/main/java/A.java
-                                +++ b/src/main/java/A.java
+                                diff --git a/module-a/src/main/java/A.java b/module-a/src/main/java/A.java
+                                --- a/module-a/src/main/java/A.java
+                                +++ b/module-a/src/main/java/A.java
                                 @@ -1 +1 @@
                                 -class A {}
                                 +class A { }
+                                diff --git a/module-b/src/main/java/B.java b/module-b/src/main/java/B.java
+                                --- a/module-b/src/main/java/B.java
+                                +++ b/module-b/src/main/java/B.java
+                                @@ -1 +1 @@
+                                -class B {}
+                                +class B { }
                                 """.trimIndent()
                             )
                         }
@@ -286,19 +348,18 @@ class MavenPluginStrategyTest :
                 )
 
             assertIs<PluginRunResult.Success>(result)
-            assertEquals(2, commands.size)
             assertEquals(
-                listOf(projectDir.resolve("module-a/src/main/java/A.java")),
-                result.changedFiles
-            )
-            assertEquals(setOf(Path.of("module-a/src/main/java/A.java")), result.diffs.keys)
-            assertTrue(
-                result.diffs.getValue(Path.of("module-a/src/main/java/A.java"))
-                    .contains("diff --git a/module-a/src/main/java/A.java")
+                setOf(
+                    Path.of("module-a/src/main/java/A.java"),
+                    Path.of("module-b/src/main/java/B.java")
+                ),
+                result.diffs.keys
             )
         }
 
-        test("run ignores patch files outside declared Maven module roots") {
+        test("run surfaces submodule pom.xml diffs in the aggregated patch") {
+            // Pins that aggregated mode (runPerSubmodule=false) covers dependency-style recipe
+            // changes to submodule POMs, not just sources.
             projectDir.resolve("pom.xml").writeText(
                 """
                 <project>
@@ -309,18 +370,8 @@ class MavenPluginStrategyTest :
                   <packaging>pom</packaging>
                   <modules>
                     <module>module-a</module>
+                    <module>module-b</module>
                   </modules>
-                </project>
-                """.trimIndent()
-            )
-            projectDir.resolve("module-a").createDirectories()
-            projectDir.resolve("module-a/pom.xml").writeText(
-                """
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example</groupId>
-                  <artifactId>module-a</artifactId>
-                  <version>1.0.0</version>
                 </project>
                 """.trimIndent()
             )
@@ -333,35 +384,23 @@ class MavenPluginStrategyTest :
                 ) {
                     override fun execute(projectDir: Path, command: List<String>): Int? {
                         if (command.any { it.endsWith(":dryRun") }) {
-                            projectDir.resolve("module-a/target/site/rewrite").createDirectories()
-                            projectDir.resolve("module-a/target/site/rewrite/rewrite.patch")
-                                .writeText(
-                                    """
-                                    diff --git a/src/main/java/A.java b/src/main/java/A.java
-                                    --- a/src/main/java/A.java
-                                    +++ b/src/main/java/A.java
-                                    @@ -1 +1 @@
-                                    -class A {}
-                                    +class A { }
-                                    """.trimIndent()
-                                )
-
-                            projectDir.resolve("untracked/deep/module-b/target/site/rewrite")
-                                .createDirectories()
-                            projectDir
-                                .resolve(
-                                    "untracked/deep/module-b/target/site/rewrite/rewrite.patch"
-                                )
-                                .writeText(
-                                    """
-                                    diff --git a/src/main/java/Rogue.java b/src/main/java/Rogue.java
-                                    --- a/src/main/java/Rogue.java
-                                    +++ b/src/main/java/Rogue.java
-                                    @@ -1 +1 @@
-                                    -class Rogue {}
-                                    +class Rogue { }
-                                    """.trimIndent()
-                                )
+                            val reportDir = extractReportDir(command)!!
+                            reportDir.resolve("rewrite.patch").writeText(
+                                """
+                                diff --git a/module-a/pom.xml b/module-a/pom.xml
+                                --- a/module-a/pom.xml
+                                +++ b/module-a/pom.xml
+                                @@ -1 +1 @@
+                                -<project/>
+                                +<project></project>
+                                diff --git a/module-b/pom.xml b/module-b/pom.xml
+                                --- a/module-b/pom.xml
+                                +++ b/module-b/pom.xml
+                                @@ -1 +1 @@
+                                -<project/>
+                                +<project></project>
+                                """.trimIndent()
+                            )
                         }
                         return 0
                     }
@@ -380,10 +419,98 @@ class MavenPluginStrategyTest :
                 )
 
             assertIs<PluginRunResult.Success>(result)
-            assertEquals(setOf(Path.of("module-a/src/main/java/A.java")), result.diffs.keys)
             assertEquals(
-                listOf(projectDir.resolve("module-a/src/main/java/A.java")),
-                result.changedFiles
+                setOf(Path.of("module-a/pom.xml"), Path.of("module-b/pom.xml")),
+                result.diffs.keys
             )
+        }
+
+        test("run returns NoChanges when the report directory contains no patch") {
+            val strategy =
+                object : MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                    ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? = 0
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = true,
+                    includeMavenCentral = true,
+                    artifactRepositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.NoChanges>(result)
+        }
+
+        test("run deletes the temp report directory after success") {
+            val capturedReportDirs = mutableListOf<Path>()
+            val strategy =
+                object : MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                    ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int? {
+                        extractReportDir(command)?.let(capturedReportDirs::add)
+                        return 0
+                    }
+                }
+
+            strategy.run(
+                projectDir = projectDir,
+                activeRecipe = "com.example.Recipe",
+                recipeArtifacts = emptyList(),
+                rewriteConfig = null,
+                rewriteConfigContent = null,
+                dryRun = true,
+                includeMavenCentral = true,
+                artifactRepositories = emptyList()
+            )
+
+            assertTrue(capturedReportDirs.isNotEmpty(), "expected at least one report dir captured")
+            capturedReportDirs.forEach { dir ->
+                assertTrue(!dir.exists(), "expected temp report dir $dir to be cleaned up")
+            }
+        }
+
+        test("run deletes the temp report directory after failure") {
+            val capturedReportDirs = mutableListOf<Path>()
+            val strategy =
+                object : MavenPluginStrategy(
+                    NoOpRunnerLogger,
+                    ToolConfigDefaults.PLUGIN_RUN_TIMEOUT,
+                    ToolConfigDefaults.REWRITE_MAVEN_PLUGIN_VERSION
+                ) {
+                    override fun execute(projectDir: Path, command: List<String>): Int {
+                        extractReportDir(command)?.let(capturedReportDirs::add)
+                        return 1
+                    }
+                }
+
+            val result =
+                strategy.run(
+                    projectDir = projectDir,
+                    activeRecipe = "com.example.Recipe",
+                    recipeArtifacts = emptyList(),
+                    rewriteConfig = null,
+                    rewriteConfigContent = null,
+                    dryRun = true,
+                    includeMavenCentral = true,
+                    artifactRepositories = emptyList()
+                )
+
+            assertIs<PluginRunResult.Failed>(result)
+            assertTrue(capturedReportDirs.isNotEmpty(), "expected at least one report dir captured")
+            capturedReportDirs.forEach { dir ->
+                assertTrue(!dir.exists(), "expected temp report dir $dir to be cleaned up")
+            }
         }
     })


### PR DESCRIPTION
The rewrite-maven-plugin's default patch location moved (target/rewrite, not target/site/rewrite) and varies with multi-module layouts, so guessing the path caused Stage 0 to miss legitimate changes and skip rewrite:run. Pass `-DreportOutputDirectory=<temp>` (the documented user property is unprefixed — `-Drewrite.reportOutputDirectory` is silently ignored) and `-Drewrite.runPerSubmodule=false` to both dryRun and run, then read `<temp>/rewrite.patch` directly. Removes the per-module discovery and the legacy `target/site/...` fallback. Gradle is unaffected (no equivalent option).