### PR TITLE
feat(lst): resolve classpaths per build unit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ cli/src/
 
 - `InMemoryLargeSourceSet` is in `org.openrewrite.internal` (not the top-level package)
 - `ProjectBuildStage` and `DependencyResolutionStage` are `open` with `open` methods — subclass in tests instead of mocking
-- Stages 1 and 2 use `discoverBuildUnits` from `ProcessRunner.kt`: root descriptors keep one root invocation per tool, while root-less monorepos discover top-most subdirectory build units to depth 3, skip default excluded dirs, cap at 25 units, and merge partial successes. See `CONTEXT.md` and `docs/adr/0001-build-unit-classpath-resolution.md`.
+- Stages 1 and 2 use `discoverBuildUnits` from `ProcessRunner.kt`: root descriptors keep one root invocation per tool, while root-less monorepos discover top-most subdirectory build units to depth 3, skip default excluded dirs, sort candidates before the 25-unit cap, and require full discovered-unit coverage before a stage is considered complete. Partial or capped coverage falls through to later fallback stages. See `CONTEXT.md` and `docs/adr/0001-build-unit-classpath-resolution.md`.
 - `ResultFormatter` has a secondary constructor accepting `PrintWriter`; `RunCommand` passes picocli's `@Spec` output writer
 - Stage 0 tries the official Gradle/Maven OpenRewrite plugins first and returns `RunResult.rawDiffs` on success. Use `--skip-plugin-run` / `Builder.skipPluginRun(true)` when testing or debugging the in-process LST pipeline directly.
 - Path exclusion: `--exclude-paths` (CLI) overrides `parse.excludePaths` (YAML) when non-empty. The resolved value is forwarded to Stage 0 and to the LST fallback so both apply identical filtering. When no JVM source survives the exclusion, classpath resolution stages 1–4 are skipped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ core/src/
 │   │   ├── LocalRepositoryStage.kt     # Stage 4: Local cache scan
 │   │   └── utils/
 │   │       ├── FileCollector.kt        # NIO walk, excluded-dir filtering, glob exclusions, extension resolution
+│   │       ├── ProcessRunner.kt        # Build-unit discovery, wrapper command resolution, subprocess runner
 │   │       ├── VersionDetector.kt      # Java/Kotlin JVM-version walk-up + parseGradleVersionFromWrapper
 │   │       ├── GradleDslClasspathResolver.kt  # Locate Gradle installation for DSL classpath
 │   │       ├── MarkerFactory.kt        # BuildTool, GitProvenance, OperatingSystem, GradleProject markers
@@ -119,6 +120,7 @@ cli/src/
 
 - `InMemoryLargeSourceSet` is in `org.openrewrite.internal` (not the top-level package)
 - `ProjectBuildStage` and `DependencyResolutionStage` are `open` with `open` methods — subclass in tests instead of mocking
+- Stages 1 and 2 use `discoverBuildUnits` from `ProcessRunner.kt`: root descriptors keep one root invocation per tool, while root-less monorepos discover top-most subdirectory build units to depth 3, skip default excluded dirs, cap at 25 units, and merge partial successes. See `CONTEXT.md` and `docs/adr/0001-build-unit-classpath-resolution.md`.
 - `ResultFormatter` has a secondary constructor accepting `PrintWriter`; `RunCommand` passes picocli's `@Spec` output writer
 - Stage 0 tries the official Gradle/Maven OpenRewrite plugins first and returns `RunResult.rawDiffs` on success. Use `--skip-plugin-run` / `Builder.skipPluginRun(true)` when testing or debugging the in-process LST pipeline directly.
 - Path exclusion: `--exclude-paths` (CLI) overrides `parse.excludePaths` (YAML) when non-empty. The resolved value is forwarded to Stage 0 and to the LST fallback so both apply identical filtering. When no JVM source survives the exclusion, classpath resolution stages 1–4 are skipped.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,12 @@
+# Context
+
+## Glossary
+
+- **Build unit**: A directory where rewrite-runner invokes Maven or Gradle for classpath resolution,
+  paired with the build tool used there.
+- **Root descriptor**: A build descriptor at the project root: `pom.xml` for Maven, or
+  `settings.gradle(.kts)` / `build.gradle(.kts)` for Gradle.
+- **Root-less monorepo**: A repository whose project root has no build descriptor for a tool, but one
+  or more subdirectories do.
+- **Top-most discovery**: Build-unit discovery rule that selects the first descriptor directory found
+  on a path and does not descend into that directory's children.

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStage.kt
@@ -230,10 +230,14 @@ open class BuildFileParseStage(
         }
     }
 
-    /** Walks [projectDir] up to depth 3, collecting parent directories of found `pom.xml` files. */
+    /**
+     * Walks descriptor files under [projectDir], collecting parent directories of found `pom.xml`
+     * files. Descriptor files are one level below the build-unit directory, so the file-walk depth is
+     * one greater than the supported build-unit subdirectory depth.
+     */
     private fun walkForPomDirs(projectDir: Path, found: MutableSet<Path>) {
         try {
-            Files.walk(projectDir, 3).use { stream ->
+            Files.walk(projectDir, FALLBACK_DESCRIPTOR_FILE_WALK_DEPTH).use { stream ->
                 stream.filter { path -> !isInDescriptorDiscoveryExcludedDir(projectDir, path) }
                     .filter { path -> path.fileName?.toString() == "pom.xml" }
                     .forEach { pomFile -> found.add(pomFile.parent) }
@@ -244,15 +248,16 @@ open class BuildFileParseStage(
     }
 
     /**
-     * Walks [projectDir] up to depth 3, calling [StaticBuildFileParser.parseGradleDependenciesStatically]
-     * for each subdirectory containing a `build.gradle` or `build.gradle.kts` file.
+     * Walks descriptor files under [projectDir], calling
+     * [StaticBuildFileParser.parseGradleDependenciesStatically] for each subdirectory containing a
+     * `build.gradle` or `build.gradle.kts` file.
      *
      * Used when there is no root build file but build files exist in subdirectories.
      */
     private fun parseGradleSubdirs(projectDir: Path): List<String> {
         val coords = mutableListOf<String>()
         try {
-            Files.walk(projectDir, 3).use { stream ->
+            Files.walk(projectDir, FALLBACK_DESCRIPTOR_FILE_WALK_DEPTH).use { stream ->
                 stream.filter { path ->
                     if (isInDescriptorDiscoveryExcludedDir(projectDir, path)) return@filter false
                     val name = path.fileName?.toString() ?: return@filter false
@@ -275,3 +280,8 @@ open class BuildFileParseStage(
         }
     }
 }
+
+private const val FALLBACK_DESCRIPTOR_DIR_DEPTH = 3
+
+// Descriptor files live inside the build-unit directory, so include one extra file level.
+private const val FALLBACK_DESCRIPTOR_FILE_WALK_DEPTH = FALLBACK_DESCRIPTOR_DIR_DEPTH + 1

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
@@ -67,6 +67,7 @@ open class DependencyResolutionStage(
     private val processTimeout: Duration = ToolConfigDefaults.SUBPROCESS_RUN_TIMEOUT
 ) {
     private val staticParser = StaticBuildFileParser(logger)
+    private var commandRoot: Path? = null
 
     /**
      * Best-effort: runs `gradle dependencies` to collect per-project configuration data for
@@ -77,24 +78,30 @@ open class DependencyResolutionStage(
      * when no dependency data could be parsed.
      */
     open fun collectGradleProjectData(projectDir: Path): Map<String, GradleProjectData>? {
-        val gradleUnits = discoverBuildUnits(projectDir, logger = logger)
-            .filter { it.tool == BuildToolKind.GRADLE }
-        if (gradleUnits.isEmpty()) return null
+        val priorCommandRoot = commandRoot
+        commandRoot = projectDir
+        try {
+            val gradleUnits = discoverBuildUnits(projectDir, logger = logger)
+                .filter { it.tool == BuildToolKind.GRADLE }
+            if (gradleUnits.isEmpty()) return null
 
-        val merged = linkedMapOf<String, GradleProjectData>()
-        gradleUnits.forEach { unit ->
-            try {
-                val rawOutput = runGradleDependenciesRawOutput(unit.dir) ?: return@forEach
-                val parsed = parseGradleDependencyTaskOutputByProject(rawOutput)
-                merged.putAll(rekeyGradleProjectData(projectDir, unit.dir, parsed))
-            } catch (e: Exception) {
-                logger.warn(
-                    "Could not collect Gradle project data for markers from ${unit.dir}: " +
-                        e.message
-                )
+            val merged = linkedMapOf<String, GradleProjectData>()
+            gradleUnits.forEach { unit ->
+                try {
+                    val rawOutput = runGradleDependenciesRawOutput(unit.dir) ?: return@forEach
+                    val parsed = parseGradleDependencyTaskOutputByProject(rawOutput)
+                    merged.putAll(rekeyGradleProjectData(projectDir, unit.dir, parsed))
+                } catch (e: Exception) {
+                    logger.warn(
+                        "Could not collect Gradle project data for markers from ${unit.dir}: " +
+                            e.message
+                    )
+                }
             }
+            return merged.takeIf { it.isNotEmpty() }
+        } finally {
+            commandRoot = priorCommandRoot
         }
-        return merged.takeIf { it.isNotEmpty() }
     }
 
     /**
@@ -112,63 +119,73 @@ open class DependencyResolutionStage(
      *   no subprocess succeeds or resolution fails completely.
      */
     open fun resolveClasspath(projectDir: Path): ClasspathResolutionResult {
-        val coords = mutableListOf<String>()
-        val gradleProjectData = linkedMapOf<String, GradleProjectData>()
+        val priorCommandRoot = commandRoot
+        commandRoot = projectDir
+        try {
+            val coords = mutableListOf<String>()
+            val gradleProjectData = linkedMapOf<String, GradleProjectData>()
 
-        discoverBuildUnits(projectDir, logger = logger).forEach { unit ->
-            when (unit.tool) {
-                BuildToolKind.MAVEN -> {
-                    logger.debug(
-                        "Stage 2: Maven build unit at ${unit.dir} — running dependency:tree"
-                    )
-                    val rawOutput = runMavenDependencyTreeOutput(unit.dir)
-                    if (rawOutput != null) {
-                        coords += parseMavenDependencyTreeOutput(rawOutput)
+            discoverBuildUnits(projectDir, logger = logger).forEach { unit ->
+                when (unit.tool) {
+                    BuildToolKind.MAVEN -> {
+                        logger.debug(
+                            "Stage 2: Maven build unit at ${unit.dir} — running dependency:tree"
+                        )
+                        val rawOutput = runMavenDependencyTreeOutput(unit.dir)
+                        if (rawOutput != null) {
+                            coords += parseMavenDependencyTreeOutput(rawOutput)
+                        }
                     }
-                }
 
-                BuildToolKind.GRADLE -> {
-                    logger.debug(
-                        "Stage 2: Gradle build unit at ${unit.dir} — running dependencies task"
-                    )
-                    val rawOutput = runGradleDependenciesRawOutput(unit.dir)
-                    if (rawOutput != null) {
-                        val gradleCoords = parseGradleDependencyTaskOutput(rawOutput)
-                        if (gradleCoords.isNotEmpty()) {
-                            coords += gradleCoords
-                            val parsedData = parseGradleDependencyTaskOutputByProject(rawOutput)
-                            gradleProjectData.putAll(
-                                rekeyGradleProjectData(projectDir, unit.dir, parsedData)
-                            )
-                        } else {
-                            logger.info("Gradle dependencies task returned no coordinates")
+                    BuildToolKind.GRADLE -> {
+                        logger.debug(
+                            "Stage 2: Gradle build unit at ${unit.dir} — running dependencies task"
+                        )
+                        val rawOutput = runGradleDependenciesRawOutput(unit.dir)
+                        if (rawOutput != null) {
+                            val gradleCoords = parseGradleDependencyTaskOutput(rawOutput)
+                            if (gradleCoords.isNotEmpty()) {
+                                coords += gradleCoords
+                                val parsedData =
+                                    parseGradleDependencyTaskOutputByProject(rawOutput)
+                                gradleProjectData.putAll(
+                                    rekeyGradleProjectData(projectDir, unit.dir, parsedData)
+                                )
+                            } else {
+                                logger.info("Gradle dependencies task returned no coordinates")
+                            }
                         }
                     }
                 }
             }
-        }
 
-        if (coords.isEmpty()) {
-            logger.info("No dependencies found via subprocess")
+            if (coords.isEmpty()) {
+                logger.info("No dependencies found via subprocess")
+                return ClasspathResolutionResult(
+                    emptyList(),
+                    gradleProjectData.takeIf {
+                        it.isNotEmpty()
+                    }
+                )
+            }
+
+            // If [resolveClasspath] was invoked through the 2-arg overload, route through the
+            // filter-aware [resolveArtifactsDirectly] overload so malformed coords are recorded.
+            // Otherwise preserve historical behaviour: pass coords as-is to the 1-arg overload
+            // (which existing subclasses may override to stub Aether).
+            val sink = pendingParseFailures
+            val classpath = if (sink != null) {
+                resolveArtifactsDirectly(coords.distinct(), sink)
+            } else {
+                resolveArtifactsDirectly(coords.distinct())
+            }
             return ClasspathResolutionResult(
-                emptyList(),
-                gradleProjectData.takeIf {
-                    it.isNotEmpty()
-                }
+                classpath,
+                gradleProjectData.takeIf { it.isNotEmpty() }
             )
+        } finally {
+            commandRoot = priorCommandRoot
         }
-
-        // If [resolveClasspath] was invoked through the 2-arg overload, route through the
-        // filter-aware [resolveArtifactsDirectly] overload so malformed coords are recorded.
-        // Otherwise preserve historical behaviour: pass coords as-is to the 1-arg overload
-        // (which existing subclasses may override to stub Aether).
-        val sink = pendingParseFailures
-        val classpath = if (sink != null) {
-            resolveArtifactsDirectly(coords.distinct(), sink)
-        } else {
-            resolveArtifactsDirectly(coords.distinct())
-        }
-        return ClasspathResolutionResult(classpath, gradleProjectData.takeIf { it.isNotEmpty() })
     }
 
     private fun rekeyGradleProjectData(
@@ -287,7 +304,7 @@ open class DependencyResolutionStage(
      * stdout output, or `null` on failure (non-zero exit, process error, or timeout).
      */
     protected open fun runMavenDependencyTreeOutput(projectDir: Path): String? {
-        val mvnCmd = resolveMavenCommand(projectDir)
+        val mvnCmd = resolveMavenCommand(projectDir, commandRoot ?: projectDir)
         val output = StringBuilder()
         val result = runProcess(
             projectDir,
@@ -366,7 +383,7 @@ open class DependencyResolutionStage(
      * per-project data (via [parseGradleDependencyTaskOutputByProject]).
      */
     protected open fun runGradleDependenciesRawOutput(projectDir: Path): String? {
-        val gradleCmd = resolveGradleCommand(projectDir)
+        val gradleCmd = resolveGradleCommand(projectDir, commandRoot ?: projectDir)
         val subprojects = staticParser.discoverSubprojects(projectDir)
         logger.debug(
             "Stage 2: discovered ${subprojects.size} subproject(s): " +

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
@@ -5,13 +5,12 @@ import io.github.skhokhlov.rewriterunner.MavenCoordinates
 import io.github.skhokhlov.rewriterunner.ParseFailure
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.config.ToolConfigDefaults
+import io.github.skhokhlov.rewriterunner.lst.utils.BuildToolKind
 import io.github.skhokhlov.rewriterunner.lst.utils.ClasspathResolutionResult
 import io.github.skhokhlov.rewriterunner.lst.utils.GradleConfigData
 import io.github.skhokhlov.rewriterunner.lst.utils.GradleProjectData
 import io.github.skhokhlov.rewriterunner.lst.utils.StaticBuildFileParser
-import io.github.skhokhlov.rewriterunner.lst.utils.hasBuildGradle
-import io.github.skhokhlov.rewriterunner.lst.utils.hasGradleBuildInSubdir
-import io.github.skhokhlov.rewriterunner.lst.utils.hasMavenPomInSubdir
+import io.github.skhokhlov.rewriterunner.lst.utils.discoverBuildUnits
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveMavenCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.runProcess
@@ -78,14 +77,24 @@ open class DependencyResolutionStage(
      * when no dependency data could be parsed.
      */
     open fun collectGradleProjectData(projectDir: Path): Map<String, GradleProjectData>? {
-        if (!hasBuildGradle(projectDir) && !hasGradleBuildInSubdir(projectDir)) return null
-        return try {
-            val rawOutput = runGradleDependenciesRawOutput(projectDir) ?: return null
-            parseGradleDependencyTaskOutputByProject(rawOutput)
-        } catch (e: Exception) {
-            logger.warn("Could not collect Gradle project data for markers: ${e.message}")
-            null
+        val gradleUnits = discoverBuildUnits(projectDir, logger = logger)
+            .filter { it.tool == BuildToolKind.GRADLE }
+        if (gradleUnits.isEmpty()) return null
+
+        val merged = linkedMapOf<String, GradleProjectData>()
+        gradleUnits.forEach { unit ->
+            try {
+                val rawOutput = runGradleDependenciesRawOutput(unit.dir) ?: return@forEach
+                val parsed = parseGradleDependencyTaskOutputByProject(rawOutput)
+                merged.putAll(rekeyGradleProjectData(projectDir, unit.dir, parsed))
+            } catch (e: Exception) {
+                logger.warn(
+                    "Could not collect Gradle project data for markers from ${unit.dir}: " +
+                        e.message
+                )
+            }
         }
+        return merged.takeIf { it.isNotEmpty() }
     }
 
     /**
@@ -104,35 +113,49 @@ open class DependencyResolutionStage(
      */
     open fun resolveClasspath(projectDir: Path): ClasspathResolutionResult {
         val coords = mutableListOf<String>()
-        var gradleProjectData: Map<String, GradleProjectData>? = null
+        val gradleProjectData = linkedMapOf<String, GradleProjectData>()
 
-        // Maven subprocess: run mvn dependency:tree
-        if (projectDir.resolve("pom.xml").exists() || hasMavenPomInSubdir(projectDir)) {
-            logger.debug("Stage 2: Maven project detected — running dependency:tree")
-            val rawOutput = runMavenDependencyTreeOutput(projectDir)
-            if (rawOutput != null) {
-                coords += parseMavenDependencyTreeOutput(rawOutput)
-            }
-        }
+        discoverBuildUnits(projectDir, logger = logger).forEach { unit ->
+            when (unit.tool) {
+                BuildToolKind.MAVEN -> {
+                    logger.debug(
+                        "Stage 2: Maven build unit at ${unit.dir} — running dependency:tree"
+                    )
+                    val rawOutput = runMavenDependencyTreeOutput(unit.dir)
+                    if (rawOutput != null) {
+                        coords += parseMavenDependencyTreeOutput(rawOutput)
+                    }
+                }
 
-        // Gradle subprocess: run gradle dependencies
-        if (hasBuildGradle(projectDir) || hasGradleBuildInSubdir(projectDir)) {
-            logger.debug("Stage 2: Gradle project detected — running dependencies task")
-            val rawOutput = runGradleDependenciesRawOutput(projectDir)
-            if (rawOutput != null) {
-                val gradleCoords = parseGradleDependencyTaskOutput(rawOutput)
-                if (gradleCoords.isNotEmpty()) {
-                    coords += gradleCoords
-                    gradleProjectData = parseGradleDependencyTaskOutputByProject(rawOutput)
-                } else {
-                    logger.info("Gradle dependencies task returned no coordinates")
+                BuildToolKind.GRADLE -> {
+                    logger.debug(
+                        "Stage 2: Gradle build unit at ${unit.dir} — running dependencies task"
+                    )
+                    val rawOutput = runGradleDependenciesRawOutput(unit.dir)
+                    if (rawOutput != null) {
+                        val gradleCoords = parseGradleDependencyTaskOutput(rawOutput)
+                        if (gradleCoords.isNotEmpty()) {
+                            coords += gradleCoords
+                            val parsedData = parseGradleDependencyTaskOutputByProject(rawOutput)
+                            gradleProjectData.putAll(
+                                rekeyGradleProjectData(projectDir, unit.dir, parsedData)
+                            )
+                        } else {
+                            logger.info("Gradle dependencies task returned no coordinates")
+                        }
+                    }
                 }
             }
         }
 
         if (coords.isEmpty()) {
             logger.info("No dependencies found via subprocess")
-            return ClasspathResolutionResult(emptyList(), gradleProjectData)
+            return ClasspathResolutionResult(
+                emptyList(),
+                gradleProjectData.takeIf {
+                    it.isNotEmpty()
+                }
+            )
         }
 
         // If [resolveClasspath] was invoked through the 2-arg overload, route through the
@@ -145,7 +168,27 @@ open class DependencyResolutionStage(
         } else {
             resolveArtifactsDirectly(coords.distinct())
         }
-        return ClasspathResolutionResult(classpath, gradleProjectData)
+        return ClasspathResolutionResult(classpath, gradleProjectData.takeIf { it.isNotEmpty() })
+    }
+
+    private fun rekeyGradleProjectData(
+        rootDir: Path,
+        unitDir: Path,
+        data: Map<String, GradleProjectData>
+    ): Map<String, GradleProjectData> {
+        val unitPath = gradleProjectPath(rootDir, unitDir)
+        if (unitPath == ":") return data
+        return data.mapKeys { (projectPath, _) ->
+            if (projectPath == ":") unitPath else unitPath + projectPath
+        }
+    }
+
+    private fun gradleProjectPath(rootDir: Path, projectDir: Path): String {
+        if (rootDir == projectDir) return ":"
+        val relative = rootDir.relativize(projectDir).toString().replace('\\', '/')
+        return relative.split('/')
+            .filter { it.isNotBlank() }
+            .joinToString(separator = ":", prefix = ":")
     }
 
     /**

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStage.kt
@@ -10,6 +10,7 @@ import io.github.skhokhlov.rewriterunner.lst.utils.ClasspathResolutionResult
 import io.github.skhokhlov.rewriterunner.lst.utils.GradleConfigData
 import io.github.skhokhlov.rewriterunner.lst.utils.GradleProjectData
 import io.github.skhokhlov.rewriterunner.lst.utils.StaticBuildFileParser
+import io.github.skhokhlov.rewriterunner.lst.utils.discoverBuildUnitResult
 import io.github.skhokhlov.rewriterunner.lst.utils.discoverBuildUnits
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveMavenCommand
@@ -51,9 +52,10 @@ import org.eclipse.aether.resolution.ArtifactResolutionException
  * were resolved. Missing types appear as `JavaType.Unknown` in the LST rather than
  * causing a hard failure.
  *
- * **Failure behaviour:** When no subprocess succeeds, or when Maven Resolver
- * produces an empty result, [resolveClasspath] returns an empty list, causing
- * [LstBuilder] to fall through to [BuildFileParseStage] (Stage 3).
+ * **Failure behaviour:** When no subprocess succeeds, capped discovery leaves some units
+ * uncovered, any discovered unit fails, or Maven Resolver produces an empty result,
+ * [resolveClasspath] returns an empty list, causing [LstBuilder] to fall through to
+ * [BuildFileParseStage] (Stage 3).
  *
  * **Extensibility:** The class is `open` with `open` / `protected open` methods so
  * tests can subclass it to inject a fake classpath without triggering network access.
@@ -125,7 +127,10 @@ open class DependencyResolutionStage(
             val coords = mutableListOf<String>()
             val gradleProjectData = linkedMapOf<String, GradleProjectData>()
 
-            discoverBuildUnits(projectDir, logger = logger).forEach { unit ->
+            val discovery = discoverBuildUnitResult(projectDir, logger = logger)
+            var completedUnits = 0
+
+            discovery.units.forEach { unit ->
                 when (unit.tool) {
                     BuildToolKind.MAVEN -> {
                         logger.debug(
@@ -133,6 +138,7 @@ open class DependencyResolutionStage(
                         )
                         val rawOutput = runMavenDependencyTreeOutput(unit.dir)
                         if (rawOutput != null) {
+                            completedUnits++
                             coords += parseMavenDependencyTreeOutput(rawOutput)
                         }
                     }
@@ -143,6 +149,7 @@ open class DependencyResolutionStage(
                         )
                         val rawOutput = runGradleDependenciesRawOutput(unit.dir)
                         if (rawOutput != null) {
+                            completedUnits++
                             val gradleCoords = parseGradleDependencyTaskOutput(rawOutput)
                             if (gradleCoords.isNotEmpty()) {
                                 coords += gradleCoords
@@ -157,6 +164,22 @@ open class DependencyResolutionStage(
                         }
                     }
                 }
+            }
+
+            if (discovery.truncated || completedUnits != discovery.units.size) {
+                val reason = if (discovery.truncated) {
+                    "discovery was capped at ${discovery.units.size} build unit(s)"
+                } else {
+                    "only $completedUnits/${discovery.units.size} build unit(s) completed"
+                }
+                logger.warn(
+                    "Stage 2 did not cover the full project: $reason; " +
+                        "falling through to Stage 3"
+                )
+                return ClasspathResolutionResult(
+                    emptyList(),
+                    gradleProjectData.takeIf { it.isNotEmpty() }
+                )
             }
 
             if (coords.isEmpty()) {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/LstBuilder.kt
@@ -6,14 +6,14 @@ import io.github.skhokhlov.rewriterunner.ParseFailure
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.UsedExecutionStage
 import io.github.skhokhlov.rewriterunner.config.ToolConfig
+import io.github.skhokhlov.rewriterunner.lst.utils.BuildToolKind
 import io.github.skhokhlov.rewriterunner.lst.utils.ClasspathResolutionResult
 import io.github.skhokhlov.rewriterunner.lst.utils.FileCollector
 import io.github.skhokhlov.rewriterunner.lst.utils.GradleDslClasspathResolver
 import io.github.skhokhlov.rewriterunner.lst.utils.MarkerFactory
 import io.github.skhokhlov.rewriterunner.lst.utils.StaticBuildFileParser
 import io.github.skhokhlov.rewriterunner.lst.utils.VersionDetector
-import io.github.skhokhlov.rewriterunner.lst.utils.hasBuildGradle
-import io.github.skhokhlov.rewriterunner.lst.utils.hasGradleBuildInSubdir
+import io.github.skhokhlov.rewriterunner.lst.utils.discoverBuildUnits
 import java.nio.file.FileVisitOption
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
@@ -763,7 +763,9 @@ open class LstBuilder(
             logger.info("Stage 1 succeeded: ${stage1.size} JAR(s)")
             val gradleData = depResolutionStage.collectGradleProjectData(projectDir)
             if (gradleData == null &&
-                (hasBuildGradle(projectDir) || hasGradleBuildInSubdir(projectDir))
+                discoverBuildUnits(projectDir, logger = logger).any {
+                    it.tool == BuildToolKind.GRADLE
+                }
             ) {
                 logger.warn(
                     "GradleProject markers could not be built — " +

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
@@ -2,7 +2,8 @@ package io.github.skhokhlov.rewriterunner.lst
 
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.config.ToolConfigDefaults
-import io.github.skhokhlov.rewriterunner.lst.utils.hasBuildGradle
+import io.github.skhokhlov.rewriterunner.lst.utils.BuildToolKind
+import io.github.skhokhlov.rewriterunner.lst.utils.discoverBuildUnits
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveMavenCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.runProcess
@@ -21,10 +22,10 @@ import kotlin.io.path.exists
  * catalogs, dependency management, and plugin-contributed dependencies that are
  * difficult to reproduce by static parsing alone.
  *
- * **Build tool detection:**
- * The presence of `pom.xml` signals a Maven project; any of `build.gradle`,
- * `build.gradle.kts`, or `settings.gradle(.kts)` signals a Gradle project.
- * If neither is found, [extractClasspath] returns `null` immediately.
+ * **Build unit discovery:**
+ * Root descriptors keep the historical single-root invocation for that tool. If a tool has no root
+ * descriptor, top-most subdirectory descriptors become build units, so root-less monorepos can still
+ * use build-tool classpaths. Maven and Gradle units are non-exclusive and their results are merged.
  *
  * **Maven:** Runs `mvnw dependency:build-classpath` (using the Maven wrapper if
  * present, otherwise `mvn`). The classpath is written to a temp file via
@@ -39,10 +40,10 @@ import kotlin.io.path.exists
  * prints each JAR path to stdout. The Gradle wrapper (`gradlew`) is used when
  * present; otherwise the system `gradle` command is used.
  *
- * **Failure behaviour:** Any failure — non-zero exit code, process timeout,
- * missing build tool, or an unexpected exception — is logged as a warning and
- * causes [extractClasspath] to return `null`. The pipeline then falls through to
- * [DependencyResolutionStage] (Stage 2).
+ * **Failure behaviour:** Per-unit failures — non-zero exit code, process timeout,
+ * missing build tool, or unexpected exception — are logged as warnings. [extractClasspath] returns
+ * the merged classpath if any unit yields JARs; otherwise it returns `null` and the pipeline falls
+ * through to [DependencyResolutionStage] (Stage 2).
  *
  * **Compilation:** After a successful Stage 1, [tryCompile] is called if the
  * project has no pre-compiled class directories. Compiled `.class` files are then
@@ -60,20 +61,29 @@ open class ProjectBuildStage(
     /**
      * Attempts to extract the project's compile classpath by invoking the build tool.
      *
-     * Detects the build tool from [projectDir]:
-     * - `pom.xml` present → Maven via `mvnw dependency:build-classpath` (or `mvn`)
-     * - `build.gradle` / `build.gradle.kts` / `settings.gradle(.kts)` present → Gradle via
-     *   a temporary init script that registers a `printClasspathForOpenRewrite` task
+     * Discovers Maven and Gradle build units under [projectDir], invokes each unit's build tool,
+     * and returns the distinct union of successful JAR paths.
      *
      * @return The list of JAR paths that make up the project's compile/test classpath, or
-     *   `null` if the build tool could not be invoked, returned a non-zero exit code,
-     *   or produced an empty result. A `null` return signals [LstBuilder] to fall through
-     *   to [DependencyResolutionStage].
+     *   `null` if no unit could be invoked successfully or every successful unit produced an empty
+     *   result. A `null` return signals [LstBuilder] to fall through to [DependencyResolutionStage].
      */
-    open fun extractClasspath(projectDir: Path): List<Path>? = when {
-        projectDir.resolve("pom.xml").exists() -> extractMavenClasspath(projectDir)
-        hasBuildGradle(projectDir) -> extractGradleClasspath(projectDir)
-        else -> null
+    open fun extractClasspath(projectDir: Path): List<Path>? {
+        val classpath = linkedSetOf<Path>()
+        val units = discoverBuildUnits(projectDir, logger = logger)
+        if (units.isEmpty()) return null
+
+        units.forEach { unit ->
+            val unitClasspath = when (unit.tool) {
+                BuildToolKind.MAVEN -> extractMavenClasspath(unit.dir)
+                BuildToolKind.GRADLE -> extractGradleClasspath(unit.dir)
+            }
+            if (!unitClasspath.isNullOrEmpty()) {
+                classpath += unitClasspath
+            }
+        }
+
+        return classpath.takeIf { it.isNotEmpty() }?.toList()
     }
 
     // ─── Maven ───────────────────────────────────────────────────────────────
@@ -177,7 +187,7 @@ open class ProjectBuildStage(
     // ─── Compilation ─────────────────────────────────────────────────────────
 
     /**
-     * Attempts to compile the project using its build tool.
+     * Attempts to compile discovered build units using their build tools.
      *
      * Called by [LstBuilder] after a successful [extractClasspath] when no pre-compiled
      * class directories are found (`target/classes`, `build/classes/java/main`, etc.).
@@ -185,30 +195,36 @@ open class ProjectBuildStage(
      * intra-project type references and wildcard imports within the project itself resolve
      * correctly during OpenRewrite's type-attribution phase.
      *
-     * Runs `mvn compile -q` for Maven or `gradle classes -q` for Gradle.
-     * Uses the project wrapper (`mvnw` / `gradlew`) when present.
+     * Runs `mvn compile` for Maven units or `gradle classes` for Gradle units. Uses each unit's
+     * wrapper (`mvnw` / `gradlew`) when present.
      *
-     * @return `true` if compilation exited with code 0; `false` on any failure (non-zero
-     *   exit, missing build tool, or exception). Never throws — failure is logged as a
-     *   warning and the pipeline continues without compiled class directories.
+     * @return `true` if any unit compiles successfully; `false` when every unit fails or no unit is
+     *   found. Never throws — failure is logged as a warning and the pipeline continues without
+     *   compiled class directories.
      */
-    open fun tryCompile(projectDir: Path): Boolean = when {
-        projectDir.resolve("pom.xml").exists() -> {
-            logger.debug("Project appears to be Maven (pom.xml found) -> attempting compilation")
-            tryMavenCompile(projectDir)
-        }
-
-        hasBuildGradle(projectDir) -> {
-            logger.debug(
-                "Project appears to be Gradle (build.gradle or settings.gradle found) -> attempting compilation"
-            )
-            tryGradleCompile(projectDir)
-        }
-
-        else -> {
+    open fun tryCompile(projectDir: Path): Boolean {
+        val units = discoverBuildUnits(projectDir, logger = logger)
+        if (units.isEmpty()) {
             logger.info("No build tool detected for compilation -> skipping")
-            false
+            return false
         }
+
+        var compiledAny = false
+        units.forEach { unit ->
+            val compiled = when (unit.tool) {
+                BuildToolKind.MAVEN -> {
+                    logger.debug("Maven build unit found at ${unit.dir} -> attempting compilation")
+                    tryMavenCompile(unit.dir)
+                }
+
+                BuildToolKind.GRADLE -> {
+                    logger.debug("Gradle build unit found at ${unit.dir} -> attempting compilation")
+                    tryGradleCompile(unit.dir)
+                }
+            }
+            compiledAny = compiledAny || compiled
+        }
+        return compiledAny
     }
 
     private fun tryMavenCompile(projectDir: Path): Boolean {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
@@ -3,6 +3,7 @@ package io.github.skhokhlov.rewriterunner.lst
 import io.github.skhokhlov.rewriterunner.RunnerLogger
 import io.github.skhokhlov.rewriterunner.config.ToolConfigDefaults
 import io.github.skhokhlov.rewriterunner.lst.utils.BuildToolKind
+import io.github.skhokhlov.rewriterunner.lst.utils.discoverBuildUnitResult
 import io.github.skhokhlov.rewriterunner.lst.utils.discoverBuildUnits
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveGradleCommand
 import io.github.skhokhlov.rewriterunner.lst.utils.resolveMavenCommand
@@ -42,9 +43,10 @@ import kotlin.io.path.exists
  * present; otherwise the system `gradle` command is used.
  *
  * **Failure behaviour:** Per-unit failures — non-zero exit code, process timeout,
- * missing build tool, or unexpected exception — are logged as warnings. [extractClasspath] returns
- * the merged classpath if any unit yields JARs; otherwise it returns `null` and the pipeline falls
- * through to [DependencyResolutionStage] (Stage 2).
+ * missing build tool, unexpected exception, or capped discovery — are logged as warnings.
+ * [extractClasspath] returns the merged classpath only when every discovered unit completes.
+ * Partial coverage returns `null` so the pipeline falls through to [DependencyResolutionStage]
+ * (Stage 2).
  *
  * **Compilation:** After a successful Stage 1, [tryCompile] is called if the
  * project has no pre-compiled class directories. Compiled `.class` files are then
@@ -71,17 +73,33 @@ open class ProjectBuildStage(
      */
     open fun extractClasspath(projectDir: Path): List<Path>? {
         val classpath = linkedSetOf<Path>()
-        val units = discoverBuildUnits(projectDir, logger = logger)
+        val discovery = discoverBuildUnitResult(projectDir, logger = logger)
+        val units = discovery.units
         if (units.isEmpty()) return null
 
+        var completedUnits = 0
         units.forEach { unit ->
             val unitClasspath = when (unit.tool) {
                 BuildToolKind.MAVEN -> extractMavenClasspath(unit.dir, projectDir)
                 BuildToolKind.GRADLE -> extractGradleClasspath(unit.dir, projectDir)
             }
-            if (!unitClasspath.isNullOrEmpty()) {
+            if (unitClasspath != null) {
+                completedUnits++
                 classpath += unitClasspath
             }
+        }
+
+        if (discovery.truncated || completedUnits != units.size) {
+            val reason = if (discovery.truncated) {
+                "discovery was capped at ${units.size} build unit(s)"
+            } else {
+                "only $completedUnits/${units.size} build unit(s) completed"
+            }
+            logger.warn(
+                "Stage 1 did not cover the full project: $reason; " +
+                    "falling through to Stage 2"
+            )
+            return null
         }
 
         return classpath.takeIf { it.isNotEmpty() }?.toList()
@@ -115,7 +133,7 @@ open class ProjectBuildStage(
             }
 
             val content = outputFile.toFile().readText().trim()
-            if (content.isEmpty()) return null
+            if (content.isEmpty()) return emptyList()
 
             return content.split(java.io.File.pathSeparator).map {
                 Path.of(it)

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStage.kt
@@ -26,6 +26,7 @@ import kotlin.io.path.exists
  * Root descriptors keep the historical single-root invocation for that tool. If a tool has no root
  * descriptor, top-most subdirectory descriptors become build units, so root-less monorepos can still
  * use build-tool classpaths. Maven and Gradle units are non-exclusive and their results are merged.
+ * Root-level wrappers are reused when subdirectory units do not have their own wrappers.
  *
  * **Maven:** Runs `mvnw dependency:build-classpath` (using the Maven wrapper if
  * present, otherwise `mvn`). The classpath is written to a temp file via
@@ -75,8 +76,8 @@ open class ProjectBuildStage(
 
         units.forEach { unit ->
             val unitClasspath = when (unit.tool) {
-                BuildToolKind.MAVEN -> extractMavenClasspath(unit.dir)
-                BuildToolKind.GRADLE -> extractGradleClasspath(unit.dir)
+                BuildToolKind.MAVEN -> extractMavenClasspath(unit.dir, projectDir)
+                BuildToolKind.GRADLE -> extractGradleClasspath(unit.dir, projectDir)
             }
             if (!unitClasspath.isNullOrEmpty()) {
                 classpath += unitClasspath
@@ -88,10 +89,10 @@ open class ProjectBuildStage(
 
     // ─── Maven ───────────────────────────────────────────────────────────────
 
-    private fun extractMavenClasspath(projectDir: Path): List<Path>? {
+    private fun extractMavenClasspath(projectDir: Path, rootDir: Path): List<Path>? {
         val outputFile = Files.createTempFile("openrewrite-cp-", ".txt")
         try {
-            val mvnCmd = resolveMavenCommand(projectDir)
+            val mvnCmd = resolveMavenCommand(projectDir, rootDir)
             val mvnCommand = listOf(
                 mvnCmd,
                 "dependency:build-classpath",
@@ -133,12 +134,12 @@ open class ProjectBuildStage(
 
     // ─── Gradle ──────────────────────────────────────────────────────────────
 
-    private fun extractGradleClasspath(projectDir: Path): List<Path>? {
+    private fun extractGradleClasspath(projectDir: Path, rootDir: Path): List<Path>? {
         val initScript = Files.createTempFile("openrewrite-init-", ".gradle")
         try {
             initScript.toFile().writeText(GRADLE_INIT_SCRIPT)
 
-            val gradleCmd = resolveGradleCommand(projectDir)
+            val gradleCmd = resolveGradleCommand(projectDir, rootDir)
             val gradleCommand = listOf(
                 gradleCmd,
                 "-i",
@@ -196,7 +197,7 @@ open class ProjectBuildStage(
      * correctly during OpenRewrite's type-attribution phase.
      *
      * Runs `mvn compile` for Maven units or `gradle classes` for Gradle units. Uses each unit's
-     * wrapper (`mvnw` / `gradlew`) when present.
+     * wrapper (`mvnw` / `gradlew`) when present, otherwise falls back to the project root wrapper.
      *
      * @return `true` if any unit compiles successfully; `false` when every unit fails or no unit is
      *   found. Never throws — failure is logged as a warning and the pipeline continues without
@@ -214,12 +215,12 @@ open class ProjectBuildStage(
             val compiled = when (unit.tool) {
                 BuildToolKind.MAVEN -> {
                     logger.debug("Maven build unit found at ${unit.dir} -> attempting compilation")
-                    tryMavenCompile(unit.dir)
+                    tryMavenCompile(unit.dir, projectDir)
                 }
 
                 BuildToolKind.GRADLE -> {
                     logger.debug("Gradle build unit found at ${unit.dir} -> attempting compilation")
-                    tryGradleCompile(unit.dir)
+                    tryGradleCompile(unit.dir, projectDir)
                 }
             }
             compiledAny = compiledAny || compiled
@@ -227,15 +228,15 @@ open class ProjectBuildStage(
         return compiledAny
     }
 
-    private fun tryMavenCompile(projectDir: Path): Boolean {
-        val mvnCmd = resolveMavenCommand(projectDir)
+    private fun tryMavenCompile(projectDir: Path, rootDir: Path): Boolean {
+        val mvnCmd = resolveMavenCommand(projectDir, rootDir)
         return runCompileTask(projectDir, listOf(mvnCmd, "compile"), "Maven")
     }
 
-    private fun tryGradleCompile(projectDir: Path): Boolean = runCompileTask(
+    private fun tryGradleCompile(projectDir: Path, rootDir: Path): Boolean = runCompileTask(
         projectDir,
         listOf(
-            resolveGradleCommand(projectDir),
+            resolveGradleCommand(projectDir, rootDir),
             "classes",
             "-i",
             "-S",

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
@@ -208,7 +208,7 @@ internal fun discoverBuildUnits(
     return units
 }
 
-// walkFileTree counts the root as depth 1, so 4 visits subdirectories 3 levels below root.
+// walkFileTree visits the root at maxDepth=1, so 4 reaches build directories 3 levels below root.
 private const val BUILD_UNIT_DISCOVERY_DEPTH = 4
 
 /** Returns `true` when any subdirectory of [dir] (up to depth 3) contains a `pom.xml`. */
@@ -250,6 +250,18 @@ internal fun resolveMavenCommand(projectDir: Path): String = when {
 }
 
 /**
+ * Returns the Maven executable for [projectDir], falling back to a wrapper at [rootDir] when a
+ * root-less build unit does not carry its own wrapper.
+ */
+internal fun resolveMavenCommand(projectDir: Path, rootDir: Path): String = when {
+    projectDir.resolve("mvnw").exists() -> "./mvnw"
+    projectDir.resolve("mvnw.cmd").exists() -> "mvnw.cmd"
+    rootDir.resolve("mvnw").exists() -> rootDir.resolve("mvnw").toAbsolutePath().toString()
+    rootDir.resolve("mvnw.cmd").exists() -> rootDir.resolve("mvnw.cmd").toAbsolutePath().toString()
+    else -> "mvn"
+}
+
+/**
  * Returns the Gradle executable to use for [projectDir]:
  * - `./gradlew` if a Unix wrapper is present
  * - `gradlew.bat` if a Windows wrapper is present
@@ -258,5 +270,22 @@ internal fun resolveMavenCommand(projectDir: Path): String = when {
 internal fun resolveGradleCommand(projectDir: Path): String = when {
     projectDir.resolve("gradlew").exists() -> "./gradlew"
     projectDir.resolve("gradlew.bat").exists() -> "gradlew.bat"
+    else -> "gradle"
+}
+
+/**
+ * Returns the Gradle executable for [projectDir], falling back to a wrapper at [rootDir] when a
+ * root-less build unit does not carry its own wrapper.
+ */
+internal fun resolveGradleCommand(projectDir: Path, rootDir: Path): String = when {
+    projectDir.resolve("gradlew").exists() -> "./gradlew"
+
+    projectDir.resolve("gradlew.bat").exists() -> "gradlew.bat"
+
+    rootDir.resolve("gradlew").exists() -> rootDir.resolve("gradlew").toAbsolutePath().toString()
+
+    rootDir.resolve("gradlew.bat").exists() ->
+        rootDir.resolve("gradlew.bat").toAbsolutePath().toString()
+
     else -> "gradle"
 }

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
@@ -170,7 +170,7 @@ internal fun discoverBuildUnits(
         Files.walkFileTree(
             dir,
             emptySet(),
-            BUILD_UNIT_DISCOVERY_DEPTH,
+            BUILD_UNIT_DISCOVERY_WALK_MAX_DEPTH,
             object : SimpleFileVisitor<Path>() {
                 override fun preVisitDirectory(
                     current: Path,
@@ -208,8 +208,10 @@ internal fun discoverBuildUnits(
     return units
 }
 
-// walkFileTree visits the root at maxDepth=1, so 4 reaches build directories 3 levels below root.
-private const val BUILD_UNIT_DISCOVERY_DEPTH = 4
+private const val BUILD_UNIT_DISCOVERY_SUBDIR_DEPTH = 3
+
+// walkFileTree visits the root at maxDepth=1, so add one to reach subdirectories at depth 3.
+private const val BUILD_UNIT_DISCOVERY_WALK_MAX_DEPTH = BUILD_UNIT_DISCOVERY_SUBDIR_DEPTH + 1
 
 /** Returns `true` when any subdirectory of [dir] (up to depth 3) contains a `pom.xml`. */
 internal fun hasMavenPomInSubdir(dir: Path): Boolean = try {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
@@ -5,8 +5,11 @@ import io.github.skhokhlov.rewriterunner.config.DurationParser
 import io.github.skhokhlov.rewriterunner.config.ToolConfigDefaults
 import java.io.IOException
 import java.io.InputStream
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.exists
@@ -19,6 +22,14 @@ internal typealias ProcessRunner = (
     timeoutName: String,
     logger: RunnerLogger
 ) -> Int?
+
+internal enum class BuildToolKind {
+    MAVEN,
+    GRADLE
+}
+
+/** A directory to invoke a build tool in, with the tool to use there. */
+internal data class BuildUnit(val dir: Path, val tool: BuildToolKind)
 
 /**
  * Runs an external process in [workDir] and waits up to [timeout] for it to finish.
@@ -112,6 +123,93 @@ internal fun hasBuildGradle(dir: Path): Boolean =
     dir.resolve("build.gradle").exists() || dir.resolve("build.gradle.kts").exists() ||
         dir.resolve("settings.gradle").exists() ||
         dir.resolve("settings.gradle.kts").exists()
+
+/**
+ * Discovers build-tool invocation roots under [dir].
+ *
+ * Root descriptors keep the historical single-root invocation for that tool. When a tool has no
+ * root descriptor, discovery falls back to top-most subdirectory descriptors up to depth 3,
+ * skipping [FileCollector.DEFAULT_EXCLUDED_DIRS] and pruning below the first build unit found.
+ */
+internal fun discoverBuildUnits(
+    dir: Path,
+    maxUnits: Int = 25,
+    logger: RunnerLogger
+): List<BuildUnit> {
+    if (maxUnits <= 0) return emptyList()
+
+    val units = mutableListOf<BuildUnit>()
+    var capWarned = false
+
+    fun addUnit(unit: BuildUnit): Boolean {
+        if (units.size >= maxUnits) {
+            if (!capWarned) {
+                logger.warn(
+                    "Discovered more than $maxUnits build unit(s) under $dir; " +
+                        "using the first $maxUnits and leaving the rest to later stages"
+                )
+                capWarned = true
+            }
+            return false
+        }
+        units += unit
+        return true
+    }
+
+    val hasRootMaven = dir.resolve("pom.xml").exists()
+    val hasRootGradle = hasBuildGradle(dir)
+
+    if (hasRootMaven && !addUnit(BuildUnit(dir, BuildToolKind.MAVEN))) return units
+    if (hasRootGradle && !addUnit(BuildUnit(dir, BuildToolKind.GRADLE))) return units
+
+    val discoverMavenSubdirs = !hasRootMaven
+    val discoverGradleSubdirs = !hasRootGradle
+    if (!discoverMavenSubdirs && !discoverGradleSubdirs) return units
+
+    try {
+        Files.walkFileTree(
+            dir,
+            emptySet(),
+            BUILD_UNIT_DISCOVERY_DEPTH,
+            object : SimpleFileVisitor<Path>() {
+                override fun preVisitDirectory(
+                    current: Path,
+                    attrs: BasicFileAttributes
+                ): FileVisitResult {
+                    if (current != dir &&
+                        current.fileName?.toString() in FileCollector.DEFAULT_EXCLUDED_DIRS
+                    ) {
+                        return FileVisitResult.SKIP_SUBTREE
+                    }
+
+                    if (current == dir) return FileVisitResult.CONTINUE
+
+                    var foundUnit = false
+                    if (discoverMavenSubdirs && current.resolve("pom.xml").exists()) {
+                        if (!addUnit(BuildUnit(current, BuildToolKind.MAVEN))) {
+                            return FileVisitResult.TERMINATE
+                        }
+                        foundUnit = true
+                    }
+                    if (discoverGradleSubdirs && hasBuildGradle(current)) {
+                        if (!addUnit(BuildUnit(current, BuildToolKind.GRADLE))) {
+                            return FileVisitResult.TERMINATE
+                        }
+                        foundUnit = true
+                    }
+                    return if (foundUnit) FileVisitResult.SKIP_SUBTREE else FileVisitResult.CONTINUE
+                }
+            }
+        )
+    } catch (e: Exception) {
+        logger.warn("Could not discover build units under $dir: ${e.message}")
+    }
+
+    return units
+}
+
+// walkFileTree counts the root as depth 1, so 4 visits subdirectories 3 levels below root.
+private const val BUILD_UNIT_DISCOVERY_DEPTH = 4
 
 /** Returns `true` when any subdirectory of [dir] (up to depth 3) contains a `pom.xml`. */
 internal fun hasMavenPomInSubdir(dir: Path): Boolean = try {

--- a/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
+++ b/core/src/main/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunner.kt
@@ -31,6 +31,9 @@ internal enum class BuildToolKind {
 /** A directory to invoke a build tool in, with the tool to use there. */
 internal data class BuildUnit(val dir: Path, val tool: BuildToolKind)
 
+/** Build units plus whether discovery found more candidates than the caller will process. */
+internal data class BuildUnitDiscoveryResult(val units: List<BuildUnit>, val truncated: Boolean)
+
 /**
  * Runs an external process in [workDir] and waits up to [timeout] for it to finish.
  *
@@ -135,36 +138,28 @@ internal fun discoverBuildUnits(
     dir: Path,
     maxUnits: Int = 25,
     logger: RunnerLogger
-): List<BuildUnit> {
-    if (maxUnits <= 0) return emptyList()
+): List<BuildUnit> = discoverBuildUnitResult(dir, maxUnits, logger).units
 
-    val units = mutableListOf<BuildUnit>()
-    var capWarned = false
+internal fun discoverBuildUnitResult(
+    dir: Path,
+    maxUnits: Int = 25,
+    logger: RunnerLogger
+): BuildUnitDiscoveryResult {
+    if (maxUnits <= 0) return BuildUnitDiscoveryResult(emptyList(), truncated = false)
 
-    fun addUnit(unit: BuildUnit): Boolean {
-        if (units.size >= maxUnits) {
-            if (!capWarned) {
-                logger.warn(
-                    "Discovered more than $maxUnits build unit(s) under $dir; " +
-                        "using the first $maxUnits and leaving the rest to later stages"
-                )
-                capWarned = true
-            }
-            return false
-        }
-        units += unit
-        return true
-    }
+    val candidates = mutableListOf<BuildUnit>()
 
     val hasRootMaven = dir.resolve("pom.xml").exists()
     val hasRootGradle = hasBuildGradle(dir)
 
-    if (hasRootMaven && !addUnit(BuildUnit(dir, BuildToolKind.MAVEN))) return units
-    if (hasRootGradle && !addUnit(BuildUnit(dir, BuildToolKind.GRADLE))) return units
+    if (hasRootMaven) candidates += BuildUnit(dir, BuildToolKind.MAVEN)
+    if (hasRootGradle) candidates += BuildUnit(dir, BuildToolKind.GRADLE)
 
     val discoverMavenSubdirs = !hasRootMaven
     val discoverGradleSubdirs = !hasRootGradle
-    if (!discoverMavenSubdirs && !discoverGradleSubdirs) return units
+    if (!discoverMavenSubdirs && !discoverGradleSubdirs) {
+        return capBuildUnits(candidates, dir, maxUnits, logger)
+    }
 
     try {
         Files.walkFileTree(
@@ -186,15 +181,11 @@ internal fun discoverBuildUnits(
 
                     var foundUnit = false
                     if (discoverMavenSubdirs && current.resolve("pom.xml").exists()) {
-                        if (!addUnit(BuildUnit(current, BuildToolKind.MAVEN))) {
-                            return FileVisitResult.TERMINATE
-                        }
+                        candidates += BuildUnit(current, BuildToolKind.MAVEN)
                         foundUnit = true
                     }
                     if (discoverGradleSubdirs && hasBuildGradle(current)) {
-                        if (!addUnit(BuildUnit(current, BuildToolKind.GRADLE))) {
-                            return FileVisitResult.TERMINATE
-                        }
+                        candidates += BuildUnit(current, BuildToolKind.GRADLE)
                         foundUnit = true
                     }
                     return if (foundUnit) FileVisitResult.SKIP_SUBTREE else FileVisitResult.CONTINUE
@@ -205,13 +196,36 @@ internal fun discoverBuildUnits(
         logger.warn("Could not discover build units under $dir: ${e.message}")
     }
 
-    return units
+    return capBuildUnits(candidates, dir, maxUnits, logger)
 }
 
 private const val BUILD_UNIT_DISCOVERY_SUBDIR_DEPTH = 3
 
 // walkFileTree visits the root at maxDepth=1, so add one to reach subdirectories at depth 3.
 private const val BUILD_UNIT_DISCOVERY_WALK_MAX_DEPTH = BUILD_UNIT_DISCOVERY_SUBDIR_DEPTH + 1
+
+private fun capBuildUnits(
+    candidates: List<BuildUnit>,
+    dir: Path,
+    maxUnits: Int,
+    logger: RunnerLogger
+): BuildUnitDiscoveryResult {
+    val sorted = candidates.sortedWith(
+        compareBy<BuildUnit> { normalizedRelativePath(dir, it.dir) }
+            .thenBy { it.tool.ordinal }
+    )
+    val truncated = sorted.size > maxUnits
+    if (truncated) {
+        logger.warn(
+            "Discovered more than $maxUnits build unit(s) under $dir; " +
+                "using the first $maxUnits by root-relative path and leaving the rest to later stages"
+        )
+    }
+    return BuildUnitDiscoveryResult(sorted.take(maxUnits), truncated)
+}
+
+private fun normalizedRelativePath(root: Path, path: Path): String =
+    root.relativize(path).toString().replace('\\', '/')
 
 /** Returns `true` when any subdirectory of [dir] (up to depth 3) contains a `pom.xml`. */
 internal fun hasMavenPomInSubdir(dir: Path): Boolean = try {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/RewriteRunnerTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
+import java.util.jar.JarOutputStream
 import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
@@ -53,6 +54,50 @@ class RewriteRunnerTest :
                 .dryRun(dryRun)
                 .build()
                 .run()
+        }
+
+        fun writeEmptyJar(path: Path) {
+            Files.createDirectories(path.parent)
+            JarOutputStream(Files.newOutputStream(path)).use { }
+        }
+
+        fun writeModulePom(moduleDir: Path, artifactId: String) {
+            moduleDir.resolve("pom.xml").writeText(
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>$artifactId</artifactId>
+                  <version>1.0.0</version>
+                </project>
+                """.trimIndent()
+            )
+        }
+
+        fun writeClasspathMvnw(moduleDir: Path, jar: Path, callLog: Path) {
+            val mvnw = moduleDir.resolve("mvnw").toFile()
+            mvnw.writeText(
+                """
+                #!/bin/sh
+                if [ "${'$'}1" = "compile" ]; then
+                  echo "compile:${'$'}(pwd)" >> "${callLog.toAbsolutePath()}"
+                  mkdir -p target/classes
+                  exit 0
+                fi
+                if [ "${'$'}1" = "dependency:build-classpath" ]; then
+                  echo "classpath:${'$'}(pwd)" >> "${callLog.toAbsolutePath()}"
+                  for arg in "${'$'}@"; do
+                    case "${'$'}arg" in
+                      -Dmdep.outputFile=*) output="${'$'}{arg#-Dmdep.outputFile=}" ;;
+                    esac
+                  done
+                  printf "%s" "${jar.toAbsolutePath()}" > "${'$'}output"
+                  exit 0
+                fi
+                exit 1
+                """.trimIndent()
+            )
+            mvnw.setExecutable(true)
         }
 
         // ─── File deletion ────────────────────────────────────────────────────────
@@ -173,6 +218,45 @@ class RewriteRunnerTest :
                 completedMarker.exists(),
                 "Configured process timeout should stop the wrapper before it completes"
             )
+        }
+
+        test("root-less Maven modules use build-unit Stage 1 classpath").config(
+            enabled = !isWindows
+        ) {
+            val callLog = projectDir.resolve("build-unit-calls.log")
+            val fakeJar = cacheDir.resolve("deps/fake-dep.jar")
+            writeEmptyJar(fakeJar)
+
+            val api = projectDir.resolve("services/api")
+            Files.createDirectories(api.resolve("src/main/java/com/example"))
+            writeModulePom(api, "api")
+            api.resolve("src/main/java/com/example/Api.java").writeText(
+                "package com.example; class Api {}\n"
+            )
+            writeClasspathMvnw(api, fakeJar, callLog)
+
+            val worker = projectDir.resolve("services/worker")
+            Files.createDirectories(worker.resolve("src/main/java/com/example"))
+            writeModulePom(worker, "worker")
+            worker.resolve("src/main/java/com/example/Worker.java").writeText(
+                "package com.example; class Worker {}\n"
+            )
+            writeClasspathMvnw(worker, fakeJar, callLog)
+
+            val result =
+                RewriteRunner.builder()
+                    .projectDir(projectDir)
+                    .activeRecipe("org.openrewrite.FindSourceFiles")
+                    .cacheDir(cacheDir)
+                    .skipPluginRun(true)
+                    .build()
+                    .run()
+
+            assertEquals(UsedExecutionStage.BUILD_TOOL, result.executionDiagnostics.stageUsed)
+            assertTrue(result.executionDiagnostics.resolvedJarCount > 0)
+            val calls = callLog.readText()
+            assertTrue("classpath:${api.toRealPath()}" in calls, calls)
+            assertTrue("classpath:${worker.toRealPath()}" in calls, calls)
         }
 
         // ─── plugin version config ──────────────────────────────────────────────

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/BuildFileParseStageTest.kt
@@ -240,7 +240,7 @@ class BuildFileParseStageTest :
 
         test("Maven fallback discovery keeps real pom.xml files at depth three") {
             resetTracking()
-            val apiDir = projectDir.resolve("services/api").also { it.createDirectories() }
+            val apiDir = projectDir.resolve("one/two/three").also { it.createDirectories() }
             apiDir.resolve("pom.xml").writeText(
                 """
                 <project>
@@ -453,6 +453,23 @@ class BuildFileParseStageTest :
 
             assertTrue(traversalCalled)
             assertTrue(capturedCoords.any { it.contains("commons-lang3") })
+        }
+
+        test("Gradle fallback discovery keeps real build files at depth three") {
+            resetTracking()
+            val appDir = projectDir.resolve("one/two/three").also { it.createDirectories() }
+            appDir.resolve("build.gradle.kts").writeText(
+                """
+                dependencies {
+                    implementation("org.slf4j:slf4j-api:2.0.0")
+                }
+                """.trimIndent()
+            )
+
+            fakeStage().resolveClasspath(projectDir)
+
+            assertTrue(traversalCalled)
+            assertTrue(capturedCoords.any { it == "org.slf4j:slf4j-api:2.0.0" })
         }
 
         test("Gradle fallback discovery ignores build files in build output dirs") {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageResolveClasspathTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageResolveClasspathTest.kt
@@ -34,6 +34,9 @@ class DependencyResolutionStageResolveClasspathTest :
             cacheDir.toFile().deleteRecursively()
         }
 
+        fun mkdir(relative: String): Path =
+            projectDir.resolve(relative).also { Files.createDirectories(it) }
+
         // ─── resolveClasspath routing ─────────────────────────────────────────────
 
         test("resolveClasspath returns empty list when no build file is present") {
@@ -365,6 +368,104 @@ class DependencyResolutionStageResolveClasspathTest :
             stage.resolveClasspath(projectDir)
             assertTrue(mavenCalled, "Maven subprocess should be attempted for mixed project")
             assertTrue(gradleCalled, "Gradle subprocess should be attempted for mixed project")
+        }
+
+        test("resolveClasspath aggregates Maven coordinates from root-less build units") {
+            val api = mkdir("services/api")
+            api.resolve("pom.xml").writeText("<project/>")
+            val worker = mkdir("services/worker")
+            worker.resolve("pom.xml").writeText("<project/>")
+
+            val calledDirs = mutableListOf<Path>()
+            var resolvedCoordinates = emptyList<String>()
+            val stage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(cacheDir.resolve("repository"), logger = NoOpRunnerLogger),
+                    NoOpRunnerLogger
+                ) {
+                    override fun runMavenDependencyTreeOutput(projectDir: Path): String {
+                        calledDirs.add(projectDir)
+                        val artifact = projectDir.fileName.toString()
+                        return "[INFO] +- org.example:$artifact:jar:1.0.0:compile\n"
+                    }
+
+                    override fun resolveArtifactsDirectly(coordinates: List<String>): List<Path> {
+                        resolvedCoordinates = coordinates
+                        return emptyList()
+                    }
+                }
+
+            stage.resolveClasspath(projectDir)
+
+            assertEquals(setOf(api, worker), calledDirs.toSet())
+            assertEquals(
+                setOf("org.example:api:1.0.0", "org.example:worker:1.0.0"),
+                resolvedCoordinates.toSet()
+            )
+        }
+
+        test("resolveClasspath merges Gradle project data from root-less build units") {
+            val api = mkdir("services/api")
+            api.resolve("build.gradle.kts").writeText("")
+            val worker = mkdir("services/worker")
+            worker.resolve("build.gradle.kts").writeText("")
+
+            val calledDirs = mutableListOf<Path>()
+            val stage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(cacheDir.resolve("repository"), logger = NoOpRunnerLogger),
+                    NoOpRunnerLogger
+                ) {
+                    override fun runGradleDependenciesRawOutput(projectDir: Path): String {
+                        calledDirs.add(projectDir)
+                        val artifact = projectDir.fileName.toString()
+                        return """
+                            > Task :dependencies
+                            compileClasspath - Compile classpath for source set 'main'.
+                            +--- org.example:$artifact:1.0.0
+                        """.trimIndent()
+                    }
+
+                    override fun resolveArtifactsDirectly(coordinates: List<String>): List<Path> =
+                        emptyList()
+                }
+
+            val result = stage.resolveClasspath(projectDir)
+
+            assertEquals(setOf(api, worker), calledDirs.toSet())
+            assertEquals(
+                setOf(":services:api", ":services:worker"),
+                result.gradleProjectData?.keys
+            )
+        }
+
+        test("collectGradleProjectData runs dependencies in each root-less Gradle unit") {
+            val api = mkdir("services/api")
+            api.resolve("build.gradle.kts").writeText("")
+            val worker = mkdir("services/worker")
+            worker.resolve("build.gradle.kts").writeText("")
+
+            val calledDirs = mutableListOf<Path>()
+            val stage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(cacheDir.resolve("repository"), logger = NoOpRunnerLogger),
+                    NoOpRunnerLogger
+                ) {
+                    override fun runGradleDependenciesRawOutput(projectDir: Path): String {
+                        calledDirs.add(projectDir)
+                        val artifact = projectDir.fileName.toString()
+                        return """
+                            > Task :dependencies
+                            compileClasspath - Compile classpath for source set 'main'.
+                            +--- org.example:$artifact:1.0.0
+                        """.trimIndent()
+                    }
+                }
+
+            val result = stage.collectGradleProjectData(projectDir)
+
+            assertEquals(setOf(api, worker), calledDirs.toSet())
+            assertEquals(setOf(":services:api", ":services:worker"), result?.keys)
         }
 
         // ─── Extra repositories (buildRemoteRepos coverage) ───────────────────────

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageResolveClasspathTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageResolveClasspathTest.kt
@@ -468,6 +468,66 @@ class DependencyResolutionStageResolveClasspathTest :
             assertEquals(setOf(":services:api", ":services:worker"), result?.keys)
         }
 
+        test("resolveClasspath reuses root wrappers for root-less build units").config(
+            enabled = !System.getProperty("os.name", "").lowercase().contains("windows")
+        ) {
+            val mavenModule = mkdir("services/api")
+            mavenModule.resolve("pom.xml").writeText("<project/>")
+            val gradleModule = mkdir("services/worker")
+            gradleModule.resolve("build.gradle.kts").writeText("")
+            val callLog = projectDir.resolve("wrapper-calls.log")
+
+            val mvnw = projectDir.resolve("mvnw").toFile()
+            mvnw.writeText(
+                """
+                #!/bin/sh
+                echo "maven:${'$'}(pwd)" >> "${callLog.toAbsolutePath()}"
+                artifact="${'$'}(basename "${'$'}(pwd)")"
+                echo "[INFO] +- org.example:${'$'}artifact:jar:1.0.0:compile"
+                exit 0
+                """.trimIndent()
+            )
+            mvnw.setExecutable(true)
+
+            val gradlew = projectDir.resolve("gradlew").toFile()
+            gradlew.writeText(
+                """
+                #!/bin/sh
+                echo "gradle:${'$'}(pwd)" >> "${callLog.toAbsolutePath()}"
+                artifact="${'$'}(basename "${'$'}(pwd)")"
+                cat <<EOF
+                > Task :dependencies
+                compileClasspath - Compile classpath for source set 'main'.
+                +--- org.example:${'$'}artifact:1.0.0
+                EOF
+                exit 0
+                """.trimIndent()
+            )
+            gradlew.setExecutable(true)
+
+            var resolvedCoordinates = emptyList<String>()
+            val stage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(cacheDir.resolve("repository"), logger = NoOpRunnerLogger),
+                    NoOpRunnerLogger
+                ) {
+                    override fun resolveArtifactsDirectly(coordinates: List<String>): List<Path> {
+                        resolvedCoordinates = coordinates
+                        return emptyList()
+                    }
+                }
+
+            stage.resolveClasspath(projectDir)
+
+            val calls = callLog.toFile().readText()
+            assertTrue("maven:${mavenModule.toRealPath()}" in calls, calls)
+            assertTrue("gradle:${gradleModule.toRealPath()}" in calls, calls)
+            assertEquals(
+                setOf("org.example:api:1.0.0", "org.example:worker:1.0.0"),
+                resolvedCoordinates.toSet()
+            )
+        }
+
         // ─── Extra repositories (buildRemoteRepos coverage) ───────────────────────
 
         test("stage accepts extra repositories with credentials") {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageResolveClasspathTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/DependencyResolutionStageResolveClasspathTest.kt
@@ -404,6 +404,37 @@ class DependencyResolutionStageResolveClasspathTest :
             )
         }
 
+        test("resolveClasspath falls through when any root-less unit fails") {
+            val api = mkdir("services/api")
+            api.resolve("pom.xml").writeText("<project/>")
+            val worker = mkdir("services/worker")
+            worker.resolve("pom.xml").writeText("<project/>")
+
+            var resolveCalled = false
+            val stage =
+                object : DependencyResolutionStage(
+                    AetherContext.build(cacheDir.resolve("repository"), logger = NoOpRunnerLogger),
+                    NoOpRunnerLogger
+                ) {
+                    override fun runMavenDependencyTreeOutput(projectDir: Path): String? =
+                        if (projectDir == api) {
+                            "[INFO] +- org.example:api:jar:1.0.0:compile\n"
+                        } else {
+                            null
+                        }
+
+                    override fun resolveArtifactsDirectly(coordinates: List<String>): List<Path> {
+                        resolveCalled = true
+                        return listOf(cacheDir.resolve("api.jar"))
+                    }
+                }
+
+            val result = stage.resolveClasspath(projectDir)
+
+            assertTrue(result.classpath.isEmpty())
+            assertFalse(resolveCalled, "Partial build-unit coverage should fall through to Stage 3")
+        }
+
         test("resolveClasspath merges Gradle project data from root-less build units") {
             val api = mkdir("services/api")
             api.resolve("build.gradle.kts").writeText("")

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageBranchTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageBranchTest.kt
@@ -5,7 +5,6 @@ import io.kotest.core.spec.style.FunSpec
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.writeText
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -66,19 +65,18 @@ class ProjectBuildStageBranchTest :
 
         // ─── Gradle classpath extraction — covers the captureStdout and success paths
 
-        test(
-            "extractClasspath returns empty list when gradlew exits 0 with no output"
-        ).config(enabled = !isWindows) {
+        test("extractClasspath returns null when gradlew exits 0 with no output").config(
+            enabled = !isWindows
+        ) {
             projectDir.resolve("build.gradle").writeText("// empty")
             val gradlew = projectDir.resolve("gradlew").toFile()
             // Exit 0 with no stdout → captureStdout path is exercised, success branch is taken,
-            // returned list is empty (all paths filtered out because none exist on disk).
+            // but the merged Stage 1 classpath is empty, so the stage falls through.
             gradlew.writeText("#!/bin/sh\nexit 0\n")
             gradlew.setExecutable(true)
 
             val result = stage.extractClasspath(projectDir)
-            assertNotNull(result, "Exit 0 with no output → empty list (not null)")
-            assertTrue(result.isEmpty(), "No paths printed → empty classpath list")
+            assertNull(result, "Exit 0 with no output -> null")
         }
 
         test("extractClasspath with gradlew handles non-zero exit gracefully").config(

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
@@ -289,7 +289,7 @@ class ProjectBuildStageTest :
             assertEquals(setOf(mavenJar, gradleJar), result?.toSet())
         }
 
-        test("extractClasspath keeps classpath from succeeding root-less units") {
+        test("extractClasspath falls through when any root-less unit fails") {
             val failingModule = mkdir("services/failing")
             failingModule.resolve("pom.xml").writeText("<project/>")
             val workingModule = mkdir("services/working")
@@ -301,7 +301,7 @@ class ProjectBuildStageTest :
 
             val result = stage.extractClasspath(projectDir)
 
-            assertEquals(listOf(jar), result)
+            assertNull(result, "Partial build-unit coverage should fall through to Stage 2")
         }
 
         test("tryCompile compiles each root-less build unit and succeeds on partial success") {

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 import kotlin.io.path.writeText
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -18,6 +19,70 @@ class ProjectBuildStageTest :
         beforeEach { projectDir = Files.createTempDirectory("bts-") }
 
         afterEach { projectDir.toFile().deleteRecursively() }
+
+        fun mkdir(relative: String): Path = projectDir.resolve(relative).also {
+            Files.createDirectories(it)
+        }
+
+        fun fakeJar(relative: String): Path = projectDir.resolve(relative).also {
+            Files.createDirectories(it.parent)
+            Files.createFile(it)
+        }
+
+        fun writeMavenWrapper(
+            moduleDir: Path,
+            classpath: List<Path> = emptyList(),
+            exitCode: Int = 0
+        ) {
+            val cp = classpath.joinToString(java.io.File.pathSeparator) {
+                it.toAbsolutePath().toString()
+            }
+            val mvnw = moduleDir.resolve("mvnw").toFile()
+            mvnw.writeText(
+                """
+                #!/bin/sh
+                if [ "${'$'}1" = "compile" ]; then
+                  if [ $exitCode -eq 0 ]; then
+                    touch compiled.marker
+                  fi
+                  exit $exitCode
+                fi
+                for arg in "${'$'}@"; do
+                  case "${'$'}arg" in
+                    -Dmdep.outputFile=*) output="${'$'}{arg#-Dmdep.outputFile=}" ;;
+                  esac
+                done
+                if [ -n "${'$'}output" ]; then
+                  printf "%s" "$cp" > "${'$'}output"
+                fi
+                exit $exitCode
+                """.trimIndent()
+            )
+            mvnw.setExecutable(true)
+        }
+
+        fun writeGradleWrapper(
+            moduleDir: Path,
+            classpath: List<Path> = emptyList(),
+            exitCode: Int = 0
+        ) {
+            val output = classpath.joinToString("\n") { it.toAbsolutePath().toString() }
+            val gradlew = moduleDir.resolve("gradlew").toFile()
+            gradlew.writeText(
+                """
+                #!/bin/sh
+                if [ "${'$'}1" = "classes" ]; then
+                  if [ $exitCode -eq 0 ]; then
+                    touch compiled.marker
+                  fi
+                  exit $exitCode
+                fi
+                printf "%s\n" "$output"
+                exit $exitCode
+                """.trimIndent()
+            )
+            gradlew.setExecutable(true)
+        }
 
         test("returns null when no build file exists") {
             // Empty directory with no pom.xml or build.gradle
@@ -206,6 +271,57 @@ class ProjectBuildStageTest :
             } finally {
                 fakeJar.toFile().delete()
             }
+        }
+
+        test("extractClasspath merges Maven and Gradle classpaths from root-less build units") {
+            val mavenModule = mkdir("services/api")
+            mavenModule.resolve("pom.xml").writeText("<project/>")
+            val gradleModule = mkdir("services/worker")
+            gradleModule.resolve("build.gradle.kts").writeText("")
+
+            val mavenJar = fakeJar("deps/maven.jar")
+            val gradleJar = fakeJar("deps/gradle.jar")
+            writeMavenWrapper(mavenModule, listOf(mavenJar))
+            writeGradleWrapper(gradleModule, listOf(gradleJar))
+
+            val result = stage.extractClasspath(projectDir)
+
+            assertEquals(setOf(mavenJar, gradleJar), result?.toSet())
+        }
+
+        test("extractClasspath keeps classpath from succeeding root-less units") {
+            val failingModule = mkdir("services/failing")
+            failingModule.resolve("pom.xml").writeText("<project/>")
+            val workingModule = mkdir("services/working")
+            workingModule.resolve("pom.xml").writeText("<project/>")
+
+            val jar = fakeJar("deps/working.jar")
+            writeMavenWrapper(failingModule, exitCode = 1)
+            writeMavenWrapper(workingModule, listOf(jar))
+
+            val result = stage.extractClasspath(projectDir)
+
+            assertEquals(listOf(jar), result)
+        }
+
+        test("tryCompile compiles each root-less build unit and succeeds on partial success") {
+            val mavenModule = mkdir("services/api")
+            mavenModule.resolve("pom.xml").writeText("<project/>")
+            val gradleModule = mkdir("services/worker")
+            gradleModule.resolve("build.gradle.kts").writeText("")
+            val failingModule = mkdir("services/failing")
+            failingModule.resolve("pom.xml").writeText("<project/>")
+
+            writeMavenWrapper(mavenModule)
+            writeGradleWrapper(gradleModule)
+            writeMavenWrapper(failingModule, exitCode = 1)
+
+            val result = stage.tryCompile(projectDir)
+
+            assertTrue(result, "At least one successful unit should make compilation succeed")
+            assertTrue(Files.exists(mavenModule.resolve("compiled.marker")))
+            assertTrue(Files.exists(gradleModule.resolve("compiled.marker")))
+            assertFalse(Files.exists(failingModule.resolve("compiled.marker")))
         }
 
         // ─── Deadlock-prevention tests ────────────────────────────────────────────

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/ProjectBuildStageTest.kt
@@ -324,6 +324,37 @@ class ProjectBuildStageTest :
             assertFalse(Files.exists(failingModule.resolve("compiled.marker")))
         }
 
+        test("extractClasspath reuses root wrappers for root-less build units") {
+            val mavenModule = mkdir("services/api")
+            mavenModule.resolve("pom.xml").writeText("<project/>")
+            val gradleModule = mkdir("services/worker")
+            gradleModule.resolve("build.gradle.kts").writeText("")
+
+            val mavenJar = fakeJar("deps/root-maven.jar")
+            val gradleJar = fakeJar("deps/root-gradle.jar")
+            writeMavenWrapper(projectDir, listOf(mavenJar))
+            writeGradleWrapper(projectDir, listOf(gradleJar))
+
+            val result = stage.extractClasspath(projectDir)
+
+            assertEquals(setOf(mavenJar, gradleJar), result?.toSet())
+        }
+
+        test("tryCompile reuses root wrappers for root-less build units") {
+            val mavenModule = mkdir("services/api")
+            mavenModule.resolve("pom.xml").writeText("<project/>")
+            val gradleModule = mkdir("services/worker")
+            gradleModule.resolve("build.gradle.kts").writeText("")
+            writeMavenWrapper(projectDir)
+            writeGradleWrapper(projectDir)
+
+            val result = stage.tryCompile(projectDir)
+
+            assertTrue(result)
+            assertTrue(Files.exists(mavenModule.resolve("compiled.marker")))
+            assertTrue(Files.exists(gradleModule.resolve("compiled.marker")))
+        }
+
         // ─── Deadlock-prevention tests ────────────────────────────────────────────
 
         test(

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunnerTest.kt
@@ -1,0 +1,152 @@
+package io.github.skhokhlov.rewriterunner.lst.utils
+
+import io.github.skhokhlov.rewriterunner.NoOpRunnerLogger
+import io.github.skhokhlov.rewriterunner.RunnerLogger
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProcessRunnerTest :
+    FunSpec({
+        var projectDir: Path = Path.of("")
+
+        beforeEach { projectDir = Files.createTempDirectory("prt-") }
+
+        afterEach { projectDir.toFile().deleteRecursively() }
+
+        fun unitPaths(units: List<BuildUnit>): Set<Pair<BuildToolKind, String>> =
+            units.map { unit ->
+                unit.tool to projectDir.relativize(unit.dir).toString().replace('\\', '/')
+            }.toSet()
+
+        fun mkdir(relative: String): Path =
+            projectDir.resolve(relative).also { Files.createDirectories(it) }
+
+        test("discoverBuildUnits returns root Maven unit when root pom exists") {
+            projectDir.resolve("pom.xml").writeText("<project/>")
+            mkdir("service").resolve("pom.xml").writeText("<project/>")
+
+            val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
+
+            assertEquals(setOf(BuildToolKind.MAVEN to ""), unitPaths(units))
+        }
+
+        test("discoverBuildUnits returns root Gradle unit when root settings exists") {
+            projectDir.resolve("settings.gradle.kts").writeText("include(\":app\")")
+            mkdir("app").resolve("build.gradle.kts").writeText("")
+
+            val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
+
+            assertEquals(setOf(BuildToolKind.GRADLE to ""), unitPaths(units))
+        }
+
+        test("discoverBuildUnits finds top-most Maven subdir units when root has no pom") {
+            mkdir("services/api").resolve("pom.xml").writeText("<project/>")
+            mkdir("services/worker").resolve("pom.xml").writeText("<project/>")
+
+            val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
+
+            assertEquals(
+                setOf(
+                    BuildToolKind.MAVEN to "services/api",
+                    BuildToolKind.MAVEN to "services/worker"
+                ),
+                unitPaths(units)
+            )
+        }
+
+        test("discoverBuildUnits finds mixed Maven and Gradle subdir units") {
+            mkdir("java-api").resolve("pom.xml").writeText("<project/>")
+            mkdir("kotlin-api").resolve("build.gradle.kts").writeText("")
+
+            val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
+
+            assertEquals(
+                setOf(
+                    BuildToolKind.MAVEN to "java-api",
+                    BuildToolKind.GRADLE to "kotlin-api"
+                ),
+                unitPaths(units)
+            )
+        }
+
+        test("discoverBuildUnits prunes nested build files below a top-most unit") {
+            mkdir("platform").resolve("pom.xml").writeText("<project/>")
+            mkdir("platform/module").resolve("pom.xml").writeText("<project/>")
+
+            val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
+
+            assertEquals(setOf(BuildToolKind.MAVEN to "platform"), unitPaths(units))
+        }
+
+        test("discoverBuildUnits skips excluded directories") {
+            mkdir("target/generated").resolve("pom.xml").writeText("<project/>")
+            mkdir("node_modules/example").resolve("build.gradle").writeText("")
+            mkdir("src/service").resolve("pom.xml").writeText("<project/>")
+
+            val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
+
+            assertEquals(setOf(BuildToolKind.MAVEN to "src/service"), unitPaths(units))
+        }
+
+        test("discoverBuildUnits respects depth three boundary") {
+            mkdir("one/two/three").resolve("pom.xml").writeText("<project/>")
+            mkdir("one/two/three/four").resolve("build.gradle.kts").writeText("")
+
+            val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
+
+            assertEquals(setOf(BuildToolKind.MAVEN to "one/two/three"), unitPaths(units))
+        }
+
+        test("discoverBuildUnits caps units and warns when more units are present") {
+            repeat(27) { index ->
+                mkdir("service-$index").resolve("pom.xml").writeText("<project/>")
+            }
+            val logger = CapturingLogger()
+
+            val units = discoverBuildUnits(projectDir, maxUnits = 25, logger = logger)
+
+            assertEquals(25, units.size)
+            assertTrue(
+                logger.warns.any { "25" in it && "build unit" in it },
+                "Expected cap warning, got ${logger.warns}"
+            )
+        }
+
+        test("discoverBuildUnits returns empty list for empty directory") {
+            val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
+
+            assertTrue(units.isEmpty())
+        }
+
+        test("resolveMavenCommand prefers Unix wrapper then Windows wrapper then mvn") {
+            assertEquals("mvn", resolveMavenCommand(projectDir))
+
+            projectDir.resolve("mvnw.cmd").writeText("")
+            assertEquals("mvnw.cmd", resolveMavenCommand(projectDir))
+
+            projectDir.resolve("mvnw").writeText("")
+            assertEquals("./mvnw", resolveMavenCommand(projectDir))
+        }
+
+        test("resolveGradleCommand prefers Unix wrapper then Windows wrapper then gradle") {
+            assertEquals("gradle", resolveGradleCommand(projectDir))
+
+            projectDir.resolve("gradlew.bat").writeText("")
+            assertEquals("gradlew.bat", resolveGradleCommand(projectDir))
+
+            projectDir.resolve("gradlew").writeText("")
+            assertEquals("./gradlew", resolveGradleCommand(projectDir))
+        }
+    })
+
+private class CapturingLogger : RunnerLogger by NoOpRunnerLogger {
+    val warns = mutableListOf<String>()
+
+    override fun warn(message: String) {
+        warns += message
+    }
+}

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunnerTest.kt
@@ -92,13 +92,20 @@ class ProcessRunnerTest :
             assertEquals(setOf(BuildToolKind.MAVEN to "src/service"), unitPaths(units))
         }
 
-        test("discoverBuildUnits respects depth three boundary") {
+        test("discoverBuildUnits includes descriptors at depth three") {
             mkdir("one/two/three").resolve("pom.xml").writeText("<project/>")
-            mkdir("one/two/three/four").resolve("build.gradle.kts").writeText("")
 
             val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
 
             assertEquals(setOf(BuildToolKind.MAVEN to "one/two/three"), unitPaths(units))
+        }
+
+        test("discoverBuildUnits excludes descriptors deeper than depth three") {
+            mkdir("one/two/three/four").resolve("pom.xml").writeText("<project/>")
+
+            val units = discoverBuildUnits(projectDir, logger = NoOpRunnerLogger)
+
+            assertTrue(units.isEmpty(), "Depth-four descriptors should not be discovered")
         }
 
         test("discoverBuildUnits caps units and warns when more units are present") {
@@ -132,6 +139,16 @@ class ProcessRunnerTest :
             assertEquals("./mvnw", resolveMavenCommand(projectDir))
         }
 
+        test("resolveMavenCommand can reuse root wrapper for subdirectory unit") {
+            val moduleDir = mkdir("services/api")
+            projectDir.resolve("mvnw").writeText("")
+
+            assertEquals(
+                projectDir.resolve("mvnw").toAbsolutePath().toString(),
+                resolveMavenCommand(moduleDir, projectDir)
+            )
+        }
+
         test("resolveGradleCommand prefers Unix wrapper then Windows wrapper then gradle") {
             assertEquals("gradle", resolveGradleCommand(projectDir))
 
@@ -140,6 +157,16 @@ class ProcessRunnerTest :
 
             projectDir.resolve("gradlew").writeText("")
             assertEquals("./gradlew", resolveGradleCommand(projectDir))
+        }
+
+        test("resolveGradleCommand can reuse root wrapper for subdirectory unit") {
+            val moduleDir = mkdir("services/api")
+            projectDir.resolve("gradlew").writeText("")
+
+            assertEquals(
+                projectDir.resolve("gradlew").toAbsolutePath().toString(),
+                resolveGradleCommand(moduleDir, projectDir)
+            )
         }
     })
 

--- a/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunnerTest.kt
+++ b/core/src/test/kotlin/io/github/skhokhlov/rewriterunner/lst/utils/ProcessRunnerTest.kt
@@ -22,6 +22,11 @@ class ProcessRunnerTest :
                 unit.tool to projectDir.relativize(unit.dir).toString().replace('\\', '/')
             }.toSet()
 
+        fun orderedUnitPaths(units: List<BuildUnit>): List<Pair<BuildToolKind, String>> =
+            units.map { unit ->
+                unit.tool to projectDir.relativize(unit.dir).toString().replace('\\', '/')
+            }
+
         fun mkdir(relative: String): Path =
             projectDir.resolve(relative).also { Files.createDirectories(it) }
 
@@ -121,6 +126,36 @@ class ProcessRunnerTest :
                 logger.warns.any { "25" in it && "build unit" in it },
                 "Expected cap warning, got ${logger.warns}"
             )
+        }
+
+        test("discoverBuildUnits sorts candidates before applying cap") {
+            mkdir("z-service").resolve("pom.xml").writeText("<project/>")
+            mkdir("a-service").resolve("pom.xml").writeText("<project/>")
+            mkdir("m-service").resolve("pom.xml").writeText("<project/>")
+
+            val units = discoverBuildUnits(projectDir, maxUnits = 2, logger = NoOpRunnerLogger)
+
+            assertEquals(
+                listOf(
+                    BuildToolKind.MAVEN to "a-service",
+                    BuildToolKind.MAVEN to "m-service"
+                ),
+                orderedUnitPaths(units)
+            )
+        }
+
+        test("discoverBuildUnitResult reports truncated discovery") {
+            mkdir("a-service").resolve("pom.xml").writeText("<project/>")
+            mkdir("b-service").resolve("pom.xml").writeText("<project/>")
+
+            val result = discoverBuildUnitResult(
+                projectDir,
+                maxUnits = 1,
+                logger = NoOpRunnerLogger
+            )
+
+            assertEquals(1, result.units.size)
+            assertTrue(result.truncated)
         }
 
         test("discoverBuildUnits returns empty list for empty directory") {

--- a/docs/adr/0001-build-unit-classpath-resolution.md
+++ b/docs/adr/0001-build-unit-classpath-resolution.md
@@ -1,0 +1,45 @@
+# ADR 0001: Build-Unit Classpath Resolution
+
+## Status
+
+Accepted
+
+## Context
+
+Stages 1 and 2 of the LST classpath pipeline historically invoked Maven or Gradle only from the
+project root. That works for ordinary single-build roots and aggregator builds, but it is weak for
+root-less monorepos where build descriptors live only in subdirectories. In those repositories the
+root subprocess cannot see module-local `pom.xml` or `build.gradle(.kts)` files, so the pipeline
+falls through to static parsing in Stage 3 and loses build-tool fidelity such as BOM-managed versions,
+dependency management, resolved Gradle versions, and transitive scope decisions.
+
+## Decision
+
+Stages 1 and 2 resolve classpaths by iterating discovered build units.
+
+A build unit is a directory where rewrite-runner invokes a build tool, paired with that tool:
+
+- Maven root `pom.xml` exists: use the project root as the Maven unit.
+- No root Maven descriptor: discover top-most subdirectory `pom.xml` files as Maven units.
+- Gradle root `settings.gradle(.kts)` or `build.gradle(.kts)` exists: use the project root as the
+  Gradle unit.
+- No root Gradle descriptor: discover top-most subdirectory Gradle descriptors as Gradle units.
+
+Discovery prunes below the first descriptor directory, skips the same default excluded directory names
+as file collection, scans to a maximum subdirectory depth of 3, and caps processing at 25 units. When
+more than 25 units are discovered, rewrite-runner warns and leaves the remaining coverage to later
+fallback stages.
+
+Stage 1 unions distinct JAR paths from successful unit classpath extractions. Stage 2 accumulates
+coordinates from successful Maven and Gradle dependency subprocesses, then resolves the distinct
+coordinate set. Gradle project data from subdirectory units is re-keyed to root-relative Gradle paths
+such as `:services:api` so build-file markers can still be attached.
+
+## Consequences
+
+Root-less Maven and Gradle monorepos can now use high-fidelity build-tool classpaths in Stages 1 and
+2 instead of falling directly to static parsing. The common root-descriptor case remains one
+subprocess per tool, preserving the previous cost profile for ordinary projects.
+
+Large root-less repositories may invoke more subprocesses than before. The 25-unit cap and Stage 3
+fallback limit the worst case while still improving the most common root-less layouts.

--- a/docs/adr/0001-build-unit-classpath-resolution.md
+++ b/docs/adr/0001-build-unit-classpath-resolution.md
@@ -26,14 +26,16 @@ A build unit is a directory where rewrite-runner invokes a build tool, paired wi
 - No root Gradle descriptor: discover top-most subdirectory Gradle descriptors as Gradle units.
 
 Discovery prunes below the first descriptor directory, skips the same default excluded directory names
-as file collection, scans to a maximum subdirectory depth of 3, and caps processing at 25 units. When
-more than 25 units are discovered, rewrite-runner warns and leaves the remaining coverage to later
-fallback stages.
+as file collection, scans to a maximum subdirectory depth of 3, sorts candidates by root-relative path,
+and caps processing at 25 units. When more than 25 units are discovered, rewrite-runner warns and does
+not treat Stage 1 or Stage 2 as complete, so later fallback stages provide full-project coverage.
 
-Stage 1 unions distinct JAR paths from successful unit classpath extractions. Stage 2 accumulates
-coordinates from successful Maven and Gradle dependency subprocesses, then resolves the distinct
-coordinate set. Gradle project data from subdirectory units is re-keyed to root-relative Gradle paths
-such as `:services:api` so build-file markers can still be attached.
+Stage 1 unions distinct JAR paths from unit classpath extractions only when every discovered unit
+completes. Stage 2 accumulates coordinates from Maven and Gradle dependency subprocesses only when
+every discovered unit completes, then resolves the distinct coordinate set. Partial per-unit coverage
+falls through to the next stage instead of reporting a build-tool or dependency-resolution success for
+the whole project. Gradle project data from subdirectory units is re-keyed to root-relative Gradle
+paths such as `:services:api` so build-file markers can still be attached.
 
 ## Consequences
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,10 +59,17 @@ Recipe JARs are cached under the tool's own `cacheDir` so they never pollute the
 | 3 | `BuildFileParseStage` | Static `pom.xml` parse + POM traversal | Static `build.gradle(.kts)` + version catalog parse + POM traversal |
 | 4 | `LocalRepositoryStage` | Local `~/.m2` cache scan | Local `~/.gradle/caches` scan |
 
-- **Stage 1** (`ProjectBuildStage`): Runs the project's own build tool to extract the exact compile classpath. Falls through on failure.
-- **Stage 2** (`DependencyResolutionStage`): Runs `mvn dependency:tree` / `gradle dependencies` subprocesses and resolves downloaded JARs directly via Aether. Supports Maven-only, Gradle-only, and mixed projects. Falls through when subprocesses fail.
+- **Stage 1** (`ProjectBuildStage`): Runs the project's own build tool to extract the exact compile classpath. It iterates discovered build units, so root-less monorepos with module-local build files can still use build-tool classpaths. Falls through on failure.
+- **Stage 2** (`DependencyResolutionStage`): Runs `mvn dependency:tree` / `gradle dependencies` subprocesses per discovered build unit and resolves downloaded JARs directly via Aether. Supports Maven-only, Gradle-only, mixed, and root-less projects. Falls through when subprocesses fail.
 - **Stage 3** (`BuildFileParseStage`): Parses `pom.xml` and `build.gradle(.kts)` statically (no subprocess) for all discovered modules, then resolves via full Maven Resolver POM traversal to obtain transitive dependencies. Falls through when no build files exist or resolution fails.
 - **Stage 4** (`LocalRepositoryStage`): Scans `~/.m2` and `~/.gradle/caches` for already-cached JARs. Always succeeds (possibly empty).
+
+Stages 1 and 2 use the build-unit model recorded in
+[`docs/adr/0001-build-unit-classpath-resolution.md`](adr/0001-build-unit-classpath-resolution.md).
+A build unit is a Maven or Gradle invocation directory. Root descriptors preserve the historical
+single-root invocation for that tool; when a root descriptor is absent, top-most subdirectory build
+files are discovered to depth 3, default excluded directories are skipped, and at most 25 units are
+processed before warning and relying on later fallback stages.
 
 The resolved classpath is **shared across all language parsers** — `JavaParser`, `KotlinParser`, and `GroovyParser` all receive the same project classpath so cross-language type references resolve correctly.
 


### PR DESCRIPTION
Closes #81

## Context

Issue #81 asked to deduplicate build-tool detection. While working through that, the more important
production issue was that the LST classpath pipeline was root-anchored:

- Stage 1 (`ProjectBuildStage.extractClasspath`) invoked Maven or Gradle only from the project root.
- Stage 2 (`DependencyResolutionStage.resolveClasspath`) made subdirectory-aware decisions, but still
  ran dependency commands from the root.
- Root-less monorepos with only subdirectory `pom.xml` or `build.gradle(.kts)` files fell through to
  Stage 3 static parsing, which works but loses build-tool fidelity such as BOM-managed versions,
  dependency management, resolved transitive scopes, and Gradle configuration data.

This PR keeps the command-resolution dedup separate for a follow-up and focuses on making Stages 1 and
2 build-unit aware.

## Current Implementation

A build unit is a directory where rewrite-runner invokes a build tool, paired with that tool.

- Maven root `pom.xml` exists: use the project root as the Maven unit.
- No root Maven descriptor: discover top-most subdirectory `pom.xml` files as Maven units.
- Gradle root `settings.gradle(.kts)` or `build.gradle(.kts)` exists: use the project root as the
  Gradle unit.
- No root Gradle descriptor: discover top-most subdirectory Gradle descriptors as Gradle units.

Discovery prunes below the first descriptor directory, skips `FileCollector.DEFAULT_EXCLUDED_DIRS`,
scans to subdirectory depth 3, sorts candidates by root-relative path and tool, and caps processing at
25 units.

Stage 1 and Stage 2 now require complete discovered-unit coverage before they short-circuit the
pipeline:

- Stage 1 unions distinct JAR paths only when discovery was not capped and every discovered unit
  completed classpath extraction. Partial or capped coverage returns `null`, so Stage 2 gets a chance
  to resolve the whole project. A successful Maven unit with an empty classpath counts as completed.
- Stage 2 accumulates coordinates and Gradle project data only when discovery was not capped and every
  discovered unit completed the dependency subprocess. Partial or capped coverage returns an empty
  classpath so Stage 3 provides full-project fallback coverage. Any Gradle marker data collected from
  completed units is preserved for later stages.
- Root-level wrappers are reused for subdirectory build units when the unit has no local wrapper.
- Compile-on-demand still attempts each discovered unit and treats any successful compilation as useful,
  because compiled class directories are gathered separately after classpath resolution.

This means one working module no longer causes the whole project to be reported as `BUILD_TOOL` or
`DEPENDENCY_RESOLUTION` success while failed, skipped, or capped units are parsed with incomplete
classpath.

## Tests

Added and updated focused coverage for:

- deterministic build-unit discovery ordering before capping;
- discovery truncation metadata;
- depth-3 discovery and depth-4 exclusion;
- excluded directory pruning;
- root-wrapper reuse for subdirectory Maven and Gradle units;
- Stage 1 falling through when any root-less unit fails;
- Stage 2 falling through before artifact resolution when any root-less unit fails;
- merged Gradle project data for complete root-less Gradle coverage.

## Documentation

- Added `docs/adr/0001-build-unit-classpath-resolution.md` for the build-unit model, cap behavior, and
  complete-coverage fallback rule.
- Added `CONTEXT.md` glossary entries for build-unit terminology.
- Updated `CLAUDE.md` so project guidance matches the current complete-coverage contract.

## Verification

- `./gradlew :core:test --tests "io.github.skhokhlov.rewriterunner.lst.utils.ProcessRunnerTest" --tests "io.github.skhokhlov.rewriterunner.lst.ProjectBuildStageTest" --tests "io.github.skhokhlov.rewriterunner.lst.DependencyResolutionStageResolveClasspathTest"`
- `./gradlew :core:ktlintCheck`
- `./gradlew check`
- `./gradlew :cli:testIntegration`
- `git diff --check`
