### PR TITLE
chore(cli)!: ship fat JAR via GitHub Releases instead of Maven Central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # create the GitHub Release and upload the CLI fat JAR asset
     environment: maven-central
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -32,6 +32,22 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
+
+      # The CLI fat JAR is too large for Maven Central, so it ships as a GitHub Release asset.
+      - name: Build CLI fat JAR
+        run: ./gradlew :cli:shadowJar --no-configuration-cache
+
+      - name: Stage release asset
+        run: |
+          version="${GITHUB_REF#refs/tags/v}"
+          src=$(ls cli/build/libs/cli-*-all.jar)
+          cp "$src" "rewrite-runner-${version}-all.jar"
+
+      - name: Upload CLI fat JAR to GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          files: rewrite-runner-*-all.jar
+          fail_on_unmatched_files: true
 
   deploy-docs:
     needs: publish

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A self-hosted CLI tool for running [OpenRewrite](https://docs.openrewrite.org/) 
 
 ## Installation
 
-`rewrite-runner` is published to Maven Central. The `core` module is the library; the `cli` module ships a thin JAR plus a `-all` fat JAR for direct CLI use.
+`rewrite-runner` is published to Maven Central as libraries: the `core` module (the library) and the `cli` module's thin JAR. The runnable `-all` fat JAR is **not** on Maven Central (it exceeds Central's upload limit) — it ships as a [GitHub Releases](https://github.com/skhokhlov/rewrite-runner/releases) asset for direct CLI use.
 
 ### Gradle
 
@@ -42,12 +42,19 @@ dependencies {
 
 ### CLI fat JAR
 
-Download the `-all` jar directly from Maven Central:
+Download the `-all` jar from the GitHub release for the version you want:
 
 ```bash
 curl -L -o rewrite-runner.jar \
-  "https://repo1.maven.org/maven2/io/github/skhokhlov/rewriterunner/cli/1.0.0/cli-1.0.0-all.jar"
+  "https://github.com/skhokhlov/rewrite-runner/releases/download/v1.0.0/rewrite-runner-1.0.0-all.jar"
 java -jar rewrite-runner.jar --help
+```
+
+Or, if you have [JBang](https://www.jbang.dev/) installed, run the CLI straight from the thin
+JAR on Maven Central (JBang resolves the classpath for you — no fat JAR needed):
+
+```bash
+jbang io.github.skhokhlov.rewriterunner:cli:1.0.0 --help
 ```
 
 ## Getting Started

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -28,11 +28,22 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-core")
 }
 
+val cliMainClass = "io.github.skhokhlov.rewriterunner.MainKt"
+
+// Declare the entry point on the thin jar too (not just the fat jar), so the Maven Central
+// artifact is self-describing: `jbang io.github.skhokhlov.rewriterunner:cli:<version>` and any
+// `java -cp` launcher can find the main class without an explicit `--main`.
+tasks.jar {
+    manifest {
+        attributes["Main-Class"] = cliMainClass
+    }
+}
+
 tasks.shadowJar {
     archiveClassifier.set("all")
     mergeServiceFiles()
     manifest {
-        attributes["Main-Class"] = "io.github.skhokhlov.rewriterunner.MainKt"
+        attributes["Main-Class"] = cliMainClass
     }
 }
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -36,6 +36,18 @@ tasks.shadowJar {
     }
 }
 
+// The `-all` fat JAR (bundling all of core's transitive tree) is too large for Maven Central's
+// upload limit and conceptually isn't a library dependency. The gradleup shadow plugin
+// auto-registers `shadowRuntimeElements` into the `java` component, which vanniktech then
+// publishes; skip that variant so the fat JAR stays out of the Central publication. The
+// `shadowJar` task itself remains available to build the artifact for GitHub Releases (see the
+// release workflow and docs/adr/0009-cli-fatjar-distribution.md). The shadow plugin registers
+// the variant on the `java` component in an afterEvaluate, so the skip must be deferred too.
+afterEvaluate {
+    (components["java"] as AdhocComponentWithVariants)
+        .withVariantsFromConfiguration(configurations["shadowRuntimeElements"]) { skip() }
+}
+
 // Test partitioning. All test code lives in one source set (shares BaseIntegrationTest helpers
 // and `ToolchainCache`); the three lanes are split by Gradle `Test.filter` class-name patterns
 // rather than by Kotest tags. The split mirrors the three CI jobs:

--- a/docs/adr/0009-cli-fatjar-distribution.md
+++ b/docs/adr/0009-cli-fatjar-distribution.md
@@ -1,0 +1,61 @@
+# ADR 0009: CLI Fat JAR Distributed via GitHub Releases, Not Maven Central
+
+## Status
+
+Accepted
+
+## Context
+
+rewrite-runner publishes two modules to Maven Central through the `publishing-convention`
+plugin (`com.vanniktech.maven.publish`):
+
+- **`core`** — the library: thin JAR + sources + javadoc, dependencies declared in the POM.
+- **`cli`** — thin JAR + sources + javadoc, **and** historically the `-all` shadow fat JAR.
+
+The fat JAR bundles all of `core`'s transitive tree (every `rewrite-*` module, Maven Resolver,
+Jackson, Logback, picocli) into a single ~110 MB artifact. It was the recommended way to run
+the CLI: the README told users to `curl` it straight from `repo1.maven.org`.
+
+That artifact exceeds Maven Central's per-file upload limit, so it cannot continue to ship
+there. Two in-place workarounds were rejected:
+
+- **`shadow { minimize() }`** to shrink the JAR is unsafe. OpenRewrite discovers recipes and
+  parsers reflectively via `ServiceLoader`, and minimization strips classes reached only by
+  reflection — breaking recipe loading at runtime in ways unit builds do not catch.
+- **Dropping the sources/javadoc JARs** to claw back size is not allowed: Sonatype requires a
+  sources JAR and a javadoc JAR for every released artifact.
+
+The fat JAR is also conceptually not a library dependency — nobody adds it to a `dependencies {}`
+block — so Maven Central is the wrong host for it regardless of size.
+
+## Decision
+
+**The runnable `-all` fat JAR ships as a GitHub Release asset; Maven Central hosts only the
+libraries (`core` and the `cli` thin JAR).**
+
+- In `cli/build.gradle.kts`, the gradleup shadow plugin auto-registers `shadowRuntimeElements`
+  on the `java` component (which vanniktech then publishes). We skip that variant from the
+  published component (`withVariantsFromConfiguration(...) { skip() }`, deferred in
+  `afterEvaluate` because shadow registers the variant in its own `afterEvaluate`). The
+  `shadowJar` task stays intact so the asset can still be built.
+- The `cli` thin JAR + sources + javadoc continue to publish to Central, preserving the
+  coordinates and the Maven Central badge. The thin JAR is KB-scale and no threat to the limit.
+- The tag-triggered `publish.yml` workflow builds the fat JAR after the Central publish and
+  uploads it as `rewrite-runner-<version>-all.jar` to the GitHub Release for that tag
+  (`softprops/action-gh-release`, `contents: write`). GitHub Releases caps individual assets at
+  2 GiB and does not meter asset storage/bandwidth for public repos — ample headroom.
+- Because the thin `cli` JAR + POM remain on Central, JBang can run the CLI directly
+  (`jbang io.github.skhokhlov.rewriterunner:cli:<version>`) without any fat JAR — documented as
+  a bonus path, not the primary one.
+
+## Consequences
+
+The Maven Central footprint drops by the entire fat JAR and stays under the upload limit, while
+library consumers are unaffected. The cost is that the CLI download moves off the immutable,
+mirror-backed Central CDN onto GitHub Releases, and the README `curl` URL changes shape
+(`releases/download/v<version>/...`). Anyone who bookmarked the old `repo1.maven.org` URL must
+update it — a one-time, hard-to-silently-reverse break, which is why this is recorded here.
+
+A future contributor tempted to "just put the fat JAR back on Central" should treat the Central
+upload limit (not preference) as the blocker, and `minimize()`'s incompatibility with
+OpenRewrite's reflective recipe loading as the reason shrinking-in-place is not a shortcut.

--- a/docs/build.md
+++ b/docs/build.md
@@ -7,7 +7,7 @@ Located in `buildSrc/src/main/kotlin/`. Applied via `plugins { id("...") }` in s
 | Plugin | Applied to | What it does |
 |--------|-----------|--------------|
 | `kotlin-convention` | `core`, `cli` | Kotlin JVM 21 toolchain, JUnit platform, `-Xmx2g` for tests, ktlint tasks (`ktlintCheck`/`ktlintFormat`), JaCoCo XML+HTML reports auto-run after test |
-| `publishing-convention` | `core` | `maven-publish`, optional signing, Dokka sources/javadoc JARs, POM template |
+| `publishing-convention` | `core`, `cli` | `maven-publish`, optional signing, Dokka sources/javadoc JARs, POM template. In `cli`, the shadow `-all` variant is skipped from the publication so the fat JAR never goes to Maven Central |
 | `dokka-convention` | `core` | Dokka HTML docs generation |
 
 `ktlintCheck` is wired into the standard `check` lifecycle task — `./gradlew check` always enforces style.
@@ -71,7 +71,10 @@ Triggers on push/PR to `main`/`master`. Three sequential jobs gate on each other
 Because the jobs chain via `needs:`, an early failure short-circuits the later lanes: a unit-test regression never spends CI minutes downloading Gradle/Maven distributions.
 
 ### Publish workflow (`.github/workflows/publish.yml`)
-Triggers on `v*` tags — publishes `core` to Maven Central.
+Triggers on `v*` tags. Publishes `core` and the `cli` thin JAR (with sources + javadoc) to
+Maven Central, then builds the `cli` `-all` fat JAR and uploads it as a GitHub Release asset
+(`rewrite-runner-<version>-all.jar`) — the fat JAR is too large for Central. See
+[`adr/0009-cli-fatjar-distribution.md`](adr/0009-cli-fatjar-distribution.md).
 
 ## Known Issues
 


### PR DESCRIPTION
The cli -all shadow fat JAR (~110 MB) exceeds Maven Central's upload limit. Skip the shadowRuntimeElements variant from the cli publication so only the thin JAR + sources + javadoc go to Central, and upload the fat JAR as a GitHub Release asset (rewrite-runner-<version>-all.jar) from the tag-triggered publish workflow. The cli thin JAR + POM remain on Central, so JBang can run the CLI without any fat JAR.

shadow { minimize() } is not a viable alternative: OpenRewrite discovers recipes/parsers reflectively via ServiceLoader and minimization strips them.

See docs/adr/0009-cli-fatjar-distribution.md.

BREAKING CHANGE: the cli -all fat JAR is no longer published to Maven Central. Download it from GitHub Releases
(https://github.com/skhokhlov/rewrite-runner/releases) instead of repo1.maven.org.