### PR TITLE
ci(build): improve Gradle CI build speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,4 @@ jobs:
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
 
       - name: Build and test
-        run: ./gradlew check shadowJar
-
+        run: ./gradlew check shadowJar --max-workers=3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,10 +12,13 @@ val tagVersion = System.getenv("GITHUB_REF")
     ?.takeIf { it.startsWith("refs/tags/") }
     ?.removePrefix("refs/tags/v")
 val gitDescribe = runCatching {
-    providers.exec { commandLine("git", "describe", "--tags", "--exact-match") }
+    providers.exec {
+        commandLine("git", "describe", "--tags", "--exact-match")
+        isIgnoreExitValue = true
+    }
         .standardOutput.asText.get().trim().removePrefix("v")
 }.getOrNull()
-val projectVersion = tagVersion ?: gitDescribe ?: "1.0-SNAPSHOT"
+val projectVersion = tagVersion ?: gitDescribe?.ifBlank { null } ?: "1.0-SNAPSHOT"
 
 allprojects {
     version = projectVersion

--- a/buildSrc/src/main/kotlin/kotlin-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-convention.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.attributes.Bundling
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.testing.jacoco.tasks.JacocoReport
 
 plugins {
@@ -19,6 +20,16 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
     jvmArgs("-Xmx2g")
+    val defaultParallelForks =
+        providers.environmentVariable("CI")
+            .map { if (it == "true" && project.name == "core") "2" else "1" }
+            .orElse("1")
+    maxParallelForks =
+        providers.gradleProperty("${project.name}TestMaxParallelForks")
+            .orElse(providers.gradleProperty("testMaxParallelForks"))
+            .orElse(defaultParallelForks)
+            .map { it.toInt().coerceAtLeast(1) }
+            .get()
 }
 
 // Resolve ktlint CLI locally in each subproject to avoid cross-project configuration resolution
@@ -43,6 +54,25 @@ tasks.register<JavaExec>("ktlintCheck") {
     mainClass.set("com.pinterest.ktlint.Main")
     args("--reporter=plain", "src/**/*.kt")
     workingDir = projectDir
+
+    val kotlinSources = project.fileTree("src") {
+        include("**/*.kt")
+    }
+    inputs.files(kotlinSources)
+        .withPropertyName("kotlinSources")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files(ktlintCli)
+        .withPropertyName("ktlintCliClasspath")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    val markerFile = layout.buildDirectory.file("reports/ktlint/ktlintCheck.marker")
+    outputs.file(markerFile)
+    outputs.cacheIf { true }
+    doLast {
+        markerFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText("ktlint passed\n")
+        }
+    }
 }
 
 // ktlintFormat — auto-fixes style violations in-place.

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/cli/RunCommandTest.kt
@@ -263,7 +263,9 @@ class RunCommandTest :
             val errBaos = ByteArrayOutputStream()
             val code = cli().setErr(PrintWriter(errBaos)).execute(
                 "--active-recipe",
-                "io.github.skhokhlov.rewriterunner.MyRecipe"
+                "io.github.skhokhlov.rewriterunner.MyRecipe",
+                "--include-extensions",
+                ".java"
             )
             assertNotEquals(0, code, "--include-extensions should no longer be recognised")
         }
@@ -272,7 +274,9 @@ class RunCommandTest :
             val errBaos = ByteArrayOutputStream()
             val code = cli().setErr(PrintWriter(errBaos)).execute(
                 "--active-recipe",
-                "io.github.skhokhlov.rewriterunner.MyRecipe"
+                "io.github.skhokhlov.rewriterunner.MyRecipe",
+                "--exclude-extensions",
+                ".md"
             )
             assertNotEquals(0, code, "--exclude-extensions should no longer be recognised")
         }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
@@ -8,6 +8,7 @@ import io.github.skhokhlov.rewriterunner.config.ToolConfigDefaults
 import io.github.skhokhlov.rewriterunner.lst.utils.ClasspathResolutionResult
 import io.github.skhokhlov.rewriterunner.lst.utils.GradleConfigData
 import io.github.skhokhlov.rewriterunner.lst.utils.GradleProjectData
+import io.github.skhokhlov.rewriterunner.lst.utils.ProcessRunner
 import io.github.skhokhlov.rewriterunner.lst.utils.StaticBuildFileParser
 import io.github.skhokhlov.rewriterunner.lst.utils.hasBuildGradle
 import io.github.skhokhlov.rewriterunner.lst.utils.hasGradleBuildInSubdir
@@ -65,8 +66,15 @@ import org.eclipse.aether.resolution.ArtifactResolutionException
 open class DependencyResolutionStage(
     private val aetherContext: AetherContext,
     protected val logger: RunnerLogger,
-    private val processTimeout: Duration = ToolConfigDefaults.SUBPROCESS_RUN_TIMEOUT
+    private val processTimeout: Duration,
+    private val processRunner: ProcessRunner = ::runProcess
 ) {
+    constructor(
+        aetherContext: AetherContext,
+        logger: RunnerLogger,
+        processTimeout: Duration = ToolConfigDefaults.SUBPROCESS_RUN_TIMEOUT
+    ) : this(aetherContext, logger, processTimeout, ::runProcess)
+
     private val staticParser = StaticBuildFileParser(logger)
 
     /**
@@ -246,12 +254,13 @@ open class DependencyResolutionStage(
     protected open fun runMavenDependencyTreeOutput(projectDir: Path): String? {
         val mvnCmd = resolveMavenCommand(projectDir)
         val output = StringBuilder()
-        val result = runProcess(
+        val result = processRunner(
             projectDir,
             listOf(mvnCmd, "dependency:tree"),
-            captureStdout = output,
-            timeout = processTimeout,
-            logger = logger
+            output,
+            processTimeout,
+            "processTimeout",
+            logger
         ) ?: return null
         if (result != 0) {
             logger.warn("Maven dependency:tree failed with exit code $result")
@@ -334,7 +343,7 @@ open class DependencyResolutionStage(
         subprojects.mapTo(tasks) { "$it:dependencies" }
 
         val output = StringBuilder()
-        val result = runProcess(
+        val result = processRunner(
             projectDir,
             listOf(
                 gradleCmd,
@@ -344,9 +353,10 @@ open class DependencyResolutionStage(
                 "--no-daemon",
                 "--no-configuration-cache"
             ) + tasks,
-            captureStdout = output,
-            timeout = processTimeout,
-            logger = logger
+            output,
+            processTimeout,
+            "processTimeout",
+            logger
         ) ?: return null
 
         if (result != 0) {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
@@ -2,6 +2,7 @@ package io.github.skhokhlov.rewriterunner.lst
 
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.config.ToolConfigDefaults
+import io.github.skhokhlov.rewriterunner.lst.utils.ProcessRunner
 import io.github.skhokhlov.rewriterunner.lst.utils.hasBuildGradle
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveMavenCommand
@@ -55,8 +56,14 @@ import kotlin.io.path.exists
  */
 open class ProjectBuildStage(
     protected val logger: RunnerLogger,
-    private val processTimeout: Duration = ToolConfigDefaults.SUBPROCESS_RUN_TIMEOUT
+    private val processTimeout: Duration,
+    private val processRunner: ProcessRunner = ::runProcess
 ) {
+    constructor(
+        logger: RunnerLogger,
+        processTimeout: Duration = ToolConfigDefaults.SUBPROCESS_RUN_TIMEOUT
+    ) : this(logger, processTimeout, ::runProcess)
+
     /**
      * Attempts to extract the project's compile classpath by invoking the build tool.
      *
@@ -89,11 +96,13 @@ open class ProjectBuildStage(
                 "-Dmdep.outputFile=${outputFile.toAbsolutePath()}"
             )
             logger.debug("Stage 1: running ${mvnCommand.joinToString(" ")}")
-            val result = runProcess(
+            val result = processRunner(
                 projectDir,
                 mvnCommand,
-                timeout = processTimeout,
-                logger = logger
+                null,
+                processTimeout,
+                "processTimeout",
+                logger
             ) ?: return null
 
             if (result != 0) {
@@ -142,12 +151,13 @@ open class ProjectBuildStage(
             )
             logger.debug("Stage 1: running ${gradleCommand.joinToString(" ")}")
             val output = StringBuilder()
-            val result = runProcess(
+            val result = processRunner(
                 projectDir,
                 gradleCommand,
-                captureStdout = output,
-                timeout = processTimeout,
-                logger = logger
+                output,
+                processTimeout,
+                "processTimeout",
+                logger
             ) ?: return null
 
             if (result != 0) {
@@ -232,11 +242,13 @@ open class ProjectBuildStage(
     private fun runCompileTask(projectDir: Path, command: List<String>, toolName: String): Boolean =
         try {
             val result =
-                runProcess(
+                processRunner(
                     projectDir,
                     command,
-                    timeout = processTimeout,
-                    logger = logger
+                    null,
+                    processTimeout,
+                    "processTimeout",
+                    logger
                 ) ?: return false
             if (result == 0) {
                 logger.info("$toolName compilation succeeded")

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategy.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategy.kt
@@ -2,6 +2,7 @@ package io.github.skhokhlov.rewriterunner.plugin
 
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.config.RepositoryConfig
+import io.github.skhokhlov.rewriterunner.lst.utils.ProcessRunner
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.runProcess
 import java.nio.file.Files
@@ -19,8 +20,15 @@ import java.time.Duration
 internal open class GradlePluginStrategy(
     private val logger: RunnerLogger,
     private val timeout: Duration,
-    private val rewritePluginVersion: String
+    private val rewritePluginVersion: String,
+    private val processRunner: ProcessRunner = ::runProcess
 ) : PluginBuildStrategy {
+    constructor(
+        logger: RunnerLogger,
+        timeout: Duration,
+        rewritePluginVersion: String
+    ) : this(logger, timeout, rewritePluginVersion, ::runProcess)
+
     override fun run(
         projectDir: Path,
         activeRecipe: String,
@@ -159,13 +167,8 @@ internal open class GradlePluginStrategy(
         }
     }
 
-    open fun execute(projectDir: Path, command: List<String>): Int? = runProcess(
-        workDir = projectDir,
-        command = command,
-        timeout = timeout,
-        timeoutName = "pluginTimeout",
-        logger = logger
-    )
+    open fun execute(projectDir: Path, command: List<String>): Int? =
+        processRunner(projectDir, command, null, timeout, "pluginTimeout", logger)
 
     private fun buildCommand(projectDir: Path, task: String, initScript: Path): List<String> =
         listOf(

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageTest.kt
@@ -53,31 +53,30 @@ class DependencyResolutionStageTest :
 
         test("resolveClasspath honors configured process timeout") {
             projectDir.resolve("pom.xml").writeText("<project/>")
-            val mvnw = projectDir.resolve("mvnw").toFile()
-            mvnw.writeText(
-                """
-                #!/bin/sh
-                sleep 5
-                exit 0
-                """.trimIndent()
-            )
-            mvnw.setExecutable(true)
+
+            var observedCommand: List<String> = emptyList()
+            var observedTimeout: Duration? = null
+            var observedTimeoutName: String? = null
+
             val timedStage =
                 DependencyResolutionStage(
                     AetherContext.build(cacheDir.resolve("repository"), logger = NoOpRunnerLogger),
                     NoOpRunnerLogger,
-                    processTimeout = Duration.ofSeconds(1)
+                    processTimeout = Duration.ofSeconds(1),
+                    processRunner = { _, command, _, timeout, timeoutName, _ ->
+                        observedCommand = command
+                        observedTimeout = timeout
+                        observedTimeoutName = timeoutName
+                        null
+                    }
                 )
 
-            val start = System.currentTimeMillis()
             val result = timedStage.resolveClasspath(projectDir)
-            val elapsed = System.currentTimeMillis() - start
 
             assertTrue(result.classpath.isEmpty(), "Timed-out Stage 2 should return no classpath")
-            assertTrue(
-                elapsed < 4_000,
-                "Configured 1s timeout should stop dependency:tree promptly, took ${elapsed}ms"
-            )
+            assertEquals(Duration.ofSeconds(1), observedTimeout)
+            assertEquals("processTimeout", observedTimeoutName)
+            assertTrue(observedCommand.contains("dependency:tree"))
         }
 
         // ─── Maven pom.xml parsing ────────────────────────────────────────────────

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 import kotlin.io.path.writeText
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -268,27 +269,28 @@ class ProjectBuildStageTest :
 
         test("extractClasspath honors configured process timeout") {
             projectDir.resolve("pom.xml").writeText("<project/>")
-            val mvnw = projectDir.resolve("mvnw").toFile()
-            mvnw.writeText(
-                """
-                #!/bin/sh
-                sleep 5
-                exit 0
-                """.trimIndent()
-            )
-            mvnw.setExecutable(true)
+
+            var observedCommand: List<String> = emptyList()
+            var observedTimeout: Duration? = null
+            var observedTimeoutName: String? = null
 
             val timedStage =
-                ProjectBuildStage(NoOpRunnerLogger, processTimeout = Duration.ofSeconds(1))
-            val start = System.currentTimeMillis()
+                ProjectBuildStage(
+                    NoOpRunnerLogger,
+                    processTimeout = Duration.ofSeconds(1),
+                    processRunner = { _, command, _, timeout, timeoutName, _ ->
+                        observedCommand = command
+                        observedTimeout = timeout
+                        observedTimeoutName = timeoutName
+                        null
+                    }
+                )
             val result = timedStage.extractClasspath(projectDir)
-            val elapsed = System.currentTimeMillis() - start
 
             assertNull(result, "Timed-out classpath extraction should fall through")
-            assertTrue(
-                elapsed < 4_000,
-                "Configured 1s timeout should stop the wrapper promptly, took ${elapsed}ms"
-            )
+            assertEquals(Duration.ofSeconds(1), observedTimeout)
+            assertEquals("processTimeout", observedTimeoutName)
+            assertTrue(observedCommand.contains("dependency:build-classpath"))
         }
     })
 

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategyTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/plugin/GradlePluginStrategyTest.kt
@@ -425,23 +425,22 @@ class GradlePluginStrategyTest :
         }
 
         test("run honors configured plugin timeout") {
-            val gradlew = projectDir.resolve("gradlew").toFile()
-            gradlew.writeText(
-                """
-                #!/bin/sh
-                sleep 5
-                exit 0
-                """.trimIndent()
-            )
-            gradlew.setExecutable(true)
+            var observedCommand: List<String> = emptyList()
+            var observedTimeout: Duration? = null
+            var observedTimeoutName: String? = null
 
             val strategy =
                 GradlePluginStrategy(
                     NoOpRunnerLogger,
                     timeout = Duration.ofSeconds(1),
-                    ToolConfigDefaults.REWRITE_GRADLE_PLUGIN_VERSION
+                    ToolConfigDefaults.REWRITE_GRADLE_PLUGIN_VERSION,
+                    processRunner = { _, command, _, timeout, timeoutName, _ ->
+                        observedCommand = command
+                        observedTimeout = timeout
+                        observedTimeoutName = timeoutName
+                        null
+                    }
                 )
-            val start = System.currentTimeMillis()
             val result =
                 strategy.run(
                     projectDir = projectDir,
@@ -453,12 +452,10 @@ class GradlePluginStrategyTest :
                     includeMavenCentral = true,
                     artifactRepositories = emptyList()
                 )
-            val elapsed = System.currentTimeMillis() - start
 
             assertIs<PluginRunResult.Failed>(result)
-            assertTrue(
-                elapsed < 4_000,
-                "Configured 1s timeout should stop rewriteDryRun promptly, took ${elapsed}ms"
-            )
+            assertEquals(Duration.ofSeconds(1), observedTimeout)
+            assertEquals("pluginTimeout", observedTimeoutName)
+            assertTrue(observedCommand.contains("rewriteDryRun"))
         }
     })

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeArtifactResolverTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/recipe/RecipeArtifactResolverTest.kt
@@ -447,8 +447,8 @@ class RecipeArtifactResolverTest :
                     .createSessionBuilder()
                     .withLocalRepositories(org.eclipse.aether.repository.LocalRepository(repoDir))
                     .setSystemProperties(System.getProperties())
-                    .setConfigProperty(ConfigurationProperties.CONNECT_TIMEOUT, 2_000)
-                    .setConfigProperty(ConfigurationProperties.REQUEST_TIMEOUT, 2_000)
+                    .setConfigProperty(ConfigurationProperties.CONNECT_TIMEOUT, 1_000)
+                    .setConfigProperty(ConfigurationProperties.REQUEST_TIMEOUT, 1_000)
                     .setConfigProperty(
                         "aether.remoteRepositoryFilter.prefixes.resolvePrefixFiles",
                         false
@@ -470,8 +470,8 @@ class RecipeArtifactResolverTest :
 
             blackHole.close()
             assertTrue(
-                elapsedMs < 10_000,
-                "resolve() must honour resolver request timeout and complete in <10 s; took ${elapsedMs}ms"
+                elapsedMs < 5_000,
+                "resolve() must honour resolver request timeout and complete in <5 s; took ${elapsedMs}ms"
             )
         }
 
@@ -523,20 +523,10 @@ class RecipeArtifactResolverTest :
             // Use "simple" local repo type so Maven Resolver reads cached files directly
             // without verifying their provenance against a remote repository.
 
-            val blackHole = ServerSocket(0)
-            val port = blackHole.localPort
-            Thread {
-                try {
-                    val conn = blackHole.accept()
-                    Thread.sleep(30_000)
-                    conn.close()
-                } catch (_: Exception) {}
-            }
-                .also { it.isDaemon = true }
-                .start()
-
             // Build a custom AetherContext with a "simple" local repository so the pre-cached
-            // root artifact is used as-is, and only the missing transitive dep hits the black-hole.
+            // root artifact is used as-is, and only the missing transitive dep hits the fake
+            // file repository.
+            val fakeRemote = cacheDir.resolve("fake-remote").also { Files.createDirectories(it) }
             val system2 = RepositorySystemSupplier().get()
             val repoDir2 = cacheDir.resolve("repository").also { it.toFile().mkdirs() }
             // "simple" type: reads cached files without _remote.repositories checks
@@ -546,22 +536,20 @@ class RecipeArtifactResolverTest :
                     .createSessionBuilder()
                     .withLocalRepositories(localRepo2)
                     .setSystemProperties(System.getProperties())
-                    .setConfigProperty(ConfigurationProperties.CONNECT_TIMEOUT, 2_000)
-                    .setConfigProperty(ConfigurationProperties.REQUEST_TIMEOUT, 2_000)
+                    .setConfigProperty(ConfigurationProperties.CONNECT_TIMEOUT, 1_000)
+                    .setConfigProperty(ConfigurationProperties.REQUEST_TIMEOUT, 1_000)
                     .build()
-            val blackHoleRepo2 = listOf(
-                RemoteRepository.Builder("blackhole", "default", "http://127.0.0.1:$port").build()
+            val fakeRemoteRepo2 = listOf(
+                RemoteRepository.Builder("fake", "default", fakeRemote.toUri().toString()).build()
             )
             val resolver =
                 RecipeArtifactResolver(
-                    AetherContext(system2, session2, blackHoleRepo2),
+                    AetherContext(system2, session2, fakeRemoteRepo2),
                     NoOpRunnerLogger
                 )
 
             // Should NOT throw — partial results (root artifact) are returned
             val paths = resolver.resolve("$rootGroupId:$rootArtifactId:$rootVersion")
-
-            blackHole.close()
 
             assertTrue(
                 paths.isNotEmpty(),

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,7 +6,7 @@ Located in `buildSrc/src/main/kotlin/`. Applied via `plugins { id("...") }` in s
 
 | Plugin | Applied to | What it does |
 |--------|-----------|--------------|
-| `kotlin-convention` | `core`, `cli` | Kotlin JVM 21 toolchain, JUnit platform, `-Xmx2g` for tests, ktlint tasks (`ktlintCheck`/`ktlintFormat`), JaCoCo XML+HTML reports auto-run after test |
+| `kotlin-convention` | `core`, `cli` | Kotlin JVM 21 toolchain, JUnit platform, `-Xmx2g` for tests, CI test fork parallelism for `core`, ktlint tasks (`ktlintCheck`/`ktlintFormat`), JaCoCo XML+HTML reports auto-run after test |
 | `publishing-convention` | `core` | `maven-publish`, optional signing, Dokka sources/javadoc JARs, POM template |
 | `dokka-convention` | `core` | Dokka HTML docs generation |
 
@@ -53,8 +53,8 @@ Chosen for **Gradle 9.0.0 + JDK 25 compatibility**:
 ### Build workflow (`.github/workflows/build.yml`)
 Triggers on push/PR to `main`/`master`:
 1. Set up JDK 21 (Temurin)
-2. `./gradlew check shadowJar` (`check` = `ktlintCheck` + `test`)
-3. Upload fat JAR as build artifact
+2. `./gradlew check shadowJar --max-workers=3` (`check` = `ktlintCheck` + `test`)
+3. Build the fat JAR
 
 ### Publish workflow (`.github/workflows/publish.yml`)
 Triggers on `v*` tags — publishes `core` to Maven Central.


### PR DESCRIPTION
Add controlled test parallelism for CI by capping the workflow at three Gradle workers and allowing the core test task to use two forks by default. The CLI integration suite remains single-forked because local profiling showed that parallel CLI forks made those tests slower, while core tests benefit from the extra fork.

Make ktlintCheck cacheable/up-to-date by declaring Kotlin source inputs, the ktlint CLI classpath input, and a marker output. This prevents unchanged style checks from rerunning on every warm build.

Unblock Gradle configuration cache by making root version detection tolerate non-tag commits. The previous git describe --exact-match call failed on ordinary commits and caused configuration-cache storage to fail; the build now treats an empty/non-tag result as the existing SNAPSHOT fallback.

Replace several timeout tests that depended on real sleep/elapsed-time behavior with injected ProcessRunner assertions. This keeps the timeout contract covered while avoiding slow and scheduler-sensitive tests. Keep one real resolver timeout coverage path, but move partial-resolution coverage to a fast local file repository.

Fix removed CLI option regression tests so they actually pass the legacy --include-extensions and --exclude-extensions flags instead of only asserting a generic command failure.

Update build documentation to reflect the current CI command and core test parallelism behavior.

Validation:
- ./gradlew :core:ktlintCheck :cli:ktlintCheck
- ./gradlew help --configuration-cache
- ./gradlew :core:test --tests "io.github.skhokhlov.rewriterunner.lst.ProjectBuildStageTest" --tests "io.github.skhokhlov.rewriterunner.lst.DependencyResolutionStageTest" --tests "io.github.skhokhlov.rewriterunner.plugin.GradlePluginStrategyTest"
- ./gradlew :core:test :cli:test --rerun-tasks --max-workers=3 -PcoreTestMaxParallelForks=2 -PcliTestMaxParallelForks=1
- ./gradlew check shadowJar --max-workers=3 -PcoreTestMaxParallelForks=2 -PcliTestMaxParallelForks=1
- git diff --check