### PR TITLE
docs: add ADRs for unresolved-recipe failure and uniform failure reporting

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,6 +51,33 @@
   and the LST fallback so both paths select the same files. Specialized parsers take precedence: a
   file a real parser claims, such as `Dockerfile*` for `DockerParser`, is never treated as plain
   text on the LST path. See also **Specialized ownership**.
+- **Recipe artifact resolution**: Fetching the coordinates named by `--recipe-artifact` so their JARs
+  exist locally. Who performs it depends on the stage and they do not share a cache: on the LST path
+  rewrite-runner resolves them itself into its own recipe cache, while on
+  [[#stage-0-plugin-first-execution]] the target project's own build tool resolves them from whatever
+  repositories that build can see. _Avoid_: using "recipe discovery" for this step.
+- **Recipe discovery**: Finding a named recipe among JARs that are already present, by scanning them
+  for recipe classes and `META-INF/rewrite/*.yml` definitions. Distinct from **recipe artifact
+  resolution**: a recipe is undiscoverable both when its artifact was never fetched and when the
+  fetched artifact is unreadable, and the two are reported identically as "recipe not found".
+- **Terminal execution failure**: A failure that ends a run after execution has begun. Always
+  reported by returning a result that carries the failure, the record of every stage that ran, and
+  any changes that legitimately landed before it — never by throwing. A run can fail and still have
+  changed files, and the result must be able to say both. Contrast **precondition error**. See
+  [[0012-uniform-failure-reporting]].
+- **Precondition error**: An invalid request detected before any execution begins, such as a project
+  directory that does not exist. Always thrown, never reported as a run outcome, because no run
+  occurred.
+- **Unresolved recipe**: A recipe a run needs but the executing environment cannot find — either the
+  recipe the user requested, or one named inside a requested [[#declarative-recipe]]'s recipe list.
+  Any unresolved recipe makes the run a failure; a run must never quietly execute the subset it
+  happened to find. Because each stage resolves from its own sources, a recipe unresolved in one
+  stage may be resolvable in another, so an unresolved recipe is grounds for falling through to a
+  later stage rather than for abandoning the run. See [[0011-unresolved-recipes-are-failures]].
+- **Declarative recipe**: A recipe defined in YAML rather than as a class, whose `recipeList` may name
+  recipes belonging to other artifacts. Discovering one requires its own artifact; initializing one
+  requires every artifact its list names, and a missing entry degrades the recipe silently instead of
+  failing discovery.
 - **Root descriptor**: A build descriptor at the project root: `pom.xml` for Maven, or
   `settings.gradle(.kts)` / `build.gradle(.kts)` for Gradle.
 - **Root-less monorepo**: A repository whose project root has no build descriptor for a tool, but one

--- a/docs/adr/0011-unresolved-recipes-are-failures.md
+++ b/docs/adr/0011-unresolved-recipes-are-failures.md
@@ -1,0 +1,105 @@
+# ADR 0011: Unresolved Recipes Are Failures, Not No-Ops
+
+## Status
+
+Proposed
+
+## Context
+
+A recipe can be missing for two unrelated reasons that are reported identically as "recipe not
+found": its artifact was never fetched, or the artifact was fetched but is unreadable. Worse, the
+two execution stages resolve recipe artifacts from **independent sources** — Stage 0 delegates to
+the target project's own build tool and its repositories, while the LST worker resolves through
+rewrite-runner's own Aether context and cache. A recipe that one stage cannot find may be perfectly
+resolvable by the other.
+
+Before this decision, every path between "we could not obtain the recipe" and what the user is told
+was a silent downgrade:
+
+- A **missing sub-recipe degrades a declarative recipe silently**. Verified against the pinned
+  plugin: a recipe list naming an absent recipe logs `recipe '<fqn>' does not exist.` followed by
+  `Recipe validation errors detected … Execution will continue regardless.`, then exits `0` having
+  executed the remaining entries. `failOnInvalidActiveRecipes` governs this and defaults to `false`.
+  A 35-step migration therefore runs 34 steps and reports success.
+- `DirectPluginExecutor` classifies Stage 0 purely on exit code and patch-file presence, so that
+  degraded run is a **Stage 0 win** carrying real patches. The stage that could have run the whole
+  recipe is never reached.
+- On a Stage 0 win, a recipe-load failure in the follow-up specialized pass was caught and
+  downgraded to a warning.
+- `RecipeLoader` accepted a partially initialized declarative recipe: `DeclarativeRecipe.initialize`
+  records `recipe '<fqn>' does not exist.` into its validation, but the loader only asserted that the
+  recipe list was non-empty. A 35-step migration would happily run 34 steps.
+- Recipe artifact resolution returned local JAR paths without checking they were readable. Combined
+  with `CHECKSUM_POLICY_IGNORE` and `UPDATE_POLICY_DAILY`, a truncated download is accepted, cached,
+  never re-fetched, and contributes zero recipes — because the upstream classpath scanner swallows
+  the resulting `IOException`. This was reproduced end to end: the same command reported
+  `Resolved 95 JAR(s)` including the recipe artifact, then failed with `Recipe(s) not found` and a
+  nearest-match suggestion drawn from the other, healthy artifacts.
+
+Two neighbouring cases were checked against the pinned plugin and are **not** affected, which
+narrows this ADR's scope: an unresolvable recipe artifact and an unknown recipe name both produce a
+hard `BUILD FAILURE` and already fall through to the LST stage correctly. Silent degradation is
+specific to sub-recipes.
+
+The combined effect is a run that reports success, changes nothing or only part of what was asked,
+and gives no indication which happened.
+
+## Decision
+
+**Any unresolved recipe fails the stage that could not resolve it.** This covers both the recipe the
+user requested and any recipe named inside a requested declarative recipe's `recipeList` — a
+migration that silently executes the subset it happened to find is a wrong answer, not a partial
+success.
+
+Because the stages have independent classpaths, an unresolved recipe is grounds for **falling
+through to a later stage**, not for aborting the run. Stage 0 reporting unresolved recipes yields
+`PluginRunResult.Failed` and routes to the full LST fallback, which may hold the artifact Stage 0
+could not reach. Only when no stage can resolve every required recipe does the run fail.
+
+Consequences of enforcing this:
+
+- Stage 0 must verify its own success rather than trusting the plugin's exit code, which means
+  inspecting captured plugin output for upstream's unresolved-recipe markers. This is deliberate: we
+  delegate execution to the official plugins but do **not** delegate the judgement of whether they
+  did the job.
+- The check runs even when Stage 0 produced diffs, because a missing sub-recipe coexists with real
+  patches. Good Stage 0 diffs are discarded in that case in favour of a fallback that can run the
+  whole recipe.
+- Output-marker matching is anchored on exact upstream strings and is therefore version-coupled to
+  the pinned plugin versions; a plugin bump can silently weaken detection, so the marker set is
+  covered by tests in the real-plugin lane.
+
+## Considered Alternatives
+
+**Trust the plugin's exit code.** Simplest, and it keeps Stage 0 free of output parsing. Rejected
+because the exit code does not distinguish a complete run from a partially initialized one: a
+declarative recipe missing a sub-recipe exits `0` and emits patches, which is exactly the case this
+ADR targets.
+
+**Force `-Drewrite.failOnInvalidActiveRecipes=true`.** Would make the Maven plugin fail hard without
+any output parsing. Rejected as insufficient and asymmetric: it governs validation errors rather than
+the not-found path, has no Gradle equivalent, and lets a project's own plugin configuration override
+it.
+
+**Tolerate sub-recipe gaps when diffs exist.** Would preserve useful Stage 0 output and avoid
+re-running work on the slower path. Rejected because it institutionalizes exactly the failure this
+ADR exists to remove: an incomplete migration that looks complete.
+
+**Have rewrite-runner resolve recipe artifacts for Stage 0 too.** Would give one resolution path and
+one cache across both stages. Rejected for now — it overrides the project's own mirrors and
+credentials, which are often the only route to internal recipe artifacts, and it discards the
+independent-classpath property that makes falling through worthwhile. See
+[ADR 0006](0006-plugin-first-execution.md).
+
+## Relationship to ADR 0012
+
+When no stage can resolve every required recipe, the run fails. *How* that failure reaches the
+caller — a returned result carrying both stages' diagnostics rather than a thrown error — is
+governed by [ADR 0012](0012-uniform-failure-reporting.md), which covers every terminal execution
+failure uniformly rather than special-casing recipe resolution.
+
+## Relationship to ADR 0006
+
+[ADR 0006](0006-plugin-first-execution.md) established that `Failed` and `Skipped` fall through
+silently to the LST pipeline. This ADR narrows what may be classified as a Stage 0 success:
+`NoChanges` now requires evidence that every required recipe actually resolved.

--- a/docs/adr/0012-uniform-failure-reporting.md
+++ b/docs/adr/0012-uniform-failure-reporting.md
@@ -1,0 +1,78 @@
+# ADR 0012: Uniform Failure Reporting — Execution Failures Are Returned, Not Thrown
+
+## Status
+
+Proposed
+
+## Context
+
+[ADR 0011](0011-unresolved-recipes-are-failures.md) establishes that an unresolved recipe fails the
+stage that could not resolve it, and that the run fails only when no stage can resolve every required
+recipe. Implementing that exposed how inconsistently the terminal case was handled.
+
+`runFullFallback` had no error handling around LST execution, so a worker failure propagated and no
+result was ever constructed. Three consequences followed:
+
+- **Diagnostics were discarded exactly when they mattered.** The accumulated executor attempts — by
+  then holding Stage 0's own record of why it failed — were lost, leaving the user only the last
+  message. Since the stages resolve from independent sources, knowing that *both* failed, and why
+  each failed, is what distinguishes an unreachable repository from a bad coordinate.
+- **A failed run could silently modify the repository.** In a hybrid run, Stage 0 has already applied
+  changes in the units it handled before the LST stage runs. A propagating exception meant the run
+  exited non-zero reporting no changed files, while the working tree genuinely had changed.
+- **The same error presented differently per execution mode.** The forked path produced an
+  `IllegalStateException` carrying a message; the in-process path produced the original
+  `IllegalArgumentException`. The CLI routes those to different branches, so one mode presented a
+  plain user-facing error and the other logged an "unhandled exception" with a stack trace.
+
+Partial disk application already had a returned-failure shape (`writeOutcome`), so the codebase had
+two contradictory conventions for reporting failure at once.
+
+## Decision
+
+**Failure detection and reporting are uniform across every failure mode.** Every terminal execution
+failure — unresolved recipe, timeout, heap exhaustion, protocol failure, worker crash — is:
+
+1. classified with a typed `ExecutorOutcome`, extending the existing set rather than encoding the
+   kind in a message string;
+2. reported by **returning** a result carrying the failure, the executor attempts from every stage
+   that ran, and any changes that legitimately landed before the failure;
+3. reflected in the CLI exit code through a single aggregate check.
+
+`RunResult` gains an aggregate accessor covering every failure kind, so callers have exactly one
+thing to check, plus an `orThrow()` escape hatch for callers who prefer fail-fast. The CLI uses the
+aggregate.
+
+**Precondition errors keep throwing.** An invalid request detected before any execution begins — a
+`projectDir` that is not a directory, a custom `ChangeWriter` supplied in forked mode — is a
+programmer error, not a run outcome. No run happened, so there is no result to return, and returning
+one would be less consistent rather than more.
+
+## Consequences
+
+- The library contract changes: `run()` no longer throws for execution failures. Callers that relied
+  on exceptions to detect timeouts or heap exhaustion must check the aggregate or call `orThrow()`.
+- A returned failure is one a caller can forget to check. The aggregate accessor and `orThrow()`
+  mitigate this; the compiler does not enforce it.
+- Reporting a failure and changed files in the same result is deliberate. Partial success is real
+  here — a hybrid run can fail overall while having legitimately applied changes — and the result
+  must be able to say so.
+
+## Considered Alternatives
+
+**Return only unresolved-recipe failures; keep throwing for everything else.** Would confine the
+contract change to the case ADR 0011 forced. Rejected: it leaves two failure conventions in the
+codebase, and the diagnostics-discarded and dirty-tree problems above are not specific to recipe
+resolution — they affect timeouts and heap exhaustion identically.
+
+**A sealed `Success | Failed` result.** The only compiler-enforced option. Rejected because it models
+this system badly: a run can fail *and* have written files, so the sealed type needs a third partial
+case, which reintroduces most of the complexity while breaking every caller.
+
+**Distinguish failure kinds by matching the message text.** Avoids extending the outcome enum.
+Rejected as fragile — it would mean matching upstream strings once inside the plugin subprocess and
+again across our own process boundary, with silent degradation whenever a message is reworded.
+
+**A builder flag to opt into returned failures.** Preserves the existing contract for current
+callers. Rejected: it makes behaviour depend on configuration, which is the inconsistency this ADR
+exists to remove.


### PR DESCRIPTION
Records two decisions that came out of investigating inconsistent recipe discovery for `org.openrewrite.java.spring.boot4.UpgradeSpringBoot_4_0` from `org.openrewrite.recipe:rewrite-spring:6.35.0`.

Docs only — no behaviour change. Both ADRs are **Proposed** and need sign-off before the implementing PRs land.

## ADR 0011 — Unresolved recipes are failures, not no-ops

Any unresolved recipe fails the stage that could not resolve it: both the recipe the user requested and any recipe named inside a requested declarative recipe's `recipeList`. Because Stage 0 and the LST worker resolve recipe artifacts from **independent sources**, an unresolved recipe is grounds for falling through to a later stage rather than aborting the run.

Motivated by a verified defect: a declarative recipe missing a sub-recipe logs `recipe '<fqn>' does not exist.` / `Execution will continue regardless.`, exits `0`, **and emits patches** — so `DirectPluginExecutor` records a Stage 0 win and a 35-step migration silently runs 34 steps.

Scope is deliberately narrow. Two neighbouring cases were tested against the pinned plugin and are *not* affected: an unresolvable recipe artifact and an unknown recipe name both produce a hard `BUILD FAILURE` and already fall through correctly.

Implements: #268, #269. Scoping rationale for #267. Open question flagged in #273.

## ADR 0012 — Execution failures are returned, not thrown

Every terminal execution failure gets a typed `ExecutorOutcome` and is reported by returning a result carrying the failure, the executor attempts from every stage that ran, and any changes that landed before it. `RunResult` gains an aggregate accessor plus `orThrow()`. Precondition errors keep throwing, since no run occurred.

Motivated by three concrete problems: diagnostics discarded exactly when needed, a hybrid run that fails after Stage 0 already wrote files reporting no changes at all, and the same error presenting differently in forked vs in-process mode.

A sealed `Success | Failed` result was considered and rejected — partial success is real here, so it needs a third case.

Implements: #271, #272. Precedent: #191.

## CONTEXT.md

Five glossary terms the investigation sharpened, including the distinction the original bug report conflated — **recipe artifact resolution** (fetching coordinates) vs **recipe discovery** (finding a recipe among JARs already present). Both fail identically as "recipe not found", which is much of why this was hard to diagnose.
