### PR TITLE
Prove fallback type attribution with real offline Gradle integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 ./gradlew shadowJar              # Build fat JAR → cli/build/libs/cli-1.0-SNAPSHOT-all.jar
 ./gradlew test                   # UNIT tests only (excludes *IntegrationTest)
-./gradlew check                  # unit tests + ktlintCheck + offline fake-wrapper integration
-./gradlew :cli:testIntegration   # Fake-wrapper integration tests (offline)
+./gradlew check                  # unit tests + ktlintCheck + offline integration
+./gradlew :cli:testIntegration   # Offline integration (fake wrappers + real fallback Gradle)
 ./gradlew :cli:testRealPlugin    # Real-plugin integration tests (downloads Maven/Gradle)
 ./gradlew :cli:testContainer     # Fat JAR in a Docker 2 GiB cgroup
 ./gradlew productionCheck        # every production lane before release publication
@@ -154,10 +154,10 @@ cli/src/
 - Upstream `rewrite-gradle-plugin` and `rewrite-maven-plugin` versions live in `gradle/libs.versions.toml` (`rewrite-gradle-plugin`, `rewrite-maven-plugin` keys). The `generatePluginVersions` task in `core/build.gradle.kts` emits a generated `BuildPluginVersions` object that `ToolConfigDefaults.REWRITE_*_PLUGIN_VERSION` reads from. Bump in the TOML — never edit the generated file.
 - Tests are split into three lanes by Gradle `Test.filter` class-name pattern (no Kotest tags):
   - `:cli:test` — unit tests only, excludes `*IntegrationTest`. Wired into `check`.
-  - `:cli:testIntegration` — fake-wrapper / per-language integration suite (offline, no toolchain downloads). Includes `*IntegrationTest`, excludes `PluginRealExecutionIntegrationTest`.
+  - `:cli:testIntegration` — offline integration suite: per-language tests, fake-wrapper Stage 0 coverage, and real nested-Gradle fallback attribution using the current distribution. Includes `*IntegrationTest`, excludes `PluginRealExecutionIntegrationTest`.
   - `:cli:testRealPlugin` — real OpenRewrite Maven/Gradle plugins (downloads distributions, hits Maven Central). The Gradle distribution under test tracks the project's own `gradle-wrapper.properties` (forwarded via `-Drewriterunner.test.gradleVersion`).
 - Stage 0 plugin execution is covered both by fake-wrapper tests (`PluginFirstIntegrationTest`, in the `testIntegration` lane) and real-wrapper tests (`PluginRealExecutionIntegrationTest`, in the `testRealPlugin` lane). The real-wrapper suite calls `RewriteRunner` directly and asserts `executionDiagnostics.stageUsed == UsedExecutionStage.PLUGIN`, and non-dry-run real plugin scenarios assert positive `estimatedTimeSaved`, so an accidental LST-fallback success or plugin-output drift cannot mask a Stage 0 regression.
-- CI runs three sequential jobs (`unit` → `integration-fake` → `plugin-real`) so a unit regression short-circuits before any toolchain download. See [`docs/testing.md`](docs/testing.md) and [`docs/build.md`](docs/build.md).
+- CI runs offline checks first; Windows worker and real-plugin jobs follow, then container acceptance follows the real-plugin lane. See [`docs/testing.md`](docs/testing.md) and [`docs/build.md`](docs/build.md).
 
 ## Logging
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,9 +42,10 @@ dependencies {
     dokka(project(":cli"))
 }
 
-// `check` remains the fast, offline release signal: it includes unit tests plus the fake-wrapper
-// integration suite, whose coordinator/worker boundary is a real JVM process. The live plugin
-// lane stays explicit for local development but is part of the aggregate production gate.
+// `check` remains the offline release signal: it includes unit tests plus the integration suite,
+// whose coordinator/worker boundary and fallback-attribution Gradle builds use real processes.
+// The live plugin lane stays explicit for local development but is part of the aggregate
+// production gate.
 tasks.named("check") {
     dependsOn(":cli:testIntegration")
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     // OpenRewrite needed in test scope for integration tests (Result, SourceFile, etc.)
     testImplementation(platform(libs.rewrite.recipe.bom))
     testImplementation("org.openrewrite:rewrite-core")
+    testImplementation("org.openrewrite:rewrite-java")
 }
 
 val cliMainClass = "io.github.skhokhlov.rewriterunner.MainKt"
@@ -65,7 +66,7 @@ afterEvaluate {
 // rather than by Kotest tags. The split mirrors the CI jobs:
 //
 //   :cli:test           → unit-only (RunCommandTest et al.; excludes *IntegrationTest)
-//   :cli:testIntegration → fake-wrapper integration suite; offline-safe, no network needed
+//   :cli:testIntegration → offline integration suite; no network or toolchain downloads
 //   :cli:testRealPlugin → real OpenRewrite Maven/Gradle plugins from Maven Central
 //   :cli:testContainer  → release fat JAR in a real Docker cgroup
 //
@@ -87,8 +88,20 @@ private val realPluginGradleVersion: String = run {
         ?: error("Could not parse Gradle version from $wrapperProps")
 }
 
-// `:cli:test` runs unit tests only. Integration suites are dedicated tasks so CI can sequence
-// the three lanes (unit → fake-wrapper → real-plugin) and surface failures at the right stage.
+// The offline fallback-attribution fixture executes a real nested Gradle build. Reuse the
+// distribution already running this build instead of downloading another toolchain.
+private val currentGradleExecutable: String = requireNotNull(gradle.gradleHomeDir) {
+    "The integration test lane requires a Gradle distribution home"
+}.resolve("bin")
+    .resolve(if (System.getProperty("os.name").contains("win", ignoreCase = true)) {
+        "gradle.bat"
+    } else {
+        "gradle"
+    })
+    .absolutePath
+
+// `:cli:test` runs unit tests only. Integration suites are dedicated tasks so CI can select
+// offline, real-plugin, and container evidence independently.
 tasks.named<Test>("test") {
     filter {
         excludeTestsMatching(integrationClassPattern)
@@ -96,11 +109,12 @@ tasks.named<Test>("test") {
     }
 }
 
-// Fake-wrapper integration tests: per-language LST coverage + Stage 0 plugin-orchestration
-// tests that drive fake `gradlew`/`mvnw` shell scripts. Fully offline; no toolchain downloads.
+// Offline integration tests: per-language LST coverage, fake-wrapper Stage 0 orchestration, and
+// real nested-Gradle fallback attribution using this build's distribution. No network or toolchain
+// download is required.
 tasks.register<Test>("testIntegration") {
     group = "verification"
-    description = "Runs integration tests with fake build-tool wrappers (offline-safe)."
+    description = "Runs offline integration tests, including real fallback attribution."
     testClassesDirs = sourceSets["test"].output.classesDirs
     classpath = sourceSets["test"].runtimeClasspath
     useJUnitPlatform()
@@ -117,6 +131,7 @@ tasks.register<Test>("testIntegration") {
             "rewriterunner.test.fatJar",
             tasks.shadowJar.get().archiveFile.get().asFile.absolutePath
         )
+        systemProperty("rewriterunner.test.gradleExecutable", currentGradleExecutable)
     }
 }
 

--- a/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/FallbackTypeAttributionIntegrationTest.kt
+++ b/cli/src/test/kotlin/io/github/skhokhlov/rewriterunner/integration/FallbackTypeAttributionIntegrationTest.kt
@@ -1,0 +1,410 @@
+package io.github.skhokhlov.rewriterunner.integration
+
+import io.github.skhokhlov.rewriterunner.ExecutorOutcome
+import io.github.skhokhlov.rewriterunner.ExecutorPhase
+import io.github.skhokhlov.rewriterunner.LogicalExecutor
+import io.github.skhokhlov.rewriterunner.RewriteRunner
+import io.github.skhokhlov.rewriterunner.RunResult
+import io.github.skhokhlov.rewriterunner.RunnerLogger
+import io.github.skhokhlov.rewriterunner.UsedExecutionStage
+import io.kotest.core.spec.style.FunSpec
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import javax.tools.ToolProvider
+import kotlin.io.path.createDirectories
+import kotlin.io.path.readLines
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.openrewrite.InMemoryExecutionContext
+import org.openrewrite.Result
+import org.openrewrite.internal.InMemoryLargeSourceSet
+import org.openrewrite.java.ChangeType
+import org.openrewrite.java.JavaParser
+
+class FallbackTypeAttributionIntegrationTest :
+    FunSpec({
+        test("ChangeType requires the external type to be attributed") {
+            ExternalDependencyFixture.create().use { fixture ->
+                assertTrue(
+                    changeTypeResults(emptyList()).isEmpty(),
+                    "ChangeType must not match an unattributed external type"
+                )
+
+                val attributedResults = changeTypeResults(listOf(fixture.jar))
+                assertEquals(1, attributedResults.size)
+                assertEquals(EXPECTED_SOURCE, attributedResults.single().after?.printAll())
+            }
+        }
+
+        test("Stage 1 build-tool classpath attributes the external type after Stage 0 fails") {
+            FallbackScenarioFixture.create(forceStage2 = false).use { fixture ->
+                val result = fixture.run()
+
+                assertRecovery(result, fixture, UsedExecutionStage.BUILD_TOOL)
+            }
+        }
+
+        test("Stage 2 dependency resolution attributes the type when Stage 1 fails") {
+            FallbackScenarioFixture.create(forceStage2 = true).use { fixture ->
+                val result = fixture.run()
+
+                assertNotEquals(
+                    0,
+                    fixture.exitCodeFor("printClasspathForOpenRewrite"),
+                    "The unresolved runtime dependency must make Stage 1 fail"
+                )
+                assertEquals(
+                    0,
+                    fixture.exitCodeFor("dependencies"),
+                    "Gradle dependency reporting must remain usable for Stage 2"
+                )
+                assertRecovery(result, fixture, UsedExecutionStage.DEPENDENCY_RESOLUTION)
+            }
+        }
+    })
+
+private fun changeTypeResults(classpath: List<Path>): List<Result> {
+    val ctx = InMemoryExecutionContext { failure ->
+        throw AssertionError("OpenRewrite failed while exercising ChangeType", failure)
+    }
+    val parser = JavaParser.fromJavaVersion().classpath(classpath).build()
+    val sourceFiles = parser.parse(ctx, ORIGINAL_SOURCE).toList()
+    return ChangeType(EXTERNAL_TYPE, REPLACEMENT_TYPE, true)
+        .run(InMemoryLargeSourceSet(sourceFiles), ctx)
+        .changeset
+        .allResults
+}
+
+private data class ExternalDependencyFixture(val root: Path, val jar: Path) : AutoCloseable {
+    override fun close() {
+        root.toFile().deleteRecursively()
+    }
+
+    companion object {
+        fun create(): ExternalDependencyFixture {
+            val root = Files.createTempDirectory("fallback-type-attribution-dependency-")
+            return ExternalDependencyFixture(root, compileExternalDependency(root))
+        }
+    }
+}
+
+private data class FallbackScenarioFixture(
+    val root: Path,
+    val projectDir: Path,
+    val cacheDir: Path,
+    val runnerUserHome: Path,
+    val wrapperLog: Path,
+    val sourceFile: Path,
+    val logger: RecordingRunnerLogger
+) : AutoCloseable {
+    fun exitCodeFor(argument: String): Int {
+        val exit = wrapperLog.readLines().single {
+            it.startsWith("EXIT|") && it.substringAfter('|').substringAfter('|').contains(argument)
+        }
+        return exit.substringAfter('|').substringBefore('|').toInt()
+    }
+
+    fun run(): RunResult = RewriteRunner.builder()
+        .projectDir(projectDir)
+        .activeRecipe(CHANGE_EXTERNAL_TYPE_RECIPE)
+        .rewriteConfig(projectDir.resolve("rewrite.yaml"))
+        .configFile(projectDir.resolve("rewriterunner.yml"))
+        .cacheDir(cacheDir)
+        .lstWorkerJvmArgs(
+            listOf(
+                "-Xmx1g",
+                "-Duser.home=${runnerUserHome.toAbsolutePath()}"
+            )
+        )
+        .logger(logger)
+        .build()
+        .run()
+
+    override fun close() {
+        root.toFile().deleteRecursively()
+    }
+
+    companion object {
+        fun create(forceStage2: Boolean): FallbackScenarioFixture {
+            val root = Files.createTempDirectory("fallback-type-attribution-")
+            val projectDir = root.resolve("project").createDirectories()
+            val cacheDir = root.resolve("cache").createDirectories()
+            val runnerUserHome = root.resolve("runner-user-home").createDirectories()
+            val gradleUserHome = root.resolve("gradle-user-home").createDirectories()
+            val repository = root.resolve("maven-repository").createDirectories()
+            val wrapperLog = root.resolve("gradle-invocations.log")
+
+            val dependencyRoot = root.resolve("dependency").createDirectories()
+            val dependency = compileExternalDependency(dependencyRoot)
+            publishExternalDependency(dependency, repository)
+
+            projectDir.resolve("settings.gradle.kts").writeText(
+                "rootProject.name = \"type-attribution-fixture\"\n"
+            )
+            projectDir.resolve("build.gradle.kts").writeText(
+                buildString {
+                    appendLine("plugins { java }")
+                    appendLine("repositories {")
+                    appendLine("    maven { url = uri(\"${repository.toUri()}\") }")
+                    appendLine("}")
+                    appendLine("dependencies {")
+                    appendLine("    implementation(\"$EXTERNAL_COORDINATE\")")
+                    if (forceStage2) {
+                        appendLine("    runtimeOnly(\"$MISSING_RUNTIME_COORDINATE\")")
+                    }
+                    appendLine("}")
+                }
+            )
+            projectDir.resolve("rewrite.yaml").writeText(
+                """
+                ---
+                type: specs.openrewrite.org/v1beta/recipe
+                name: $CHANGE_EXTERNAL_TYPE_RECIPE
+                recipeList:
+                  - org.openrewrite.java.ChangeType:
+                      oldFullyQualifiedTypeName: $EXTERNAL_TYPE
+                      newFullyQualifiedTypeName: $REPLACEMENT_TYPE
+                      ignoreDefinition: true
+                """.trimIndent() + "\n"
+            )
+            projectDir.resolve("rewriterunner.yml").writeText(
+                """
+                includeMavenCentral: false
+                rewriteGradlePluginVersion: $UNAVAILABLE_PLUGIN_VERSION
+                artifactRepositories:
+                  - url: "${repository.toUri()}"
+                """.trimIndent() + "\n"
+            )
+            val sourceFile = projectDir.resolve(SOURCE_PATH).also {
+                it.parent.createDirectories()
+                it.writeText(ORIGINAL_SOURCE)
+            }
+            installGradleWrapper(projectDir, gradleUserHome, wrapperLog)
+
+            return FallbackScenarioFixture(
+                root = root,
+                projectDir = projectDir,
+                cacheDir = cacheDir,
+                runnerUserHome = runnerUserHome,
+                wrapperLog = wrapperLog,
+                sourceFile = sourceFile,
+                logger = RecordingRunnerLogger()
+            )
+        }
+    }
+}
+
+private fun assertRecovery(
+    result: RunResult,
+    fixture: FallbackScenarioFixture,
+    expectedStage: UsedExecutionStage
+) {
+    val pluginAttempt = result.executionDiagnostics.executorAttempts.single {
+        it.executor == LogicalExecutor.GRADLE_PLUGIN
+    }
+    assertEquals(ExecutorPhase.PLUGIN_DRY_RUN, pluginAttempt.phase)
+    assertEquals(ExecutorOutcome.FAILED, pluginAttempt.outcome)
+    val pluginExitCode = assertNotNull(pluginAttempt.exitCode)
+    assertNotEquals(0, pluginExitCode)
+    assertEquals(pluginExitCode, fixture.exitCodeFor("rewriteDryRun"))
+    assertTrue(
+        fixture.wrapperLog.readLines().first().contains("rewriteDryRun"),
+        "The first real Gradle invocation must be the Stage 0 plugin attempt"
+    )
+    assertTrue(
+        fixture.logger.debugMessages.any {
+            it.contains("Could not find org.openrewrite:plugin:$UNAVAILABLE_PLUGIN_VERSION")
+        },
+        "Stage 0 did not fail for the deliberately unavailable OpenRewrite plugin:\n" +
+            fixture.logger.debugMessages.joinToString("\n")
+    )
+
+    assertEquals(expectedStage, result.executionDiagnostics.stageUsed)
+    assertEquals(1, result.executionDiagnostics.resolvedJarCount)
+    assertEquals(setOf(Path.of(SOURCE_PATH)), result.rawDiffs.keys)
+    assertEquals(EXPECTED_SOURCE, fixture.sourceFile.readText())
+    assertEquals(
+        EXPECTED_SEMANTIC_DIFF,
+        result.rawDiffs.getValue(Path.of(SOURCE_PATH)).semanticChangeLines()
+    )
+
+    val workerAttempt = result.executionDiagnostics.executorAttempts.single {
+        it.executor == LogicalExecutor.LST_WORKER
+    }
+    assertEquals(ExecutorOutcome.SUCCESS, workerAttempt.outcome)
+    assertNotEquals(ProcessHandle.current().pid(), assertNotNull(workerAttempt.processId))
+}
+
+private fun compileExternalDependency(root: Path): Path {
+    val sourceDir = root.resolve("source/com/acme").createDirectories()
+    val classesDir = root.resolve("classes").createDirectories()
+    val source = sourceDir.resolve("External.java")
+    source.writeText(
+        """
+        package com.acme;
+
+        public class External {
+        }
+        """.trimIndent() + "\n"
+    )
+    val compiler = checkNotNull(ToolProvider.getSystemJavaCompiler()) {
+        "A JDK compiler is required for the type-attribution integration fixture"
+    }
+    assertEquals(
+        0,
+        compiler.run(null, null, null, "-d", classesDir.toString(), source.toString()),
+        "Could not compile the external dependency fixture"
+    )
+
+    val jar = root.resolve("external-1.0.jar")
+    JarOutputStream(Files.newOutputStream(jar)).use { output ->
+        Files.walk(classesDir).use { compiled ->
+            compiled
+                .filter(Files::isRegularFile)
+                .forEach { classFile ->
+                    val entryName = classesDir.relativize(classFile).toString().replace('\\', '/')
+                    output.putNextEntry(JarEntry(entryName))
+                    Files.copy(classFile, output)
+                    output.closeEntry()
+                }
+        }
+    }
+    return jar
+}
+
+private fun publishExternalDependency(jar: Path, repository: Path) {
+    val artifactDir = repository.resolve("com/acme/external/1.0").createDirectories()
+    Files.copy(
+        jar,
+        artifactDir.resolve("external-1.0.jar"),
+        StandardCopyOption.REPLACE_EXISTING
+    )
+    artifactDir.resolve("external-1.0.pom").writeText(
+        """
+        <project xmlns="http://maven.apache.org/POM/4.0.0">
+          <modelVersion>4.0.0</modelVersion>
+          <groupId>com.acme</groupId>
+          <artifactId>external</artifactId>
+          <version>1.0</version>
+        </project>
+        """.trimIndent() + "\n"
+    )
+}
+
+private fun installGradleWrapper(projectDir: Path, gradleUserHome: Path, log: Path) {
+    val executable = Path.of(
+        checkNotNull(System.getProperty("rewriterunner.test.gradleExecutable")) {
+            "Run this test through the :cli:testIntegration Gradle task"
+        }
+    ).toAbsolutePath()
+
+    if (isWindows) {
+        projectDir.resolve("gradlew.bat").writeText(
+            """
+            @echo off
+            echo START^|%*>>"${log.toAbsolutePath()}"
+            set "GRADLE_USER_HOME=${gradleUserHome.toAbsolutePath()}"
+            call "$executable" --offline %*
+            set "status=%ERRORLEVEL%"
+            echo EXIT^|%status%^|%*>>"${log.toAbsolutePath()}"
+            exit /b %status%
+            """.trimIndent() + "\r\n"
+        )
+    } else {
+        val gradlew = projectDir.resolve("gradlew")
+        gradlew.writeText(
+            """
+            #!/bin/sh
+            set -u
+            printf 'START|%s\n' "$D*" >> '${log.toAbsolutePath().shellSingleQuoted()}'
+            export GRADLE_USER_HOME='${gradleUserHome.toAbsolutePath().shellSingleQuoted()}'
+            '${executable.shellSingleQuoted()}' --offline "$D@"
+            status="$D?"
+            printf 'EXIT|%s|%s\n' "${D}status" "$D*" >> '${log.toAbsolutePath().shellSingleQuoted()}'
+            exit "${D}status"
+            """.trimIndent() + "\n"
+        )
+        Files.setPosixFilePermissions(gradlew, posixExecutable)
+    }
+}
+
+private fun Path.shellSingleQuoted(): String = toString().replace("'", "'\"'\"'")
+
+private fun String.semanticChangeLines(): List<String> = lineSequence()
+    .filter {
+        (it.startsWith("+") && !it.startsWith("+++")) ||
+            (it.startsWith("-") && !it.startsWith("---"))
+    }
+    .toList()
+
+private class RecordingRunnerLogger : RunnerLogger {
+    val debugMessages = CopyOnWriteArrayList<String>()
+
+    override fun lifecycle(message: String) = Unit
+
+    override fun info(message: String) = Unit
+
+    override fun debug(message: String) {
+        debugMessages += message
+    }
+
+    override fun warn(message: String) = Unit
+
+    override fun error(message: String, cause: Throwable?) = Unit
+}
+
+private const val EXTERNAL_TYPE = "com.acme.External"
+private const val REPLACEMENT_TYPE = "com.acme.Replacement"
+private const val EXTERNAL_COORDINATE = "com.acme:external:1.0"
+private const val MISSING_RUNTIME_COORDINATE = "com.acme:missing-runtime:1.0"
+private const val UNAVAILABLE_PLUGIN_VERSION = "0.0.0-stage0-must-fail"
+private const val CHANGE_EXTERNAL_TYPE_RECIPE = "com.acme.ChangeExternalType"
+private const val SOURCE_PATH = "src/main/java/com/example/UsesExternal.java"
+
+private val ORIGINAL_SOURCE =
+    """
+    package com.example;
+
+    import com.acme.External;
+
+    final class UsesExternal {
+        private External value;
+
+        External getValue() {
+            return value;
+        }
+    }
+    """.trimIndent() + "\n"
+
+private val EXPECTED_SOURCE =
+    """
+    package com.example;
+
+    import com.acme.Replacement;
+
+    final class UsesExternal {
+        private Replacement value;
+
+        Replacement getValue() {
+            return value;
+        }
+    }
+    """.trimIndent() + "\n"
+
+private val EXPECTED_SEMANTIC_DIFF =
+    listOf(
+        "-import com.acme.External;",
+        "+import com.acme.Replacement;",
+        "-    private External value;",
+        "+    private Replacement value;",
+        "-    External getValue() {",
+        "+    Replacement getValue() {"
+    )

--- a/docs/build.md
+++ b/docs/build.md
@@ -56,24 +56,32 @@ Chosen for **Gradle 9.x + JDK 25 compatibility**:
 ## CI/CD
 
 ### Build workflow (`.github/workflows/build.yml`)
-Triggers on push/PR to `main`/`master`. Three sequential jobs gate on each other so each failure surfaces at the right lane.
+Triggers on push/PR to `main`/`master`. Offline checks gate the Windows worker and live-plugin
+jobs; container acceptance follows the live-plugin lane.
 
-**`unit` job** (fast lane):
+**`unit` job** (offline checks):
 1. Set up JDK 21 (Temurin)
-2. `./gradlew check shadowJar` (`check` = `ktlintCheck` + `test`; `test` excludes everything matching `*IntegrationTest`)
+2. `./gradlew check shadowJar` — unit tests and lint plus `:cli:testIntegration`. The integration
+   task includes per-language tests, fake-wrapper Stage 0 coverage, and the real nested-Gradle
+   fallback-attribution fixture. Nested Gradle reuses the current distribution and runs offline.
 3. Fat JAR is produced as a build artifact of the same command
 
-**`integration-fake` job** (offline integration lane, needs `unit`):
+**`windows-worker` job** (needs `unit`):
 1. Set up JDK 21 (Temurin)
-2. `./gradlew :cli:testIntegration` — runs every `*IntegrationTest` except `PluginRealExecutionIntegrationTest`, including the per-language LST integration tests and the fake-wrapper Stage 0 suite. No network calls; no toolchain downloads.
+2. Run the focused core worker protocol/path tests and the fat-JAR distribution test on Windows.
 
-**`plugin-real` job** (real-plugin lane, needs `integration-fake`):
+**`plugin-real` job** (real-plugin lane, needs `unit`):
 1. Set up JDK 21 (Temurin)
 2. Cache `~/.m2/repository` and `cli/build/test-cache/toolchains/` (the toolchain cache key embeds `hashFiles('gradle/wrapper/gradle-wrapper.properties')` so bumping the wrapper auto-evicts the stale Gradle distribution)
 3. `./gradlew :cli:testRealPlugin --info` — runs only `PluginRealExecutionIntegrationTest` against the live OpenRewrite Maven/Gradle plugins
 4. Timeout: 25 minutes (covers first-run downloads from Maven Central)
 
-Because the jobs chain via `needs:`, an early failure short-circuits the later lanes: a unit-test regression never spends CI minutes downloading Gradle/Maven distributions.
+**`container` job** (needs `plugin-real`):
+1. Set up JDK 21 (Temurin)
+2. Run the release fat JAR under a real 2 GiB Docker cgroup.
+
+Because the external-environment jobs depend on earlier evidence, an offline regression never
+spends CI minutes downloading plugin toolchains or starting container acceptance.
 
 ### Publish workflow (`.github/workflows/publish.yml`)
 Triggers on `v*` tags. Publishes `core` and the `cli` thin JAR (with sources, javadoc, and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -117,17 +117,17 @@ cli/src/test/kotlin/.../
 
 ## Test Lanes
 
-Tests are split into four lanes by Gradle `Test.filter` class-name pattern. Each lane has a
-dedicated CI job; in CI they run sequentially so a failure shows up at the right stage.
+Tests are split into four lanes by Gradle `Test.filter` class-name pattern. The offline lanes run
+under root `check`; live-plugin and container evidence use explicit CI jobs.
 
 | Lane | Gradle task | Scope | When |
 |------|-------------|-------|------|
-| Unit + forked acceptance | `:core:test`, `:cli:test` | Configuration, protocol, diagnostics, and real core worker JVM tests; excludes `*IntegrationTest` | `check` lifecycle, CI job 1 |
-| Integration (fake wrappers) | `:cli:testIntegration` | All ordinary `*IntegrationTest` classes except real-plugin and container acceptance; offline-safe | CI job 2 |
-| Integration (real plugins) | `:cli:testRealPlugin` | `PluginRealExecutionIntegrationTest` only; downloads Maven/Gradle distributions and pulls live plugin artifacts from Maven Central | CI job 3 |
-| Container acceptance | `:cli:testContainer` | Built CLI fat JAR running under a real Docker `--memory=2g --memory-swap=2g` cgroup | CI job 4 |
+| Unit + forked acceptance | `:core:test`, `:cli:test` | Configuration, protocol, diagnostics, and real core worker JVM tests; excludes `*IntegrationTest` | Root `check` |
+| Integration (offline) | `:cli:testIntegration` | Ordinary `*IntegrationTest` classes: fake wrappers, per-language coverage, and real nested-Gradle fallback attribution; no network or toolchain download | Root `check` |
+| Integration (real plugins) | `:cli:testRealPlugin` | `PluginRealExecutionIntegrationTest` only; downloads Maven/Gradle distributions and pulls live plugin artifacts from Maven Central | `plugin-real` CI job |
+| Container acceptance | `:cli:testContainer` | Built CLI fat JAR running under a real Docker `--memory=2g --memory-swap=2g` cgroup | `container` CI job |
 
-Root `check` includes the offline fake-wrapper integration lane. `productionCheck` additionally runs
+Root `check` includes the offline integration lane. `productionCheck` additionally runs
 the real-plugin and container lanes and builds the release fat JAR. Both external-environment lanes
 are authoritative once selected: missing network, toolchain, Docker, or image prerequisites fail the
 task rather than producing a green skip. Tag publication runs `productionCheck` before publication.
@@ -142,6 +142,22 @@ The core suite exercises the worker through public `RewriteRunner` behavior: def
 shape, a distinct child PID, worker-observed explicit `-Xmx`, disk application, and rejection of a
 custom change writer in forked mode. Unit tests also cover automatic heap boundaries and configuration
 precedence. Worker failures must not retry the same work in-process.
+
+## LST fallback type-attribution tests
+
+`FallbackTypeAttributionIntegrationTest` proves that the Stage 1 and Stage 2 classpaths affect
+type-sensitive recipe behavior, not just diagnostics. It compiles `com.acme.External` into a real
+JAR, publishes it to a temporary Maven-layout file repository, and runs `ChangeType` through the
+public `RewriteRunner` path. A direct negative control first proves the recipe produces no result
+without that JAR.
+
+Both recovery scenarios attempt Stage 0 with a deliberately unavailable Gradle plugin from the
+file repository. The fixture reuses the Gradle distribution already running the test task, forces
+all nested invocations offline, and gives the project, rewrite-runner cache, Gradle user home,
+runner user home, and Maven repository temporary directories. Stage 2 adds an unresolved
+`runtimeOnly` dependency and records real wrapper exit codes to prove Stage 1 failed while the
+`dependencies` task remained usable. Both scenarios assert the winning stage and the exact
+`External` to `Replacement` source changes.
 
 ## Stage 0 Plugin Tests
 
@@ -173,7 +189,7 @@ observed the configured `-Xmx`, rather than merely checking the rendered Gradle/
 # Unit only (fast):
 ./gradlew :cli:test
 
-# Full offline verification (unit + fake-wrapper integration):
+# Full offline verification (unit + offline integration):
 ./gradlew check :cli:testIntegration
 
 # Real-plugin lane (downloads toolchains + plugins on first run; ~5 min warm):


### PR DESCRIPTION
## Summary

- Add real offline integration coverage for Stage 1 and Stage 2 type attribution.
- Compile and publish a temporary external dependency, then verify `ChangeType` behavior through `RewriteRunner`.
- Reuse the active Gradle distribution for nested fallback fixtures.
- Update build, CI, and testing documentation for the revised lanes.

## Testing

- Added integration tests covering plugin failure, build-tool fallback, dependency-resolution fallback, semantic diffs, and worker process isolation.
- Not run (not requested).